### PR TITLE
feat(ui): establish semantic theme tokens and core primitives

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,10 +15,11 @@
 # Scope boundary:
 #   A successful run covers formatting, native normalization, D-Bus owner
 #   lifecycle, the QML adapter boundary, coordinator determinism, and the real
-#   PanelWindow state scenario under a software-rendered headless wlroots
-#   compositor. Success here does NOT replace the real KDE/KWin verification
-#   matrix tracked in issue #35 (multi-display, hardware rendering, and final
-#   cross-state checks still require a real desktop session).
+#   PanelWindow state scenario and the UI-primitive gallery, under a
+#   software-rendered headless wlroots compositor. Success here does NOT
+#   replace the real KDE/KWin verification matrix tracked in issue #35
+#   (multi-display, hardware rendering, and final cross-state checks still
+#   require a real desktop session).
 name: Repository checks
 
 on:
@@ -71,7 +72,7 @@ jobs:
         run: make check-nondisplay
 
   surface-state:
-    name: Surface-state checks (headless Wayland)
+    name: Surface checks (headless Wayland)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
@@ -96,7 +97,7 @@ jobs:
       - name: Verify repository requirements
         run: make requirements
 
-      - name: Run surface-state checks under a headless compositor
+      - name: Run surface and UI-primitive checks under a headless compositor
         run: |
           logdir=/tmp/nagi-diagnostics
           rm -rf "$logdir"
@@ -107,7 +108,7 @@ jobs:
           # client exit status, so the inner shell records the make status itself.
           set +e
           timeout --kill-after=10s 300 \
-            cage -- sh -c 'make test-surface-state >"$1" 2>&1; printf "%s\n" "$?" >"$2"' \
+            cage -- sh -c 'make test-surface-state >"$1" 2>&1 && make test-ui-primitives >>"$1" 2>&1; printf "%s\n" "$?" >"$2"' \
             sh "$logdir/quickshell.log" "$status_file" \
             2>"$logdir/compositor.log"
           wrapper_status=$?
@@ -125,7 +126,7 @@ jobs:
 
           test_status="$(cat "$status_file")"
           if [ "$test_status" -ne 0 ] || [ "$wrapper_status" -ne 0 ]; then
-            printf 'Surface-state checks failed (test status %s, wrapper status %s).\n' "$test_status" "$wrapper_status" >&2
+            printf 'Surface checks failed (test status %s, wrapper status %s).\n' "$test_status" "$wrapper_status" >&2
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ OWNER_TEST := $(BUILD_DIR)/kwin-owner-lifecycle-test
 OWNER_TEST_MOC := $(BUILD_DIR)/kwin_owner_lifecycle_test.moc
 COORDINATOR_TEST_DIR := $(BUILD_DIR)/coordinator-test
 SURFACE_STATE_TEST_DIR := $(BUILD_DIR)/surface-state-test
+UI_PRIMITIVES_TEST_DIR := $(BUILD_DIR)/ui-primitives-test
 HELPER_SOURCES := src/kwin-virtual-desktops/main.cpp src/kwin-virtual-desktops/desktop_snapshot.cpp
 HELPER_HEADERS := src/kwin-virtual-desktops/desktop_snapshot.h
 QT_CFLAGS := $(shell $(PKG_CONFIG) --cflags Qt6Core Qt6DBus)
@@ -29,7 +30,7 @@ QUICKSHELL_CHANNEL := stable
 FEDORA_QUICKSHELL_COPR := errornointernet/quickshell
 FEDORA_QUICKSHELL_PACKAGE := quickshell
 
-.PHONY: help requirements prepare check-quickshell check-helper-toolchain helper test-native test-owner-lifecycle test-adapter test-coordinator test-surface-state check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
+.PHONY: help requirements prepare check-quickshell check-helper-toolchain helper test-native test-owner-lifecycle test-adapter test-coordinator test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
 
 help:
 	@printf '%s\n' \
@@ -40,6 +41,7 @@ help:
 		'make test-adapter    Test the QML adapter boundary' \
 		'make test-coordinator  Test island ownership and restoration' \
 		'make test-surface-state  Exercise coordinator in the actual island surface' \
+		'make test-ui-primitives  Render theme tokens and primitives in the island surface' \
 		'make launch          Run this checkout in the foreground' \
 		'make diagnose        Run with authoritative verbose diagnostics' \
 		'make instances       List this checkout instance as JSON' \
