### PR TITLE
feat(platform): add idle clock and weather state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ HELPER_MOC := $(BUILD_DIR)/main.moc
 OWNER_TEST := $(BUILD_DIR)/kwin-owner-lifecycle-test
 OWNER_TEST_MOC := $(BUILD_DIR)/kwin_owner_lifecycle_test.moc
 COORDINATOR_TEST_DIR := $(BUILD_DIR)/coordinator-test
+WEATHER_TEST_DIR := $(BUILD_DIR)/weather-test
 SURFACE_STATE_TEST_DIR := $(BUILD_DIR)/surface-state-test
 UI_PRIMITIVES_TEST_DIR := $(BUILD_DIR)/ui-primitives-test
 HELPER_SOURCES := src/kwin-virtual-desktops/main.cpp src/kwin-virtual-desktops/desktop_snapshot.cpp
@@ -30,7 +31,7 @@ QUICKSHELL_CHANNEL := stable
 FEDORA_QUICKSHELL_COPR := errornointernet/quickshell
 FEDORA_QUICKSHELL_PACKAGE := quickshell
 
-.PHONY: help requirements prepare check-quickshell check-helper-toolchain helper test-native test-owner-lifecycle test-adapter test-coordinator test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
+.PHONY: help requirements prepare check-quickshell check-helper-toolchain helper test-native test-owner-lifecycle test-adapter test-coordinator test-weather test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
 
 help:
 	@printf '%s\n' \
@@ -41,6 +42,7 @@ help:
 		'make test-adapter    Test the QML adapter boundary' \
 		'make test-coordinator  Test island ownership and restoration' \
 		'make test-surface-state  Exercise coordinator in the actual island surface' \
+		'make test-weather    Test compact clock and weather adapter state' \
 		'make test-ui-primitives  Render theme tokens and primitives in the island surface' \
 		'make launch          Run this checkout in the foreground' \
 		'make diagnose        Run with authoritative verbose diagnostics' \
@@ -105,8 +107,14 @@ test-adapter: check-quickshell | $(BUILD_DIR)
 test-coordinator: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(COORDINATOR_TEST_DIR)/qml
 	cp tests/coordinator/shell.qml $(COORDINATOR_TEST_DIR)/shell.qml
-	cp qml/IslandStateCoordinator.qml $(COORDINATOR_TEST_DIR)/qml/IslandStateCoordinator.qml
+	cp qml/IslandStateCoordinator.qml $(COORDINATOR_TEST_DIR)/qml/
 	$(QS) -p $(COORDINATOR_TEST_DIR) --no-duplicate
+
+test-weather: check-quickshell | $(BUILD_DIR)
+	mkdir -p $(WEATHER_TEST_DIR)/qml
+	cp tests/weather/shell.qml $(WEATHER_TEST_DIR)/shell.qml
+	cp qml/WeatherAdapter.qml qml/CompactClock.qml $(WEATHER_TEST_DIR)/qml/
+	$(QS) -p $(WEATHER_TEST_DIR) --no-duplicate
 
 test-surface-state: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(SURFACE_STATE_TEST_DIR)/qml
@@ -184,7 +192,7 @@ lint-advisory:
 
 check: check-nondisplay test-surface-state test-ui-primitives
 
-check-nondisplay: check-quickshell format-check test-native test-owner-lifecycle test-adapter test-coordinator
+check-nondisplay: check-quickshell format-check test-native test-owner-lifecycle test-adapter test-coordinator test-weather
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/qml/CompactClock.qml
+++ b/qml/CompactClock.qml
@@ -1,0 +1,13 @@
+import Quickshell
+import QtQuick
+
+// Compact 24-hour idle clock state. Minute precision is the visible
+// granularity of the idle island, so this clock updates only when the minute
+// changes; no higher-frequency timer or animation ever runs.
+SystemClock {
+    id: clock
+
+    precision: SystemClock.Minutes
+
+    readonly property string text: Qt.formatDateTime(clock.date, "HH:mm")
+}