@@ -109,8 +111,14 @@ test-coordinator: check-quickshell | $(BUILD_DIR)
 test-surface-state: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(SURFACE_STATE_TEST_DIR)/qml
 	cp tests/surface-state/shell.qml $(SURFACE_STATE_TEST_DIR)/shell.qml
-	cp qml/IslandStateCoordinator.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(SURFACE_STATE_TEST_DIR)/qml/
+	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandStateCoordinator.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(SURFACE_STATE_TEST_DIR)/qml/
 	$(QS) -p $(SURFACE_STATE_TEST_DIR) --no-duplicate
+
+test-ui-primitives: check-quickshell | $(BUILD_DIR)
+	mkdir -p $(UI_PRIMITIVES_TEST_DIR)/qml
+	cp tests/ui/shell.qml $(UI_PRIMITIVES_TEST_DIR)/shell.qml
+	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/IslandProgressBar.qml qml/IslandStateCoordinator.qml qml/IslandSurface.qml $(UI_PRIMITIVES_TEST_DIR)/qml/
+	$(QS) -p $(UI_PRIMITIVES_TEST_DIR) --no-duplicate
 
 check-quickshell:
 	@set -eu; \
@@ -174,7 +182,7 @@ lint-advisory:
 		exit 0; \
 	}
 
-check: check-nondisplay test-surface-state
+check: check-nondisplay test-surface-state test-ui-primitives
 
 check-nondisplay: check-quickshell format-check test-native test-owner-lifecycle test-adapter test-coordinator
 

--- a/qml/IslandButton.qml
+++ b/qml/IslandButton.qml
@@ -1,0 +1,109 @@
+import QtQuick
+import QtQuick.Controls
+
+// Button primitive: text button with standard, accent, and danger variants.
+// Renders hover, pressed, keyboard-focus, and disabled states. The focus ring
+// appears only for keyboard focus, and disabled controls flatten (dimmed
+// content, no border) instead of changing hue.
+AbstractButton {
+    id: control
+
+    property string variant: "standard"
+    property string label: ""
+
+    focusPolicy: Qt.StrongFocus
+    hoverEnabled: true
+    leftPadding: Theme.spacing.md
+    rightPadding: Theme.spacing.md
+    topPadding: Theme.spacing.xs
+    bottomPadding: Theme.spacing.xs
+    implicitHeight: Theme.size.controlHeightMd
+    implicitWidth: implicitContentWidth + leftPadding + rightPadding
+    opacity: enabled ? 1 : Theme.opacity.disabled
+
+    scale: pressed ? 0.97 : 1
+
+    Behavior on scale {
+        NumberAnimation {
+            duration: Theme.motion.durationFast
+            easing.type: Theme.motion.easingStandard
+        }
+    }
+
+    function fillColor() {
+        if (!enabled) {
+            return Theme.color.controlFill;
+        }
+        if (variant === "accent") {
+            return pressed ? Theme.color.accentPressed : hovered ? Theme.color.accentHover :
+                                                                   Theme.color.accent;
+        }
+        if (variant === "danger") {
+            return pressed ? Theme.color.dangerPressed : hovered ? Theme.color.dangerHover :
+                                                                   Theme.color.danger;
+        }
+        return pressed ? Theme.color.controlFillPressed : hovered ? Theme.color.controlFillHover :
+                                                                    Theme.color.controlFill;
+    }
+
+    function contentColor() {
+        if (variant === "accent") {
+            return Theme.color.accentForeground;
+        }
+        if (variant === "danger") {
+            return Theme.color.dangerForeground;
+        }
+        return Theme.color.textPrimary;
+    }
+
+    function outlineColor() {
+        if (variant !== "standard" || !enabled) {
+            return "transparent";
+        }
+        return pressed ? Theme.color.surfaceBorderPressed : hovered
+                         ? Theme.color.surfaceBorderHover : Theme.color.surfaceBorder;
+    }
+
+    background: IslandPanel {
+        color: control.fillColor()
+        border.color: control.outlineColor()
+    }
+
+    contentItem: IslandText {
+        text: control.label
+        size: "body"
+        font.weight: Theme.type.weightMedium
+        color: control.contentColor()
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+    }
+
+    IslandFocusRing {
+        visible: control.visualFocus
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
+        cursorShape: Qt.PointingHandCursor
+        hoverEnabled: true
+        enabled: control.enabled
+    }
+
+    Keys.onTabPressed: {
+        const next = control.nextItemInFocusChain(true);
+        if (next !== null) {
+            next.forceActiveFocus(Qt.TabFocusReason);
+        }
+    }
+
+    Keys.onBacktabPressed: {
+        const previous = control.nextItemInFocusChain(false);
+        if (previous !== null) {
+            previous.forceActiveFocus(Qt.BacktabFocusReason);
+        }
+    }
+
+    Accessible.role: Accessible.Button
+    Accessible.name: control.label
+}

--- a/qml/IslandFocusRing.qml
+++ b/qml/IslandFocusRing.qml
@@ -1,0 +1,18 @@
+import QtQuick
+
+// Focus primitive: an offset keyboard-focus ring hugging the owner geometry
+// from the outside. Bind `visible` to the owner's keyboard-focus signal (for
+// example `control.visualFocus`). The ring is a shape cue, so keyboard focus
+// never relies on hue alone.
+Rectangle {
+    id: ring
+
+    anchors.fill: parent
+    anchors.margins: -(Theme.size.focusRingGap)
+    radius: Theme.radius.pill
+    color: "transparent"
+
+    border.color: Theme.color.focusRing
+    border.width: Theme.size.focusRingWidth
+    visible: false
+}

--- a/qml/IslandIconButton.qml
+++ b/qml/IslandIconButton.qml
@@ -1,0 +1,90 @@
+import QtQuick
+import QtQuick.Controls
+import Quickshell.Widgets
+
+// Icon button primitive: circular button rendering a single icon. The icon
+// accepts any image URL, including Quickshell icon URLs for theme icons.
+// States match IslandButton; disabled controls flatten instead of changing
+// hue.
+AbstractButton {
+    id: control
+
+    property string source: ""
+    property string size: "md"
+    property string label: ""
+
+    focusPolicy: Qt.StrongFocus
+    hoverEnabled: true
+    implicitWidth: size === "sm" ? Theme.size.controlHeightSm : size === "lg"
+                                   ? Theme.size.controlHeightLg : Theme.size.controlHeightMd
+    implicitHeight: implicitWidth
+    opacity: enabled ? 1 : Theme.opacity.disabled
+
+    scale: pressed ? 0.95 : 1
+
+    Behavior on scale {
+        NumberAnimation {
+            duration: Theme.motion.durationFast
+            easing.type: Theme.motion.easingStandard
+        }
+    }
+
+    function fillColor() {
+        if (!enabled) {
+            return Theme.color.controlFill;
+        }
+        return pressed ? Theme.color.controlFillPressed : hovered ? Theme.color.controlFillHover :
+                                                                    Theme.color.controlFill;
+    }
+
+    function outlineColor() {
+        if (!enabled) {
+            return "transparent";
+        }
+        return pressed ? Theme.color.surfaceBorderPressed : hovered
+                         ? Theme.color.surfaceBorderHover : Theme.color.surfaceBorder;
+    }
+
+    background: IslandPanel {
+        color: control.fillColor()
+        border.color: control.outlineColor()
+    }
+
+    contentItem: Item {
+        IconImage {
+            anchors.centerIn: parent
+            source: control.source
+            implicitSize: control.size === "sm" ? Theme.size.iconSizeSm : control.size === "lg"
+                                                  ? Theme.size.iconSizeLg : Theme.size.iconSizeMd
+        }
+    }
+
+    IslandFocusRing {
+        visible: control.visualFocus
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
+        cursorShape: Qt.PointingHandCursor
+        hoverEnabled: true
+        enabled: control.enabled
+    }
+
+    Keys.onTabPressed: {
+        const next = control.nextItemInFocusChain(true);
+        if (next !== null) {
+            next.forceActiveFocus(Qt.TabFocusReason);
+        }
+    }
+
+    Keys.onBacktabPressed: {
+        const previous = control.nextItemInFocusChain(false);
+        if (previous !== null) {
+            previous.forceActiveFocus(Qt.BacktabFocusReason);
+        }
+    }
+
+    Accessible.role: Accessible.Button
+    Accessible.name: control.label
+}