--- a/qml/WeatherAdapter.qml
+++ b/qml/WeatherAdapter.qml
@@ -1,0 +1,910 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+// MET Norway Locationforecast 2.0 compact weather state (ADR-0003 boundary).
+//
+// Platform adapter owning the request, validation, bounded cache, one-shot
+// scheduling, backoff, and symbol normalization behind the optional Idle
+// weather state. Presentation consumes only the typed state below; provider
+// codes, URLs, coordinates, payloads, and cache contents never leave this
+// file, and no request-related value is ever logged.
+//
+// Privacy model: weather is opt-in through explicit local coordinates.
+// Missing or invalid coordinates perform no request and keep no cache.
+// Requests carry two-decimal truncated coordinates and the public identifying
+// User-Agent only; the optional label never leaves the machine.
+Scope {
+    id: root
+
+    // Project version reported in the provider User-Agent. Bump with releases.
+    property string version: "0.1.0"
+
+    // Opt-in location. Invalid or missing values keep weather unavailable
+    // without any request. Altitude is optional whole metres; the label is
+    // local-only and is never sent, persisted, or logged.
+    property real latitude: Number.NaN
+    property real longitude: Number.NaN
+    property var altitude: null
+    property string label: ""
+
+    // Verification seams following the coordinator's injected-clock pattern.
+    // Production leaves them unset and uses the wall clock, Math.random, the
+    // built-in XMLHttpRequest transport, and the per-shell cache directory.
+    property var wallNow: null
+    property var randomSource: null
+    property var transport: null
+    property int requestTimeoutMs: 10000
+    property string cacheDirectory: ""
+    property string cacheFileName: "weather.json"
+
+    // ---- normalized state -------------------------------------------------
+
+    // True while a valid current timestep is exposed, including the bounded
+    // stale window before the six-hour cutoff.
+    readonly property bool available: engine.available
+    // True while available content comes from an expired cache record.
+    readonly property bool stale: engine.stale
+    readonly property real temperatureC: engine.snapshot === null ? Number.NaN :
+                                                                    engine.snapshot.temperatureC
+    readonly property string condition: engine.snapshot === null ? "unknown" :
+                                                                   engine.snapshot.condition
+
+    readonly property string dayPhase: engine.snapshot === null ? "day" : engine.snapshot.dayPhase
+    readonly property date forecastTime: engine.snapshot === null ? new Date(Number.NaN) : new Date(
+                                                                        engine.snapshot.forecastEpoch)
+    readonly property date fetchedAt: Number.isFinite(engine.fetchedAt) ? new Date(
+                                                                              engine.fetchedAt) :
+                                                                          new Date(Number.NaN)
+    // Bounded failure kinds: "none", "unconfigured", "transient", "throttled",
+    // "permanent", "stale". It reports the most recent failure and never
+    // carries provider payloads.
+    readonly property string failure: engine.failure
+
+    // Scheduling visibility for verification: epoch milliseconds of the next
+    // allowed network request (0 when none is scheduled) and the number of
+    // requests started since instantiation.
+    readonly property real nextRequestAt: engine.nextRequestAt
+    readonly property int requestCount: engine.requestCount
+    readonly property bool locationConfigured: engine.locationKey !== ""
+    readonly property int maximumResponseCharacters: 1048576
+    readonly property int cacheSchemaVersion: 1
+
+    // Emitted after every completed cache write, including clears. Verification
+    // uses it to sequence cross-instance cache scenarios deterministically.
+    signal cacheSaved
+
+    // Deadline handlers. The internal one-shot timers invoke these; exposing
+    // them lets verification fire exact deadlines deterministically. Each is
+    // idempotent and guarded.
+    function refreshDeadlineReached() {
+        engine.runRefresh();
+    }
+
+    function localDeadlineReached() {
+        engine.runLocalDeadline();
+    }
+
+    function requestTimeoutReached() {
+        engine.requestTimeoutReached();
+    }
+
+    Component.onCompleted: applyLocation()
+    onLatitudeChanged: engine.scheduleLocationSync()
+    onLongitudeChanged: engine.scheduleLocationSync()
+    onAltitudeChanged: engine.scheduleLocationSync()
+    onVersionChanged: engine.scheduleLocationSync()
+
+    FileView {
+        id: cacheFileView
+
+        path: root.cacheDirectory === "" ? Quickshell.cacheDir + "/" + root.cacheFileName : root.cacheDirectory
+                                           + "/" + root.cacheFileName
+        atomicWrites: true
+        blockLoading: true
+        printErrors: false
+        onSaved: root.cacheSaved()
+    }
+
+    Timer {
+        id: refreshTimer
+
+        repeat: false
+        onTriggered: root.refreshDeadlineReached()
+    }
+
+    Timer {
+        id: localTimer
+
+        repeat: false
+        onTriggered: root.localDeadlineReached()
+    }
+
+    Timer {
+        id: timeoutTimer
+
+        repeat: false
+        onTriggered: root.requestTimeoutReached()
+    }
+
+    QtObject {
+        id: engine
+
+        // Backoff tiers in milliseconds for network errors, timeouts, invalid
+        // responses, and 5xx responses; 429 uses throttleTiers.
+        readonly property var backoffTiers: [600000, 1800000, 3600000, 10800000, 21600000]
+        readonly property var throttleTiers: [3600000, 10800000, 21600000]
+        readonly property real backoffJitterFraction: 0.2
+        readonly property int refreshJitterMs: 300000
+        readonly property int startupJitterMs: 30000
+        readonly property int expiresFallbackMs: 3600000
+        readonly property int minimumRefreshGapMs: 600000
+        readonly property int staleCutoffMs: 21600000
+        readonly property int maximumTimestepAgeMs: 5400000
+        readonly property real minimumTemperatureC: -90
+        readonly property real maximumTemperatureC: 60
+
+        property string locationKey: ""
+        property string activeVersion: ""
+        property string coarseLatitude: ""
+        property string coarseLongitude: ""
+        property var coarseAltitude: null
+
+        property var cache: null
+        property real expiresEpoch: Number.NaN
+        property var snapshot: null
+        property real fetchedAt: Number.NaN
+
+        property bool available: false
+        property bool stale: false
+        property string failure: "unconfigured"
+
+        property int backoffIndex: 0
+        property int throttleTier: 0
+        property var permanentKey: null
+        property real nextRequestAt: 0
+
+        property bool inFlight: false
+        property int requestCount: 0
+        property int requestSerial: 0
+        property var activeRequest: null
+        property var warnedKeys: ({})
+        property bool locationSyncScheduled: false
+
+        function currentTime() {
+            const value = root.wallNow === null ? Date.now() : root.wallNow();
+            return typeof value === "number" && Number.isFinite(value) ? value : 0;
+        }
+
+        function random01() {
+            const value = root.randomSource === null ? Math.random() : root.randomSource();
+            if (typeof value !== "number" || !Number.isFinite(value)) {
+                return 0;
+            }
+
+            return Math.min(Math.max(value, 0), 1);
+        }
+
+        // Positive jitter in [0, span) milliseconds.
+        function jitter(span) {
+            return Math.floor(random01() * span);
+        }
+
+        function warnOnce(key, message) {
+            if (warnedKeys[key] === true) {
+                return;
+            }
+
+            warnedKeys[key] = true;
+            console.warn(message);
+        }
+
+        // Truncation toward zero at two decimals with a tolerance for binary
+        // rounding dust around exact hundredths, so 48.85 stays 48.85 while
+        // 48.8566 still truncates to 48.85.
+        function truncateCoordinate(value) {
+            const scaled = value * 100;
+            const rounded = Math.round(scaled);
+            const corrected = Math.abs(scaled - rounded) < 0.000001 ? rounded : scaled;
+            const truncated = corrected < 0 ? Math.ceil(corrected) : Math.floor(corrected);
+            return truncated === 0 ? 0 : truncated / 100;
+        }
+
+        function validatedLocation() {
+            if (typeof root.latitude !== "number" || !Number.isFinite(root.latitude) || typeof root.longitude
+                    !== "number" || !Number.isFinite(root.longitude) || root.latitude < -90
+                    || root.latitude > 90 || root.longitude < -180 || root.longitude > 180) {
+                return null;
+            }
+
+            let altitudeValue = null;
+            if (root.altitude !== null && root.altitude !== undefined) {
+                if (typeof root.altitude !== "number" || !Number.isFinite(root.altitude) || !Number.isInteger(
+                            root.altitude)) {
+                    return null;
+                }
+
+                altitudeValue = root.altitude;
+            }
+
+            const latitude = truncateCoordinate(root.latitude);
+            const longitude = truncateCoordinate(root.longitude);
+            return {
+                "key": "v1|" + latitude.toFixed(2) + "|" + longitude.toFixed(2) + (altitudeValue
+                                                                                   === null ? "" :
+                                                                                              "|" + altitudeValue),
+                "latitude": latitude.toFixed(2),
+                "longitude": longitude.toFixed(2),
+                "altitude": altitudeValue === null ? null : String(altitudeValue)
+            };
+        }
+
+        function scheduleLocationSync() {
+            if (locationSyncScheduled) {
+                return;
+            }
+
+            locationSyncScheduled = true;
+            Qt.callLater(function () {
+                locationSyncScheduled = false;
+                root.applyLocation();
+            });
+        }
+
+        // Single entry point for configuration changes. Any location or version
+        // change cancels in-flight work, drops previous verdicts, and restarts
+        // from the cache; clearing the location additionally removes the
+        // previous location's cached content.
+        function applyLocation() {
+            const location = validatedLocation();
+            const key = location === null ? "" : location.key;
+            const version = typeof root.version === "string" && root.version.length > 0
+                  ? root.version : "unknown";
+            if (key === locationKey && version === activeVersion) {
+                return;
+            }
+
+            abortActiveRequest();
+            stopTimers();
+            cache = null;
+            expiresEpoch = Number.NaN;
+            nextRequestAt = 0;
+            backoffIndex = 0;
+            throttleTier = 0;
+            permanentKey = null;
+            snapshot = null;
+            fetchedAt = Number.NaN;
+            available = false;
+            stale = false;
+            locationKey = key;
+            activeVersion = version;
+
+            if (key === "") {
+                coarseLatitude = "";
+                coarseLongitude = "";
+                coarseAltitude = null;
+                failure = "unconfigured";
+                clearCacheFile();
+                return;
+            }
+
+            coarseLatitude = location.latitude;
+            coarseLongitude = location.longitude;
+            coarseAltitude = location.altitude;
+
+            const now = currentTime();
+            const record = loadCacheRecord(key);
+            failure = "none";
+            if (record !== null) {
+                cache = record;
+                const parsedExpires = Date.parse(record.expires);
+                expiresEpoch = Number.isFinite(parsedExpires) ? parsedExpires : Number.NaN;
+                adoptRecord(now);
+                armRefresh(expiresEpoch > now ? expiresEpoch + jitter(refreshJitterMs) : now
+                                                + jitter(startupJitterMs));
+            } else {
+                armRefresh(now + jitter(startupJitterMs));
+            }
+        }
+
+        function loadCacheRecord(key) {
+            const raw = cacheFileView.text();
+            if (typeof raw !== "string" || raw.length === 0) {
+                return null;
+            }
+
+            let record = null;
+            try {
+                record = JSON.parse(raw);
+            } catch (error) {
+                record = null;
+            }
+
+            const valid = record !== null && typeof record === "object" && record.schemaVersion
+                  === root.cacheSchemaVersion && record.locationKey === key && typeof record.body
+                  === "string" && record.body.length > 0 && record.body.length
+                  <= root.maximumResponseCharacters && typeof record.expires === "string"
+                  && typeof record.lastModified === "string" && Number.isFinite(record.retrievedAt)
+                  && Number.isFinite(record.validatedAt) && Number.isFinite(Date.parse(
+                                                                                record.expires));
+            if (!valid) {
+                clearCacheFile();
+                return null;
+            }
+
+            return record;
+        }
+
+        // Re-derives visible state from the adopted cache body without any
+        // request, exactly as ADR-0003 requires on startup.
+        function adoptRecord(now) {
+            const selection = selectTimestep(cache.body, now);
+            if (selection.ok) {
+                commitSnapshot(selection.snapshot, cache.retrievedAt);
+            } else {
+                clearWeather("stale");
+            }
+
+            armLocalDeadline();
+        }
+
+        function runLocalDeadline() {
+            if (cache === null) {
+                return;
+            }
+
+            const now = currentTime();
+            if (now - cache.validatedAt >= staleCutoffMs) {
+                cache = null;
+                expiresEpoch = Number.NaN;
+                clearWeather("stale");
+                clearCacheFile();
+                stopLocalTimer();
+                return;
+            }
+
+            const selection = selectTimestep(cache.body, now);
+            if (selection.ok) {
+                snapshot = selection.snapshot;
+                available = true;
+                stale = Number.isFinite(expiresEpoch) && expiresEpoch <= now;
+                if (failure === "stale") {
+                    failure = "none";
+                }
+            } else {
+                clearWeather("stale");
+            }
+
+            armLocalDeadline();
+        }
+
+        // Selects the latest timeseries entry not later than now, no more than
+        // 90 minutes old, whose same entry carries both required fields.
+        function selectTimestep(bodyText, now) {
+            let parsed = null;
+            try {
+                parsed = JSON.parse(bodyText);
+            } catch (error) {
+                parsed = null;
+            }
+
+            const timeseries = parsed !== null && typeof parsed === "object" && parsed.properties
+                  !== null && typeof parsed.properties === "object" && parsed.properties.timeseries
+                  !== null && typeof parsed.properties.timeseries === "object"
+                  && parsed.properties.timeseries.length > 0 ? parsed.properties.timeseries : null;
+            if (timeseries === null) {
+                return {
+                    "ok": false
+                };
+            }
+
+            let best = null;
+            let bestTime = -Infinity;
+            for (let index = 0; index < timeseries.length; index += 1) {
+                const entry = timeseries[index];
+                if (entry === null || typeof entry !== "object" || typeof entry.time !== "string") {
+                    continue;
+                }
+
+                const time = Date.parse(entry.time);
+                if (!Number.isFinite(time) || time > now || now - time > maximumTimestepAgeMs) {
+                    continue;
+                }
+
+                const details = entry.data !== null && typeof entry.data === "object"
+                      && entry.data.instant !== null && typeof entry.data.instant === "object"
+                      && entry.data.instant.details !== null && typeof entry.data.instant.details
+                      === "object" ? entry.data.instant.details : null;
+                const summary = entry.data !== null && typeof entry.data === "object"
+                      && entry.data.next_1_hours !== null && typeof entry.data.next_1_hours
+                      === "object" && entry.data.next_1_hours.summary !== null
+                      && typeof entry.data.next_1_hours.summary === "object"
+                      ? entry.data.next_1_hours.summary : null;
+                const temperature = details === null ? null : details.air_temperature;
+                const symbolCode = summary === null ? null : summary.symbol_code;
+                if (typeof temperature !== "number" || !Number.isFinite(temperature) || temperature
+                        < minimumTemperatureC || temperature > maximumTemperatureC
+                        || typeof symbolCode !== "string" || symbolCode.length === 0) {
+                    continue;
+                }
+
+                if (time > bestTime) {
+                    bestTime = time;
+                    const normalized = normalizeSymbol(symbolCode);
+                    best = {
+                        "temperatureC": temperature,
+                        "condition": normalized.condition,
+                        "dayPhase": normalized.dayPhase,
+                        "forecastEpoch": time
+                    };
+                }
+            }
+
+            return best === null ? {
+                                       "ok": false
+                                   } : {
+                "ok": true,
+                "snapshot": best
+            };
+        }
+
+        // Collapses MET Norway symbol codes into the stable compact condition
+        // enum and separates the day phase suffix. Thunder is tested before the
+        // precipitation families because thunder variants span all of them.
+        // Unknown codes map to "unknown" with one bounded diagnostic that
+        // carries no raw provider output.
+        function normalizeSymbol(code) {
+            let phase = "day";
+            let base = code;
+            const suffixes = [["polartwilight", "polartwilight"], ["night", "night"], ["day",
+                                                                                       "day"]];
+
+
+            for (let index = 0; index < suffixes.length; index += 1) {
+                const suffix = "_" + suffixes[index][0];
+                if (base.length > suffix.length && base.lastIndexOf(suffix) === base.length
+                        - suffix.length) {
+                    phase = suffixes[index][1];
+                    base = base.slice(0, base.length - suffix.length);
+                    break;
+                }
+            }
+
+            let condition = "unknown";
+            if (base === "clearsky") {
+                condition = "clear";
+            } else if (base === "fair") {
+                condition = "mostlyClear";
+            } else if (base === "partlycloudy") {
+                condition = "partlyCloudy";
+            } else if (base === "cloudy") {
+                condition = "cloudy";
+            } else if (base === "fog") {
+                condition = "fog";
+            } else if (base.indexOf("thunder") !== -1) {
+                condition = "thunderstorm";
+            } else if (base.indexOf("sleet") !== -1) {
+                condition = "sleet";
+            } else if (base.indexOf("snow") !== -1) {
+                condition = "snow";
+            } else if (base.indexOf("rain") !== -1) {
+                condition = "rain";
+            } else {
+                warnOnce("unknown-symbol",
+                         "weather: unrecognized provider condition; using the unknown condition");
+            }
+
+            return {
+                "condition": condition,
+                "dayPhase": phase
+            };
+        }
+
+        function commitSnapshot(snapshotValue, fetchedEpoch) {
+            snapshot = snapshotValue;
+            fetchedAt = fetchedEpoch;
+            available = true;
+            stale = Number.isFinite(expiresEpoch) && expiresEpoch <= currentTime();
+            failure = "none";
+        }
+
+        function clearWeather(kind) {
+            snapshot = null;
+            fetchedAt = Number.NaN;
+            available = false;
+            stale = false;
+            failure = kind;
+        }
+
+        function runRefresh() {
+            if (locationKey === "" || permanentKey !== null || inFlight) {
+                return;
+            }
+
+            const now = currentTime();
+            if (nextRequestAt > now) {
+                return;
+            }
+
+            let url = "https://api.met.no/weatherapi/locationforecast/2.0/compact?lat="
+                + coarseLatitude + "&lon=" + coarseLongitude;
+            if (coarseAltitude !== null) {
+                url += "&altitude=" + coarseAltitude;
+            }
+
+            const headers = {
+                "User-Agent": root.userAgentValue
+            };
+            if (cache !== null && cache.lastModified !== "") {
+                headers["If-Modified-Since"] = cache.lastModified;
+            }
+
+            startRequest(url, headers);
+        }
+
+        function startRequest(url, headers) {
+            requestSerial += 1;
+            const serial = requestSerial;
+            inFlight = true;
+            requestCount += 1;
+            timeoutTimer.interval = Math.max(1, root.requestTimeoutMs);
+            timeoutTimer.restart();
+            const request = {
+                "url": url,
+                "headers": headers,
+                "timeoutMs": Math.max(1, root.requestTimeoutMs),
+                "onCompleted": function (outcome) {
+                    if (serial !== requestSerial || !inFlight) {
+                        return;
+                    }
+
+                    finishRequest(outcome);
+                }
+            };
+            activeRequest = root.transport === null ? builtinRequest(request) :
+                                                      root.transport.create(request);
+        }
+
+        // Built-in asynchronous XMLHttpRequest transport. Qt exposes no request
+        // timeout, so the one-shot timeout timer aborts the request.
+        function builtinRequest(request) {
+            const xhr = new XMLHttpRequest();
+            xhr.onreadystatechange = function () {
+                if (xhr.readyState !== XMLHttpRequest.DONE) {
+                    return;
+                }
+
+                if (xhr.status === 0) {
+                    request.onCompleted({
+                                            "networkError": true
+                                        });
+                    return;
+                }
+
+                request.onCompleted({
+                                        "status": xhr.status,
+                                        "headers": root.parseHeaderBlock(xhr.getAllResponseHeaders(
+                                                                             )),
+                                        "bodyText": xhr.responseText
+                                    });
+            };
+            xhr.open("GET", request.url, true);
+            for (const name in request.headers) {
+                xhr.setRequestHeader(name, request.headers[name]);
+            }
+
+            xhr.send();
+            return {
+                "abort": function () {
+                    xhr.abort();
+                }
+            };
+        }
+
+        function finishRequest(outcome) {
+            inFlight = false;
+            timeoutTimer.stop();
+            handleOutcome(outcome);
+        }
+
+        function requestTimeoutReached() {
+            if (!inFlight) {
+                return;
+            }
+
+            abortActiveRequest();
+            finishRequest({
+                              "networkError": true
+                          });
+        }
+
+        function handleOutcome(outcome) {
+            const now = currentTime();
+            if (outcome === null || typeof outcome !== "object" || outcome.networkError === true
+                    || typeof outcome.status !== "number") {
+                scheduleBackoff();
+                return;
+            }
+
+            const status = Math.floor(outcome.status);
+            if (status === 200 || status === 203) {
+                adoptSuccessResponse(status, outcome, now);
+            } else if (status === 304) {
+                adoptNotModified(outcome, now);
+            } else if (status === 429) {
+                scheduleThrottle(outcome.headers, now);
+            } else if (status >= 500 && status <= 599) {
+                scheduleBackoff();
+            } else if (status >= 400 && status <= 499) {
+                markPermanent();
+            } else {
+                // Unexpected 1xx/2xx/3xx codes are malformed responses.
+                scheduleBackoff();
+            }
+        }
+
+        function adoptSuccessResponse(status, outcome, now) {
+            const body = typeof outcome.bodyText === "string" ? outcome.bodyText : "";
+            const headers = outcome.headers !== null && typeof outcome.headers === "object" ? outcome.headers :
+                                                                                              {};
+            if (body.length === 0 || body.length > root.maximumResponseCharacters) {
+                scheduleBackoff();
+                return;
+            }
+
+            const selection = selectTimestep(body, now);
+            if (!selection.ok) {
+                scheduleBackoff();
+                return;
+            }
+
+            const expiresRaw = typeof headers["expires"] === "string" ? headers["expires"] : "";
+            const lastModifiedRaw = typeof headers["last-modified"] === "string"
+                  ? headers["last-modified"] : "";
+            const parsedExpires = Date.parse(expiresRaw);
+            cache = {
+                "schemaVersion": root.cacheSchemaVersion,
+                "locationKey": locationKey,
+                "body": body,
+                "expires": expiresRaw,
+                "lastModified": lastModifiedRaw,
+                "retrievedAt": now,
+                "validatedAt": now
+            };
+            expiresEpoch = Number.isFinite(parsedExpires) ? parsedExpires : Number.NaN;
+            backoffIndex = 0;
+            throttleTier = 0;
+            commitSnapshot(selection.snapshot, now);
+            writeCache(cache);
+            armRefresh(successRefreshAt(now, expiresEpoch));
+            armLocalDeadline();
+            if (status === 203) {
+                warnOnce("deprecated",
+                         "weather: provider reports deprecating data; honoring cache headers");
+            }
+        }
+
+        // A 304 keeps the cached body, re-selects the current timestep locally,
+        // refreshes validation metadata from the new headers, and schedules the
+        // next request without downloading a replacement body.
+        function adoptNotModified(outcome, now) {
+            if (cache === null || cache.lastModified === "") {
+                scheduleBackoff();
+                return;
+            }
+
+            const headers = outcome.headers !== null && typeof outcome.headers === "object" ? outcome.headers :
+                                                                                              {};
+            const expiresRaw = typeof headers["expires"] === "string" ? headers["expires"] : "";
+            let refreshedExpires = cache.expires;
+            if (expiresRaw !== "") {
+                const parsedExpires = Date.parse(expiresRaw);
+                if (Number.isFinite(parsedExpires)) {
+                    refreshedExpires = expiresRaw;
+                    expiresEpoch = parsedExpires;
+                }
+            }
+
+            const lastModifiedRaw = typeof headers["last-modified"] === "string"
+                  ? headers["last-modified"] : "";
+            // Records are replaced wholesale instead of mutated in place.
+            cache = {
+                "schemaVersion": cache.schemaVersion,
+                "locationKey": cache.locationKey,
+                "body": cache.body,
+                "expires": refreshedExpires,
+                "lastModified": lastModifiedRaw === "" ? cache.lastModified : lastModifiedRaw,
+                "retrievedAt": cache.retrievedAt,
+                "validatedAt": now
+            };
+            backoffIndex = 0;
+            throttleTier = 0;
+            const selection = selectTimestep(cache.body, now);
+            if (selection.ok) {
+                commitSnapshot(selection.snapshot, cache.retrievedAt);
+            } else {
+                clearWeather("stale");
+            }
+
+            writeCache(cache);
+            armRefresh(successRefreshAt(now, expiresEpoch));
+            armLocalDeadline();
+        }
+
+        // Next request after a successful validation: the response expiry plus
+        // positive jitter, with the 60-minute fallback when headers are missing
+        // or invalid, never sooner than ten minutes after completion.
+        function successRefreshAt(now, expiresEpochValue) {
+            const base = Number.isFinite(expiresEpochValue) ? Math.max(expiresEpochValue, now
+                                                                       + minimumRefreshGapMs) : now
+                                                              + expiresFallbackMs;
+            return base + jitter(refreshJitterMs);
+        }
+
+        function scheduleBackoff() {
+            const now = currentTime();
+            const index = Math.min(backoffIndex, backoffTiers.length - 1);
+            backoffIndex = Math.min(index + 1, backoffTiers.length - 1);
+            const delay = backoffTiers[index] + jitter(Math.floor(backoffTiers[index]
+                                                                  * backoffJitterFraction));
+            failure = "transient";
+            armRefresh(now + delay);
+        }
+
+        function scheduleThrottle(headers, now) {
+            const raw = headers !== null && typeof headers === "object" && typeof headers["retry-after"]
+                  === "string" ? headers["retry-after"] : "";
+            let retryAfter = 0;
+            if (/^[0-9]+$/.test(raw)) {
+                retryAfter = parseInt(raw, 10) * 1000;
+            } else {
+                const parsed = Date.parse(raw);
+                if (Number.isFinite(parsed)) {
+                    retryAfter = Math.max(0, parsed - now);
+                }
+            }
+
+            const tierDelay = throttleTiers[Math.min(throttleTier, throttleTiers.length - 1)];
+            throttleTier = Math.min(throttleTier + 1, throttleTiers.length - 1);
+            const base = Math.max(retryAfter, tierDelay);
+            const delay = base + jitter(Math.floor(base * backoffJitterFraction));
+            failure = "throttled";
+            armRefresh(now + delay);
+        }
+
+        function markPermanent() {
+            permanentKey = locationKey + "|" + activeVersion;
+            stopTimers();
+            nextRequestAt = 0;
+            clearWeather("permanent");
+        }
+
+        function armRefresh(atEpoch) {
+            const now = currentTime();
+            nextRequestAt = Math.max(atEpoch, now);
+            refreshTimer.interval = Math.max(1, Math.floor(nextRequestAt - now));
+            refreshTimer.restart();
+        }
+
+        // One local deadline covers the next cached timeseries boundary and the
+        // six-hour stale cutoff; both recompute state without network activity.
+        function armLocalDeadline() {
+            if (cache === null) {
+                stopLocalTimer();
+                return;
+            }
+
+            const now = currentTime();
+            let deadline = cache.validatedAt + staleCutoffMs;
+            // The expiry instant flips the exposed stale flag; past expiries
+            // are skipped so the deadline never re-arms in a tight loop.
+            if (Number.isFinite(expiresEpoch) && expiresEpoch > now) {
+                deadline = Math.min(deadline, expiresEpoch);
+            }
+
+            let parsed = null;
+            try {
+                parsed = JSON.parse(cache.body);
+            } catch (error) {
+                parsed = null;
+            }
+
+            const timeseries = parsed !== null && typeof parsed === "object" && parsed.properties
+                  !== null && typeof parsed.properties === "object" && parsed.properties.timeseries
+                  !== null && typeof parsed.properties.timeseries === "object"
+                  ? parsed.properties.timeseries : null;
+            if (timeseries !== null) {
+                for (let index = 0; index < timeseries.length; index += 1) {
+                    const entry = timeseries[index];
+                    if (entry === null || typeof entry !== "object" || typeof entry.time
+                            !== "string") {
+                        continue;
+                    }
+
+                    const time = Date.parse(entry.time);
+                    if (Number.isFinite(time) && time > now) {
+                        deadline = Math.min(deadline, time + 1);
+                        break;
+                    }
+                }
+            }
+
+            localTimer.interval = Math.max(1, Math.floor(deadline - now));
+            localTimer.restart();
+        }
+
+        function stopLocalTimer() {
+            localTimer.stop();
+        }
+
+        function stopTimers() {
+            refreshTimer.stop();
+            stopLocalTimer();
+            timeoutTimer.stop();
+        }
+
+        function abortActiveRequest() {
+            requestSerial += 1;
+            const active = activeRequest;
+            activeRequest = null;
+            if (active !== null && active !== undefined && active.abort !== undefined && active.abort
+                    !== null) {
+                active.abort();
+            }
+        }
+
+        // The cache holds one location's bounded record: schema version, the
+        // complete compact body, the exact header strings, and the timestamps.
+        // Quickshell exposes no file-deletion API, so removal overwrites the
+        // file with empty content; an empty or foreign record never validates.
+        function writeCache(record) {
+            const serialized = JSON.stringify(record);
+            if (serialized.length >= root.maximumResponseCharacters) {
+                warnOnce("cache-size",
+                         "weather: cache record exceeds the size bound; skipping persistence");
+                return;
+            }
+
+            cacheFileView.setText(serialized);
+        }
+
+        function clearCacheFile() {
+            if (cacheFileView.loaded) {
+                cacheFileView.setText("");
+            }
+        }
+    }
+
+    readonly property string userAgentValue: "NagiShell/" + version
+                                             + " github.com/Anthodev/nagi-shell"
+
+    function applyLocation() {
+        engine.applyLocation();
+    }
+
+    function parseHeaderBlock(raw) {
+        const headers = {};
+        if (typeof raw !== "string" || raw.length === 0) {
+            return headers;
+        }
+
+        const lines = raw.split("\n");
+        for (let index = 0; index < lines.length; index += 1) {
+            const line = lines[index];
+            const carriage = line.charCodeAt(line.length - 1) === 13;
+            const cleaned = carriage ? line.slice(0, line.length - 1) : line;
+            const separator = cleaned.indexOf(":");
+            if (separator <= 0) {
+                continue;
+            }
+
+            headers[cleaned.slice(0, separator).toLowerCase()] = cleaned.slice(separator + 1).trim(
+                        );
+
+        }
+
+        return headers;
+    }
+}

--- a/shell.qml
+++ b/shell.qml
@@ -7,8 +7,16 @@ ShellRoot {
         helperPath: Quickshell.shellPath("build/nagi-kwin-virtual-desktops")
     }
 
+    CompactClock {
+        id: clock
+    }
+
     IslandStateCoordinator {
         id: islandState
+    }
+
+    WeatherAdapter {
+        id: weather
     }
 
     IslandSurfaceHost {

--- a/tests/weather/shell.qml
+++ b/tests/weather/shell.qml
@@ -1,0 +1,613 @@
+import Quickshell
+import QtQuick
+import "qml"
+
+ShellRoot {
+    id: test
+
+    property real nowMs: 1755800400000
+    property int runId: Quickshell.processId
+    property int fileCounter: 0
+    property var rngQueue: []
+    property var sharedFirst: null
+    property var sharedSecond: null
+    property var sharedThird: null
+    property var sharedFourth: null
+    property var sharedFirstCap: null
+    property var sharedSecondCap: null
+    property var sharedThirdCap: null
+    property var sharedFourthCap: null
+
+    function require(condition, message) {
+        if (!condition) {
+            console.error("FAIL: " + message);
+            Qt.exit(1);
+            throw new Error(message);
+        }
+    }
+
+    function nextRandom() {
+        return rngQueue.length > 0 ? rngQueue.shift() : 0;
+    }
+
+    // QML copies plain JavaScript objects when they cross into a var property,
+    // so the harness keeps each capture record here and hands the adapter only
+    // the transport whose closures reach the original record.
+    function newCapture(responder) {
+        const record = {
+            "requests": [],
+            "responder": responder
+        };
+        const transport = {
+            "create": function (request) {
+                record.requests.push(request);
+                const outcome = record.responder === null ? null : record.responder(
+                        record.requests.length, request);
+                if (outcome !== null && typeof outcome === "object") {
+                    request.onCompleted(outcome);
+                }
+
+                return {
+                    "abort": function () {}
+                };
+            }
+        };
+        return {
+            "record": record,
+            "transport": transport
+        };
+    }
+
+    function metEntry(offsetMs, temperature, symbolCode) {
+        return {
+            "time": new Date(test.nowMs + offsetMs).toISOString(),
+            "data": {
+                "instant": {
+                    "details": {
+                        "air_temperature": temperature
+                    }
+                },
+                "next_1_hours": {
+                    "summary": {
+                        "symbol_code": symbolCode
+                    }
+                }
+            }
+        };
+    }
+
+    function metBody(entries) {
+        return JSON.stringify({
+                                  "properties": {
+                                      "timeseries": entries
+                                  }
+                              });
+    }
+
+    function ok(status, bodyText, expiresDeltaMs, lastModified) {
+        return {
+            "status": status,
+            "headers": {
+                "expires": new Date(test.nowMs + expiresDeltaMs).toUTCString(),
+                "last-modified": lastModified
+            },
+            "bodyText": bodyText
+        };
+    }
+
+    function makeWeather(overrides) {
+        const properties = {
+            "wallNow": function () {
+                return test.nowMs;
+            },
+            "randomSource": function () {
+                return test.nextRandom();
+            },
+            "cacheDirectory": Quickshell.shellDir,
+            "cacheFileName": "weather-" + test.runId + "-" + (test.fileCounter++) + ".json"
+        };
+        for (const key in overrides) {
+            properties[key] = overrides[key];
+        }
+
+        return weatherFactory.createObject(test, properties);
+    }
+
+    function conditionFor(symbolCode) {
+        const capture = newCapture(function () {
+            return ok(200, metBody([metEntry(-600000, 12.5, symbolCode)]), 1800000, "Symbol LM");
+        });
+        const weather = makeWeather({
+                                        "latitude": 48.8566,
+                                        "longitude": 2.3522,
+                                        "transport": capture.transport
+                                    });
+        weather.refreshDeadlineReached();
+        require(weather.available, "condition probe for " + symbolCode + " exposes state");
+        const result = {
+            "condition": weather.condition,
+            "dayPhase": weather.dayPhase
+        };
+        weather.destroy();
+        return result;
+    }
+
+    function run() {
+        rngQueue = [];
+
+        // Unconfigured and invalid locations never request and stay unavailable.
+        const unconfiguredCap = newCapture(null);
+        const unconfigured = makeWeather({
+                                             "transport": unconfiguredCap.transport
+                                         });
+        unconfigured.refreshDeadlineReached();
+        require(!unconfigured.locationConfigured && !unconfigured.available
+                && unconfigured.failure === "unconfigured",
+                "unconfigured weather stays unavailable without requests");
+        require(unconfiguredCap.record.requests.length === 0,
+                "unconfigured weather sends no request");
+
+        const invalidLatitudeCap = newCapture(null);
+        const invalidLatitude = makeWeather({
+                                                "latitude": 95.0,
+                                                "longitude": 10.0,
+                                                "transport": invalidLatitudeCap.transport
+                                            });
+        invalidLatitude.refreshDeadlineReached();
+        require(invalidLatitude.failure === "unconfigured"
+                && invalidLatitudeCap.record.requests.length === 0,
+                "out-of-range latitude performs no request");
+
+        const fractionalAltitudeCap = newCapture(null);
+        const fractionalAltitude = makeWeather({
+                                                   "latitude": 10.0,
+                                                   "longitude": 10.0,
+                                                   "altitude": 12.5,
+                                                   "transport": fractionalAltitudeCap.transport
+                                               });
+        fractionalAltitude.refreshDeadlineReached();
+        require(fractionalAltitude.failure === "unconfigured"
+                && fractionalAltitudeCap.record.requests.length === 0,
+                "fractional altitude performs no request");
+
+        // Requests carry truncated coarse coordinates, the identifying public
+        // User-Agent, no credential, and never the local label.
+        const shapedCap = newCapture(null);
+        const shaped = makeWeather({
+                                       "latitude": 48.8566,
+                                       "longitude": 2.3522,
+                                       "altitude": 35,
+                                       "label": "Home label",
+                                       "transport": shapedCap.transport
+                                   });
+        shaped.refreshDeadlineReached();
+        require(shapedCap.record.requests.length === 1,
+                "configured weather sends exactly its scheduled request");
+        const shapedRequest = shapedCap.record.requests[0];
+        require(shapedRequest.url
+                === "https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=48.85&lon=2.35&altitude=35",
+                "request URL uses two-decimal truncated coordinates");
+        require(shapedRequest.headers["User-Agent"]
+                === "NagiShell/0.1.0 github.com/Anthodev/nagi-shell",
+                "requests identify Nagi Shell with the public User-Agent");
+        require(shapedRequest.url.indexOf("Home") === -1,
+                "the local label never leaves the machine");
+        require(Object.keys(shapedRequest.headers).length === 1,
+                "requests carry no credential or extra header");
+
+        const negativeShapedCap = newCapture(null);
+        const negativeShaped = makeWeather({
+                                               "latitude": -33.8688,
+                                               "longitude": -74.0066,
+                                               "transport": negativeShapedCap.transport
+                                           });
+        negativeShaped.refreshDeadlineReached();
+        require(negativeShapedCap.record.requests[0].url.indexOf("?lat=-33.86&lon=-74.00")
+                !== -1 && negativeShapedCap.record.requests[0].url.indexOf("altitude") === -1,
+                "negative coordinates truncate toward zero and unknown altitude is omitted");
+
+        const zeroishShapedCap = newCapture(null);
+        const zeroishShaped = makeWeather({
+                                              "latitude": 0.001,
+                                              "longitude": -0.001,
+                                              "transport": zeroishShapedCap.transport
+                                          });
+        zeroishShaped.refreshDeadlineReached();
+        require(zeroishShapedCap.record.requests[0].url.indexOf("?lat=0.00&lon=0.00") !== -1,
+                "near-zero coordinates normalize without a negative-zero sign");
+
+        // A valid response exposes temperature and normalized condition from
+        // one current timestep and honors the expiry schedule with jitter.
+        const validCap = newCapture(null);
+        const valid = makeWeather({
+                                      "latitude": 48.8566,
+                                      "longitude": 2.3522,
+                                      "transport": validCap.transport
+                                  });
+        const completionTime = test.nowMs;
+        valid.refreshDeadlineReached();
+        validCap.record.requests[0].onCompleted(ok(
+                                                     200,
+                                                     metBody([metEntry(-1800000, 21.5,
+                                                                       "partlycloudy_day"),
+                                                         metEntry(-600000, 18.4, "clearsky_night")]),
+                                                     1800000, "LM-1"));
+        require(valid.available && !valid.stale && valid.failure === "none",
+                "a valid response is available and fresh");
+        require(valid.temperatureC === 18.4 && valid.condition === "clear"
+                && valid.dayPhase === "night",
+                "state comes from the latest satisfying single timestep");
+        require(valid.forecastTime.getTime() === completionTime - 600000,
+                "forecast time matches the selected entry");
+        require(valid.fetchedAt.getTime() === completionTime,
+                "fetched time marks the retrieval");
+        require(valid.nextRequestAt === Math.max(completionTime + 1800000,
+                                                 completionTime + 600000),
+                "zero jitter schedules the next request exactly at expiry");
+
+        // Symbol normalization matrix: intensity and shower variants collapse;
+        // day-phase suffixes separate; thunder wins over precipitation families.
+        const matrix = [["clearsky", "clear", "day"], ["fair", "mostlyClear", "day"],
+            ["partlycloudy_day", "partlyCloudy", "day"],
+            ["partlycloudy_night", "partlyCloudy", "night"], ["cloudy", "cloudy", "day"],
+            ["fog_polartwilight", "fog", "polartwilight"],
+            ["heavyrainshowersandthunder_day", "thunderstorm", "day"],
+            ["lightsleetshowers_night", "sleet", "night"], ["heavysnow", "snow", "day"],
+            ["rainshowers_day", "rain", "day"], ["lightrain", "rain", "day"],
+            ["sleet", "sleet", "day"]];
+        for (let index = 0; index < matrix.length; index += 1) {
+            const normalized = conditionFor(matrix[index][0]);
+            require(normalized.condition === matrix[index][1] && normalized.dayPhase
+                    === matrix[index][2],
+                    "symbol " + matrix[index][0] + " normalizes to " + matrix[index][1] + "/"
+                    + matrix[index][2]);
+        }
+
+        require(conditionFor("mysterycode").condition === "unknown",
+                "unknown provider codes map to the bounded unknown condition");
+
+        // Only one request may be in flight, and none before the deadline.
+        const gatedCap = newCapture(null);
+        const gated = makeWeather({
+                                      "latitude": 48.8566,
+                                      "longitude": 2.3522,
+                                      "transport": gatedCap.transport
+                                  });
+        gated.refreshDeadlineReached();
+        gated.refreshDeadlineReached();
+        require(gatedCap.record.requests.length === 1,
+                "no second request starts while one is in flight");
+        gatedCap.record.requests[0].onCompleted(ok(200,
+                                                   metBody([metEntry(-600000, 9.9, "fog")]),
+                                                   3600000, "LM-2"));
+        gated.refreshDeadlineReached();
+        require(gatedCap.record.requests.length === 1,
+                "no request occurs before Expires");
+
+        test.nowMs += 3600000;
+        gated.refreshDeadlineReached();
+        require(gatedCap.record.requests.length === 2,
+                "expiry opens the conditional refresh window");
+        require(gatedCap.record.requests[1].headers["If-Modified-Since"] === "LM-2",
+                "the conditional request replays the exact cached Last-Modified value");
+        const notModifiedAt = test.nowMs;
+        gatedCap.record.requests[1].onCompleted({
+                                                    "status": 304,
+                                                    "headers": {
+                                                        "expires": new Date(
+                                                            test.nowMs + 7200000).toUTCString()
+                                                    },
+                                                    "bodyText": ""
+                                                });
+        require(gated.available && gated.temperatureC === 9.9 && !gated.stale,
+                "a 304 keeps the cached body and reselects state locally");
+        require(gated.nextRequestAt === Math.max(notModifiedAt + 7200000,
+                                                 notModifiedAt + 600000),
+                "a 304 refreshes validation metadata from the new headers");
+
+        // Timeouts and network errors take the transient backoff tiers.
+        const timingOutCap = newCapture(null);
+        const timingOut = makeWeather({
+                                          "latitude": 48.8566,
+                                          "longitude": 2.3522,
+                                          "transport": timingOutCap.transport
+                                      });
+        timingOut.refreshDeadlineReached();
+        require(timingOutCap.record.requests.length === 1,
+                "timeout scenario sends its request");
+        timingOut.requestTimeoutReached();
+        require(timingOut.failure === "transient" && !timingOut.available,
+                "an aborted request is a transient failure without state");
+        require(timingOut.nextRequestAt === test.nowMs + 600000,
+                "first transient failure retries after ten minutes plus jitter");
+        const expectedTiers = [1800000, 3600000, 10800000, 21600000, 21600000];
+        for (let tier = 1; tier < 6; tier += 1) {
+            test.nowMs = timingOut.nextRequestAt;
+            timingOut.refreshDeadlineReached();
+            timingOutCap.record.requests[tier].onCompleted({
+                                                               "networkError": true
+                                                           });
+            require(timingOut.nextRequestAt === test.nowMs + expectedTiers[tier - 1],
+                    "transient failure tier " + tier + " follows the bounded backoff ladder");
+        }
+
+        // A 5xx response takes the same bounded transient ladder.
+        test.nowMs = timingOut.nextRequestAt;
+        timingOut.refreshDeadlineReached();
+        timingOutCap.record.requests[6].onCompleted(ok(500, "server error", 60000, ""));
+        require(timingOut.nextRequestAt === test.nowMs + 21600000,
+                "a 5xx response follows the capped transient tier");
+
+        // A 203 deprecation response still yields valid normalized state.
+        const deprecatedCap = newCapture(null);
+        const deprecated = makeWeather({
+                                           "latitude": 48.8566,
+                                           "longitude": 2.3522,
+                                           "transport": deprecatedCap.transport
+                                       });
+        deprecated.refreshDeadlineReached();
+        deprecatedCap.record.requests[0].onCompleted(ok(203,
+                                                        metBody([metEntry(-600000, 6.6,
+                                                                          "fog")]),
+                                                        1800000, "LM-203"));
+        require(deprecated.available && deprecated.temperatureC === 6.6
+                && deprecated.failure === "none",
+                "a 203 deprecation response still exposes valid state");
+
+        // Throttling waits at least as long as Retry-After and escalates tiers.
+        const throttledCap = newCapture(null);
+        const throttled = makeWeather({
+                                          "latitude": 48.8566,
+                                          "longitude": 2.3522,
+                                          "transport": throttledCap.transport
+                                      });
+        throttled.refreshDeadlineReached();
+        throttledCap.record.requests[0].onCompleted({
+                                                        "status": 429,
+                                                        "headers": {
+                                                            "retry-after": "120"
+                                                        },
+                                                        "bodyText": ""
+                                                    });
+        require(throttled.failure === "throttled"
+                && throttled.nextRequestAt === test.nowMs + 3600000,
+                "throttling waits for the greater of Retry-After and sixty minutes");
+        test.nowMs = throttled.nextRequestAt;
+        throttled.refreshDeadlineReached();
+        throttledCap.record.requests[1].onCompleted({
+                                                        "status": 429,
+                                                        "bodyText": ""
+                                                    });
+        require(throttled.nextRequestAt === test.nowMs + 10800000,
+                "repeated throttling escalates to the three-hour tier");
+        test.nowMs = throttled.nextRequestAt;
+        throttled.refreshDeadlineReached();
+        throttledCap.record.requests[2].onCompleted({
+                                                        "status": 429,
+                                                        "headers": {
+                                                            "retry-after": new Date(
+                                                                test.nowMs + 90000).toUTCString()
+                                                        },
+                                                        "bodyText": ""
+                                                    });
+        require(throttled.nextRequestAt === test.nowMs + 21600000,
+                "HTTP-date Retry-After parses and repeated throttling caps at six hours");
+
+        // Other 4xx responses are permanent until location or version changes.
+        const permanentCap = newCapture(null);
+        const permanent = makeWeather({
+                                          "latitude": 48.8566,
+                                          "longitude": 2.3522,
+                                          "transport": permanentCap.transport
+                                      });
+        permanent.refreshDeadlineReached();
+        permanentCap.record.requests[0].onCompleted(ok(404, "gone", 60000, ""));
+        require(permanent.failure === "permanent" && !permanent.available,
+                "permanent rejection exposes unavailable weather");
+        test.nowMs += 86400000;
+        permanent.refreshDeadlineReached();
+        require(permanentCap.record.requests.length === 1,
+                "permanent failures stop automatic retries");
+        permanent.version = "0.2.0";
+        permanent.applyLocation();
+        permanent.refreshDeadlineReached();
+        require(permanentCap.record.requests.length === 2,
+                "changing the application version restarts a permanently rejected location");
+
+        // Malformed and oversized responses retry transiently and preserve the
+        // last valid content during the stale window.
+        const resilientCap = newCapture(null);
+        const resilient = makeWeather({
+                                          "latitude": 48.8566,
+                                          "longitude": 2.3522,
+                                          "transport": resilientCap.transport
+                                      });
+        resilient.refreshDeadlineReached();
+        resilientCap.record.requests[0].onCompleted(ok(200,
+                                                       metBody([metEntry(-600000, 7.5, "fog")]),
+                                                       600000, "LM-3"));
+        require(resilient.temperatureC === 7.5, "preservation scenario reaches a valid state");
+        test.nowMs += 600000;
+        resilient.localDeadlineReached();
+        resilient.refreshDeadlineReached();
+        resilientCap.record.requests[1].onCompleted(ok(200, "{not json", 600000, "LM-4"));
+        require(resilient.failure === "transient" && resilient.available
+                && resilient.temperatureC === 7.5 && resilient.stale,
+                "malformed bodies keep the last valid content through the stale window");
+        const oversized = "x".repeat(resilient.maximumResponseCharacters + 1);
+        test.nowMs = resilient.nextRequestAt;
+        resilient.refreshDeadlineReached();
+        resilientCap.record.requests[2].onCompleted(ok(200, oversized, 600000, "LM-5"));
+        require(resilient.available && resilient.temperatureC === 7.5,
+                "oversized bodies never replace exposed state");
+
+        const missingFieldsCap = newCapture(null);
+        const missingFields = makeWeather({
+                                              "latitude": 48.8566,
+                                              "longitude": 2.3522,
+                                              "transport": missingFieldsCap.transport
+                                          });
+        missingFields.refreshDeadlineReached();
+        missingFieldsCap.record.requests[0].onCompleted(ok(200,
+                                                           metBody([metEntry(-60000, 150,
+                                                                             "fog")]),
+                                                           600000, ""));
+        require(missingFields.failure === "transient" && !missingFields.available,
+                "responses failing field validation expose nothing");
+
+        // Cached content ages locally: the expiry instant flips stale, the
+        // timeseries boundary advances selection, and six hours clear everything.
+        const agingCap = newCapture(null);
+        const aging = makeWeather({
+                                      "latitude": 48.8566,
+                                      "longitude": 2.3522,
+                                      "transport": agingCap.transport
+                                  });
+        aging.refreshDeadlineReached();
+        const agingValidatedAt = test.nowMs;
+        agingCap.record.requests[0].onCompleted(ok(
+                                                   200,
+                                                   metBody([metEntry(-4800000, 3.3, "snow"),
+                                                       metEntry(300000, 4.4, "rain")]),
+                                                   1800000, "LM-6"));
+        require(aging.temperatureC === 3.3 && aging.condition === "snow",
+                "aging scenario starts on the current entry");
+        test.nowMs += 300001;
+        aging.localDeadlineReached();
+        require(aging.temperatureC === 4.4 && aging.condition === "rain" && !aging.stale,
+                "the timeseries boundary advances the selected entry without a request");
+        require(agingCap.record.requests.length === 1,
+                "local advancement performs no network activity");
+        test.nowMs += 1499999;
+        aging.localDeadlineReached();
+        require(aging.available && aging.stale,
+                "passing Expires exposes stale but available content");
+        test.nowMs = agingValidatedAt + 21600001;
+        aging.localDeadlineReached();
+        require(!aging.available && aging.failure === "stale",
+                "six hours without validation clears the weather");
+        aging.refreshDeadlineReached();
+        require(agingCap.record.requests.length === 2
+                && agingCap.record.requests[1].headers["If-Modified-Since"] === undefined,
+                "after the cutoff recovery requests are unconditional again");
+
+        // A cache whose entries all age out clears at the next local deadline.
+        const exhaustedCap = newCapture(null);
+        const exhausted = makeWeather({
+                                          "latitude": 48.8566,
+                                          "longitude": 2.3522,
+                                          "transport": exhaustedCap.transport
+                                      });
+        exhausted.refreshDeadlineReached();
+        exhaustedCap.record.requests[0].onCompleted(ok(200,
+                                                       metBody([metEntry(-5400000, 1.1,
+                                                                         "fog")]),
+                                                       3600000, "LM-7"));
+        test.nowMs += 60001;
+        exhausted.localDeadlineReached();
+        require(!exhausted.available && exhausted.failure === "stale",
+                "losing the last valid timestep clears the weather immediately");
+
+        // Startup jitter stays inside its positive bound.
+        rngQueue = [0.9999];
+        const jitterBase = test.nowMs;
+        const jittered = makeWeather({
+                                         "latitude": 48.8566,
+                                         "longitude": 2.3522,
+                                         "transport": newCapture(null).transport
+                                     });
+        require(jittered.nextRequestAt === jitterBase + Math.floor(0.9999 * 30000),
+                "startup refresh waits a positive sub-thirty-second jitter");
+
+        // The clock stays independent of every weather failure above.
+        require(/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(clock.text),
+                "the compact clock renders 24-hour minute text");
+        require(clock.precision === SystemClock.Minutes && !isNaN(clock.date.getTime()),
+                "the compact clock updates only at minute precision");
+
+        // Cache lifecycle across instances: adoption without requests, keyed
+        // replacement, and removal of a previous location's record.
+        sharedFirstCap = newCapture(null);
+        sharedFirst = makeWeather({
+                                      "latitude": 48.8566,
+                                      "longitude": 2.3522,
+                                      "cacheFileName": "weather-shared-" + runId + ".json",
+                                      "transport": sharedFirstCap.transport
+                                  });
+        sharedFirst.refreshDeadlineReached();
+        sharedFirstCap.record.requests[0].onCompleted(ok(
+                                                          200,
+                                                          metBody([metEntry(-600000, 19.5,
+                                                                            "partlycloudy_day")]),
+                                                          3600000, "LM-SHARED"));
+        afterSaved(sharedFirst, runCacheReplacementStage);
+    }
+
+    // The shared-cache scenarios continue across cache-saved signals so every
+    // stage observes fully persisted state.
+    function afterSaved(weatherAdapter, continuation) {
+        const handler = function () {
+            weatherAdapter.cacheSaved.disconnect(handler);
+            continuation();
+        };
+
+        weatherAdapter.cacheSaved.connect(handler);
+    }
+
+    function runCacheReplacementStage() {
+        require(sharedFirst.temperatureC === 19.5 && sharedFirst.available,
+                "the first shared instance holds its response state");
+
+        sharedSecondCap = newCapture(null);
+        sharedSecond = makeWeather({
+                                       "latitude": 48.8566,
+                                       "longitude": 2.3522,
+                                       "cacheFileName": "weather-shared-" + runId + ".json",
+                                       "transport": sharedSecondCap.transport
+                                   });
+        sharedSecond.refreshDeadlineReached();
+        require(sharedSecond.available && sharedSecond.temperatureC === 19.5,
+                "a matching startup adopts the cached forecast without a request");
+        require(sharedSecondCap.record.requests.length === 0 && !sharedSecond.stale,
+                "adopted caches serve while their stored expiry is in the future");
+
+        sharedThirdCap = newCapture(null);
+        sharedThird = makeWeather({
+                                      "latitude": 41.3874,
+                                      "longitude": 2.1686,
+                                      "cacheFileName": "weather-shared-" + runId + ".json",
+                                      "transport": sharedThirdCap.transport
+                                  });
+        afterSaved(sharedThird, runCacheClearedStage);
+    }
+
+    function runCacheClearedStage() {
+        sharedFourthCap = newCapture(null);
+        sharedFourth = makeWeather({
+                                       "latitude": 48.8566,
+                                       "longitude": 2.3522,
+                                       "cacheFileName": "weather-shared-" + runId + ".json",
+                                       "transport": sharedFourthCap.transport
+                                   });
+        sharedFourth.refreshDeadlineReached();
+        require(sharedFourthCap.record.requests.length === 1,
+                "a replaced location removes the previous location's cache record");
+        require(sharedFourthCap.record.requests[0].headers["If-Modified-Since"] === undefined,
+                "removed records cannot produce conditional requests");
+
+        console.log("weather state tests passed");
+        Qt.exit(0);
+    }
+
+    Component {
+        id: weatherFactory
+
+        WeatherAdapter {}
+    }
+
+    CompactClock {
+        id: clock
+    }
+
+    Component.onCompleted: Qt.callLater(test.run)
+}


### PR DESCRIPTION
Add the Idle state layer: a 24-hour clock that updates only at minute
precision, and an optional MET Norway Locationforecast 2.0 weather
adapter behind typed normalized state (available, stale, temperatureC,
condition, dayPhase, forecastTime, fetchedAt, failure).

Weather is opt-in through explicit local coordinates; invalid or
missing coordinates perform no request. Requests carry truncated
two-decimal coordinates and the public identifying User-Agent, one
in-flight XHR with a 10-second abort, and never send the local label.
A single private atomic cache below 1 MiB in the per-shell cache
directory stores the bounded body, exact header strings, and
timestamps keyed by coarse coordinates and altitude. After expiry the
cached Last-Modified is replayed as If-Modified-Since, a 304 keeps the
body and reselects the current timestep locally, and one-shot jittered
deadlines replace any polling loop. Failures follow bounded tiers:
10 min to 6 h transient backoff, Retry-Afer-aware throttling, permanent
4xx until the location or version changes, and a six-hour stale cutoff
that clears content without touching the clock.

Adds a headless deterministic test suite (make test-weather) wired
into check-nondisplay.

Closes #18