--- a/qml/IslandPanel.qml
+++ b/qml/IslandPanel.qml
@@ -1,0 +1,16 @@
+import QtQuick
+
+// Surface primitive: the rounded card every island region renders on. All
+// visuals come from Theme tokens; consumers may override `radius` for nested
+// cards but must keep using tokens.
+Rectangle {
+    id: panel
+
+    implicitWidth: Theme.size.islandIdleWidth
+    implicitHeight: Theme.size.islandIdleHeight
+    radius: Theme.radius.pill
+    color: Theme.color.surface
+
+    border.color: Theme.color.surfaceBorder
+    border.width: Theme.size.hairlineWidth
+}

--- a/qml/IslandProgressBar.qml
+++ b/qml/IslandProgressBar.qml
@@ -1,0 +1,55 @@
+import QtQuick
+
+// Progress primitive: determinate or indeterminate horizontal progress.
+// Progress is communicated by geometry and, when indeterminate, by motion —
+// never by hue alone.
+Item {
+    id: bar
+
+    property real value: 0
+    property bool indeterminate: false
+    property string label: ""
+    property real phase: 0
+
+    readonly property real effectiveValue: Math.min(1, Math.max(0, value))
+
+    implicitWidth: Theme.size.islandIdleWidth
+    implicitHeight: Theme.size.progressBarHeight
+    opacity: enabled ? 1 : Theme.opacity.disabled
+
+    Rectangle {
+        id: track
+
+        anchors.fill: parent
+        radius: height / 2
+        color: Theme.color.progressTrack
+    }
+
+    Rectangle {
+        id: fill
+
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        width: bar.indeterminate ? bar.width * Theme.size.progressIndeterminateSpan : bar.width
+                                   * bar.effectiveValue
+        x: bar.indeterminate ? (bar.width + width) * bar.phase - width : 0
+        radius: height / 2
+        color: Theme.color.accent
+        visible: bar.indeterminate || bar.effectiveValue > 0
+
+        NumberAnimation {
+            target: bar
+            property: "phase"
+            running: bar.indeterminate && bar.enabled && bar.visible
+            loops: Animation.Infinite
+            from: 0
+            to: 1
+            duration: Theme.motion.durationSlow
+            easing.type: Theme.motion.easingStandard
+        }
+    }
+
+    Accessible.role: Accessible.ProgressBar
+    Accessible.name: bar.label
+}

--- a/qml/IslandSurface.qml
+++ b/qml/IslandSurface.qml
@@ -12,9 +12,9 @@ PanelWindow {
     readonly property real ownerRevision: coordinator.revision
     readonly property int focusTarget: coordinator.focusTarget
     readonly property real focusRequestSerial: coordinator.focusRequestSerial
-    readonly property int edgeInset: 8
-    readonly property int preferredHeight: 36
-    readonly property int preferredWidth: 120
+    readonly property int edgeInset: Theme.spacing.sm
+    readonly property int preferredHeight: Theme.size.islandIdleHeight
+    readonly property int preferredWidth: Theme.size.islandIdleWidth
 
     function acknowledgePresentation(generation, epoch, contentRevision) {
         if (generation <= 0 || hostSurfaceGeneration !== generation) {
@@ -64,12 +64,7 @@ PanelWindow {
     implicitWidth: safeLogicalSize(preferredWidth, screen === null ? 0 : screen.width)
     margins.top: edgeInset
 
-    Rectangle {
+    IslandPanel {
         anchors.fill: parent
-        color: "#f5080d16"
-        radius: height / 2
-
-        border.color: "#263448"
-        border.width: 1
     }
 }

--- a/qml/IslandText.qml
+++ b/qml/IslandText.qml
@@ -1,0 +1,17 @@
+import QtQuick
+
+// Text primitive: labels pick a semantic tone and scale instead of raw
+// colors or pixel sizes. Callers may still bind `color` directly when they
+// need a token-driven color that is not one of the standard tones (for
+// example filled-button content).
+Text {
+    id: label
+
+    property string tone: "primary"
+    property string size: "body"
+
+    font.pixelSize: size === "caption" ? Theme.type.caption : size === "title" ? Theme.type.title :
+                                                                                 Theme.type.body
+    color: tone === "secondary" ? Theme.color.textSecondary : tone === "muted"
+                                  ? Theme.color.textMuted : Theme.color.textPrimary
+}

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -1,0 +1,107 @@
+pragma Singleton
+
+import Quickshell
+import QtQuick
+
+// Semantic design-system boundary of the island. Visual components read these
+// tokens instead of raw literals so contrast, sizing, and motion stay
+// consistent and auditable in one place.
+//
+// Contrast floors, measured (WCAG 2.1 relative luminance) against the
+// composited island surface (#080D16 at 96% alpha over black and over white
+// desktops):
+//   textPrimary   >= 16.2:1  AAA body text
+//   textSecondary >= 10.2:1  AAA body text
+//   textMuted     >=  5.8:1  AA body text
+//   accentForeground = 7.4:1  against the accent fill
+//   dangerForeground = 6.6:1  against the danger fill
+//   focusRing     >=  8.8:1  non-text UI minimum is 3:1
+//   accent        >=  7.19:1 control boundary against the surface
+//   progressFill  =   5.9:1  against the progress track
+// Never lower a token below its documented floor without re-measuring both
+// composites. HDR readability relies on the same pairs: the surface is
+// near-opaque and no primitive depends on blur or backdrop effects.
+Singleton {
+    id: root
+
+    readonly property QtObject color: QtObject {
+        readonly property color surface: "#F5080D16"
+        readonly property color surfaceBorder: "#263448"
+        readonly property color surfaceBorderHover: "#33465C"
+        readonly property color surfaceBorderPressed: "#40566E"
+        readonly property color controlFill: "#16222F"
+        readonly property color controlFillHover: "#1E2E3E"
+        readonly property color controlFillPressed: "#263A50"
+        readonly property color textPrimary: "#EFF3F8"
+        readonly property color textSecondary: "#B9C4D2"
+        readonly property color textMuted: "#8494A6"
+        readonly property color accent: "#7AA2F7"
+        readonly property color accentHover: "#93B4F9"
+        readonly property color accentPressed: "#6390EE"
+        readonly property color accentForeground: "#0B1220"
+        readonly property color danger: "#F26D7E"
+        readonly property color dangerHover: "#F58594"
+        readonly property color dangerPressed: "#E4576B"
+        readonly property color dangerForeground: "#1F0A0E"
+        readonly property color success: "#7BD88F"
+        readonly property color warning: "#E8C268"
+        readonly property color focusRing: "#8FB5FF"
+        readonly property color progressTrack: "#1C2836"
+    }
+
+    readonly property QtObject spacing: QtObject {
+        readonly property int xs: 4
+        readonly property int sm: 8
+        readonly property int md: 12
+        readonly property int lg: 16
+        readonly property int xl: 24
+        readonly property int xxl: 32
+    }
+
+    readonly property QtObject radius: QtObject {
+        readonly property int sm: 8
+        readonly property int md: 12
+        readonly property int pill: 9999
+    }
+
+    // Typography stays on the platform default family; only semantic sizes and
+    // weights are tokenized until a concrete typeface decision exists.
+    readonly property QtObject type: QtObject {
+        readonly property int caption: 11
+        readonly property int body: 13
+        readonly property int title: 15
+        readonly property int weightRegular: Font.Normal
+        readonly property int weightMedium: Font.Medium
+        readonly property int weightSemibold: Font.DemiBold
+    }
+
+    readonly property QtObject size: QtObject {
+        readonly property int islandIdleWidth: 120
+        readonly property int islandIdleHeight: 36
+        readonly property int controlHeightSm: 26
+        readonly property int controlHeightMd: 32
+        readonly property int controlHeightLg: 38
+        readonly property int iconSizeSm: 14
+        readonly property int iconSizeMd: 18
+        readonly property int iconSizeLg: 22
+        readonly property int progressBarHeight: 4
+        readonly property real progressIndeterminateSpan: 0.28
+        readonly property int focusRingWidth: 2
+        readonly property int focusRingGap: 2
+        readonly property int hairlineWidth: 1
+    }
+
+    readonly property QtObject opacity: QtObject {
+        // Disabled controls dim as a whole and lose their border affordance,
+        // so the state rides on luminance and flattening, never hue alone.
+        readonly property real disabled: 0.45
+    }
+
+    readonly property QtObject motion: QtObject {
+        readonly property int durationFast: 100
+        readonly property int durationNormal: 180
+        readonly property int durationSlow: 280
+        readonly property int easingStandard: Easing.OutCubic
+        readonly property int easingEmphasized: Easing.InOutCubic
+    }
+}

--- a/tests/ui/shell.qml
+++ b/tests/ui/shell.qml
@@ -1,0 +1,202 @@
+import Quickshell
+import QtQuick
+import "qml"
+
+// Gallery harness: renders every core primitive inside the real island
+// surface and asserts their observable contracts (token resolution, state
+// visuals driven by focus reasons, disabled flattening, progress clamping).
+ShellRoot {
+    id: test
+
+    function require(condition, message) {
+        if (!condition) {
+            console.error("FAIL: " + message);
+            Qt.exit(1);
+            throw new Error(message);
+        }
+    }
+
+    function traversalReaches(start, target) {
+        let cursor = start;
+        for (let hop = 0; hop < 8 && cursor !== null; hop += 1) {
+            cursor = cursor.nextItemInFocusChain(true);
+            if (cursor === target) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function runChecks() {
+        require(typeof Theme.color.surface !== "undefined", "color tokens resolve");
+        require(typeof Theme.spacing.md === "number", "spacing tokens resolve");
+        require(typeof Theme.radius.pill === "number", "radius tokens resolve");
+        require(typeof Theme.type.body === "number", "typography tokens resolve");
+        require(typeof Theme.size.controlHeightMd === "number", "sizing tokens resolve");
+        require(typeof Theme.opacity.disabled === "number", "opacity tokens resolve");
+        require(typeof Theme.motion.durationNormal === "number", "motion tokens resolve");
+
+        require(String(primaryText.color) !== String(secondaryText.color),
+                "primary tone differs from secondary");
+        require(String(secondaryText.color) !== String(mutedText.color),
+                "secondary tone differs from muted");
+        require(String(primaryText.color) !== String(mutedText.color),
+                "primary tone differs from muted");
+
+        standardButton.forceActiveFocus(Qt.TabFocusReason);
+        require(standardButton.activeFocus, "enabled button takes keyboard focus");
+        require(standardButton.visualFocus, "keyboard focus reason drives the visible ring");
+        accentButton.forceActiveFocus(Qt.MouseFocusReason);
+        require(!standardButton.visualFocus, "focus loss clears the keyboard ring");
+        require(accentButton.activeFocus && !accentButton.visualFocus,
+                "pointer focus does not draw the keyboard ring");
+
+        disabledButton.forceActiveFocus(Qt.TabFocusReason);
+        require(!disabledButton.activeFocus, "disabled button refuses focus");
+        require(!disabledButton.enabled, "disabled button reports the disabled state");
+        require(String(disabledButton.background.color) === String(Theme.color.controlFill),
+                "disabled button keeps the resting fill");
+
+        require(traversalReaches(standardButton, accentButton),
+                "keyboard traversal reaches the accent button");
+        require(traversalReaches(accentButton, iconButton),
+                "keyboard traversal reaches the icon button");
+
+        determinateProgress.value = 1.7;
+        require(determinateProgress.effectiveValue === 1, "progress clamps above the range");
+        determinateProgress.value = -0.5;
+        require(determinateProgress.effectiveValue === 0, "progress clamps below the range");
+        determinateProgress.value = 0.4;
+
+        require(indeterminateProgress.indeterminate, "indeterminate progress reports its mode");
+        require(iconButton.implicitWidth === iconButton.implicitHeight,
+                "icon button stays circular");
+        console.log("island ui primitive tests passed");
+
+        if (Quickshell.env("NAGI_UI_HOLD") === "1") {
+            standardButton.forceActiveFocus(Qt.TabFocusReason);
+            console.log("holding for visual inspection");
+            return;
+        }
+
+        Qt.exit(0);
+    }
+
+    Component.onCompleted: Qt.callLater(test.runChecks)
+
+    IslandStateCoordinator {
+        id: coordinator
+    }
+
+    IslandSurface {
+        id: surface
+
+        coordinator: coordinator
+        hostSurfaceGeneration: 0
+        implicitWidth: 640
+        implicitHeight: 360
+
+        Column {
+            anchors.centerIn: parent
+            spacing: Theme.spacing.lg
+
+            Row {
+                spacing: Theme.spacing.xl
+
+                IslandText {
+                    id: primaryText
+
+                    text: "Primary"
+                    tone: "primary"
+                }
+
+                IslandText {
+                    id: secondaryText
+
+                    text: "Secondary"
+                    tone: "secondary"
+                    size: "caption"
+                }
+
+                IslandText {
+                    id: mutedText
+
+                    text: "Muted"
+                    tone: "muted"
+                    size: "caption"
+                }
+            }
+
+            Row {
+                spacing: Theme.spacing.md
+
+                IslandButton {
+                    id: standardButton
+
+                    label: "Standard"
+                }
+
+                IslandButton {
+                    id: accentButton
+
+                    label: "Accent"
+                    variant: "accent"
+                }
+
+                IslandButton {
+                    label: "Danger"
+                    variant: "danger"
+                }
+
+                IslandButton {
+                    id: disabledButton
+
+                    enabled: false
+                    label: "Disabled"
+                }
+            }
+
+            Row {
+                spacing: Theme.spacing.md
+
+                IslandIconButton {
+                    id: iconButton
+
+                    label: "Example action"
+                    size: "md"
+                    source: "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><rect x='2' y='2' width='12' height='12' rx='3' fill='%23EFF3F8'/></svg>"
+                }
+
+                IslandIconButton {
+                    enabled: false
+                    label: "Disabled action"
+                    size: "sm"
+                    source: "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><circle cx='8' cy='8' r='6' fill='%23B9C4D2'/></svg>"
+                }
+
+                IslandIconButton {
+                    label: "Large action"
+                    size: "lg"
+                    source: "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><path d='M3 13 L13 13 L8 4 Z' fill='%237AA2F7'/></svg>"
+                }
+            }
+
+            IslandProgressBar {
+                id: determinateProgress
+
+                indeterminate: false
+                label: "Determinate example"
+                value: 0.4
+                width: 240
+            }
+
+            IslandProgressBar {
+                id: indeterminateProgress
+
+                indeterminate: true
+                label: "Indeterminate example"
+                width: 240
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #15

## What

- **`qml/Theme.qml`** — semantic design-system singleton (Quickshell `Singleton`, no qmldir machinery) exposing color, spacing, radius, typography, sizing, opacity, and motion token groups. Documented WCAG floors are measured against both SDR composites of the 96%-alpha surface (over black and white desktops); the surface is near-opaque and no primitive uses blur or backdrop effects, so HDR tone-mapping keeps the same high-luminance-contrast pairs readable.
- **Primitives** — `IslandPanel` (surface), `IslandText` (tone/size), `IslandButton` (standard/accent/danger variants), `IslandIconButton` (circular, image or icon-theme source), `IslandFocusRing`, and `IslandProgressBar` (determinate + indeterminate). All visuals read tokens; hover/pressed/keyboard-focus/disabled states render where applicable.
- **Accessibility behavior** — the focus ring is a shape cue driven by `visualFocus`, so only keyboard focus draws it; disabled controls dim *and* lose their border affordance (luminance + flattening, never hue alone); progress communicates by geometry and motion; buttons expose button role/name and Tab/Backtab traversal.
- **Integration** — `IslandSurface` now composes `IslandPanel` with sizing/spacing tokens instead of raw literals.
- **Checks** — new `make test-ui-primitives` gallery renders every primitive inside the real island surface and asserts observable contracts; wired into `make check` and into the headless-Wayland CI job alongside the surface-state scenario.

## Verification

- `make check-nondisplay` (format-check, native, D-Bus owner lifecycle, adapter, coordinator) — green locally on Quickshell 0.3.0.
- `make test-surface-state` — still green after the surface rewiring (real KDE Wayland session).
- `make test-ui-primitives` — green on the real session; screenshot inspection confirmed text hierarchy, all three button variants, visible keyboard focus ring, flattened disabled controls, circular icon buttons with rendered icons, and both progress modes at target scale.
- Contrast audit re-run against the shipped `Theme.qml` values: 14/14 pairs above their documented floors (min: muted text 5.83:1, focus ring 8.81:1, accent boundary 7.19:1).
- Known limitation: HDR rendering cannot be exercised on this SDR display; readability there rests on the measured contrast pairs plus the blur-free near-opaque surface, to be re-checked under the real-desktop matrix tracked in #35.
