### PR TITLE
feat(platform): integrate PipeWire audio controls (#22)

### DIFF
--- a/.github/actions/install-toolchain/action.yml
+++ b/.github/actions/install-toolchain/action.yml
@@ -1,7 +1,7 @@
 name: 'Install Fedora 44 toolchain'
 description: >-
-  Installs the pinned Fedora 44 CI toolchain: native build dependencies,
-  Qt/QML tools, and Quickshell from the stable errornointernet/quickshell COPR.
+  Installs the pinned Fedora 44 CI toolchain: native Qt and PipeWire build
+  dependencies, QML tools, and Quickshell from the stable COPR.
 runs:
   using: composite
   steps:
@@ -14,6 +14,7 @@ runs:
         make
         gcc-c++
         pkgconf-pkg-config
+        pipewire-devel
         qt6-qtbase-devel
         qt6-qtdeclarative-devel
         dbus-daemon

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,18 +6,19 @@
 #
 # Environment contract:
 #   - Pinned Fedora 44 container aligned with the supported local toolchain.
-#   - Quickshell installed from the stable errornointernet/quickshell COPR;
-#     `make requirements` fails before any test when the version is below the
-#     repository minimum.
+#   - Quickshell installed from the stable errornointernet/quickshell COPR and
+#     PipeWire development headers installed from Fedora; `make requirements`
+#     validates both before any test.
 #   - No secret, privileged runner, GPU, real KDE session, or external service
 #     state is required.
 #
 # Scope boundary:
 #   A successful run covers formatting, native normalization, D-Bus owner
-#   lifecycle, the QML adapter boundary, coordinator determinism, and the real
-#   PanelWindow state scenario and the UI-primitive gallery, under a
-#   software-rendered headless wlroots compositor. Success here does NOT
-#   replace the real KDE/KWin verification matrix tracked in issue #35
+#   lifecycle, the native audio bridge protocol and volume math, QML adapter
+#   boundaries, coordinator determinism, the real PanelWindow state scenario,
+#   and the UI-primitive gallery under a software-rendered headless wlroots
+#   compositor. Success here does NOT replace the real KDE/KWin verification
+#   matrix tracked in issue #35
 #   (multi-display, hardware rendering, and final cross-state checks still
 #   require a real desktop session).
 name: Repository checks

--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,28 @@ HELPER_TEST := $(BUILD_DIR)/kwin-virtual-desktops-test
 HELPER_MOC := $(BUILD_DIR)/main.moc
 OWNER_TEST := $(BUILD_DIR)/kwin-owner-lifecycle-test
 OWNER_TEST_MOC := $(BUILD_DIR)/kwin_owner_lifecycle_test.moc
+AUDIO_HELPER := $(BUILD_DIR)/nagi-pipewire-audio
+AUDIO_PROTOCOL_TEST := $(BUILD_DIR)/pipewire-audio-protocol-test
+AUDIO_VOLUME_TEST := $(BUILD_DIR)/pipewire-audio-volume-test
 COORDINATOR_TEST_DIR := $(BUILD_DIR)/coordinator-test
 WEATHER_TEST_DIR := $(BUILD_DIR)/weather-test
 MEDIA_TEST_DIR := $(BUILD_DIR)/media-test
+AUDIO_TEST_DIR := $(BUILD_DIR)/audio-test
+AUDIO_LIVE_TEST_DIR := $(BUILD_DIR)/audio-live-test
+AUDIO_LIVE_WRITE_TEST_DIR := $(BUILD_DIR)/audio-live-write-test
 SURFACE_STATE_TEST_DIR := $(BUILD_DIR)/surface-state-test
 UI_PRIMITIVES_TEST_DIR := $(BUILD_DIR)/ui-primitives-test
 IDLE_TEST_DIR := $(BUILD_DIR)/idle-test
 HELPER_SOURCES := src/kwin-virtual-desktops/main.cpp src/kwin-virtual-desktops/desktop_snapshot.cpp
 HELPER_HEADERS := src/kwin-virtual-desktops/desktop_snapshot.h
+AUDIO_HELPER_SOURCES := src/pipewire-audio/main.cpp src/pipewire-audio/protocol.cpp src/pipewire-audio/volume.cpp
+AUDIO_HELPER_HEADERS := src/pipewire-audio/protocol.h src/pipewire-audio/volume.h
 QT_CFLAGS := $(shell $(PKG_CONFIG) --cflags Qt6Core Qt6DBus)
 QT_LIBS := $(shell $(PKG_CONFIG) --libs Qt6Core Qt6DBus)
+PIPEWIRE_CFLAGS := $(shell $(PKG_CONFIG) --cflags libpipewire-0.3)
+PIPEWIRE_LIBS := $(shell $(PKG_CONFIG) --libs libpipewire-0.3)
 NATIVE_CXXFLAGS := -std=c++20 -O2 -Wall -Wextra -Wpedantic
+AUDIO_NATIVE_CXXFLAGS := -std=gnu++20 -O2 -Wall -Wextra -Wno-sfinae-incomplete
 
 
 QUICKSHELL_MIN_VERSION := 0.3.0
@@ -33,19 +44,25 @@ QUICKSHELL_CHANNEL := stable
 FEDORA_QUICKSHELL_COPR := errornointernet/quickshell
 FEDORA_QUICKSHELL_PACKAGE := quickshell
 
-.PHONY: help requirements prepare check-quickshell check-helper-toolchain helper test-native test-owner-lifecycle test-adapter test-coordinator test-weather test-media test-idle test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
+.PHONY: help requirements prepare check-quickshell check-helper-toolchain check-audio-toolchain helper audio-helper test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-adapter test-coordinator test-weather test-media test-audio test-audio-live test-audio-live-write test-idle test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
 
 help:
 	@printf '%s\n' \
-		'make requirements    Show and verify the Quickshell dependency' \
+		'make requirements    Show and verify runtime/build dependencies' \
 		'make helper          Build the KWin virtual desktop helper' \
+		'make audio-helper    Build the confirmed PipeWire audio bridge' \
 		'make test-native     Test KWin tuple normalization' \
 		'make test-owner-lifecycle  Test KWin owner loss and replacement' \
+		'make test-audio-protocol  Test the audio bridge command boundary' \
+		'make test-audio-volume  Test proportional average-volume writes' \
 		'make test-adapter    Test the QML adapter boundary' \
 		'make test-coordinator  Test island ownership and restoration' \
 		'make test-surface-state  Exercise coordinator in the actual island surface' \
 		'make test-weather    Test compact clock and weather adapter state' \
 		'make test-media      Test the MPRIS media adapter state' \
+		'make test-audio      Test the PipeWire audio adapter state' \
+		'make test-audio-live Probe the live PipeWire graph without changing it' \
+		'make test-audio-live-write  Change and restore live default audio state' \
 		'make test-ui-primitives  Render theme tokens and primitives in the island surface' \
 		'make test-idle       Test idle island composition and collapse' \
 		'make launch          Run this checkout in the foreground' \
@@ -63,10 +80,11 @@ help:
 requirements:
 	@printf 'Quickshell >= %s from the %s release channel\n' '$(QUICKSHELL_MIN_VERSION)' '$(QUICKSHELL_CHANNEL)'
 	@printf 'Fedora 44 source: COPR %s, package %s (never quickshell-git)\n' '$(FEDORA_QUICKSHELL_COPR)' '$(FEDORA_QUICKSHELL_PACKAGE)'
-	@printf 'Install: sudo dnf copr enable %s && sudo dnf install %s\n' '$(FEDORA_QUICKSHELL_COPR)' '$(FEDORA_QUICKSHELL_PACKAGE)'
-	@printf 'Native helper build: C++20 plus Qt 6 Core and DBus development files\n'
+	@printf 'Install: sudo dnf copr enable %s && sudo dnf install %s pipewire-devel\n' '$(FEDORA_QUICKSHELL_COPR)' '$(FEDORA_QUICKSHELL_PACKAGE)'
+	@printf 'Native builds: C++20, Qt 6 Core/DBus, and libpipewire 0.3 development files\n'
 	@$(MAKE) --no-print-directory check-quickshell
 	@$(MAKE) --no-print-directory check-helper-toolchain
+	@$(MAKE) --no-print-directory check-audio-toolchain
 
 prepare:
 	@touch .qmlls.ini
@@ -74,6 +92,9 @@ prepare:
 check-helper-toolchain:
 	@$(PKG_CONFIG) --exists Qt6Core Qt6DBus
 	@test -x '$(MOC)'
+
+check-audio-toolchain:
+	@$(PKG_CONFIG) --exists Qt6Core libpipewire-0.3
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
@@ -93,10 +114,27 @@ $(HELPER_TEST): tests/kwin_virtual_desktops_test.cpp src/kwin-virtual-desktops/d
 $(OWNER_TEST): tests/kwin_owner_lifecycle_test.cpp $(OWNER_TEST_MOC) | $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(QT_CFLAGS) -I$(BUILD_DIR) tests/kwin_owner_lifecycle_test.cpp -o $@ $(LDFLAGS) $(QT_LIBS)
 
+$(AUDIO_HELPER): $(AUDIO_HELPER_SOURCES) $(AUDIO_HELPER_HEADERS) | $(BUILD_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(AUDIO_NATIVE_CXXFLAGS) $(QT_CFLAGS) $(PIPEWIRE_CFLAGS) -Isrc/pipewire-audio $(AUDIO_HELPER_SOURCES) -o $@ $(LDFLAGS) $(QT_LIBS) $(PIPEWIRE_LIBS)
+
+$(AUDIO_PROTOCOL_TEST): tests/pipewire_audio_protocol_test.cpp src/pipewire-audio/protocol.cpp $(AUDIO_HELPER_HEADERS) | $(BUILD_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(AUDIO_NATIVE_CXXFLAGS) $(QT_CFLAGS) -Isrc/pipewire-audio tests/pipewire_audio_protocol_test.cpp src/pipewire-audio/protocol.cpp -o $@ $(LDFLAGS) $(QT_LIBS)
+
+$(AUDIO_VOLUME_TEST): tests/pipewire_audio_volume_test.cpp src/pipewire-audio/volume.cpp src/pipewire-audio/volume.h | $(BUILD_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(AUDIO_NATIVE_CXXFLAGS) -Isrc/pipewire-audio tests/pipewire_audio_volume_test.cpp src/pipewire-audio/volume.cpp -o $@ $(LDFLAGS)
+
 helper: check-helper-toolchain $(HELPER)
+
+audio-helper: check-audio-toolchain $(AUDIO_HELPER)
 
 test-native: check-helper-toolchain $(HELPER_TEST)
 	$(HELPER_TEST)
+
+test-audio-protocol: check-audio-toolchain $(AUDIO_PROTOCOL_TEST)
+	$(AUDIO_PROTOCOL_TEST)
+
+test-audio-volume: $(AUDIO_VOLUME_TEST)
+	$(AUDIO_VOLUME_TEST)
 
 test-owner-lifecycle: check-helper-toolchain $(HELPER) $(OWNER_TEST)
 	@command -v '$(DBUS_RUN_SESSION)' >/dev/null
@@ -125,6 +163,24 @@ test-media: check-quickshell | $(BUILD_DIR)
 	cp tests/media/shell.qml $(MEDIA_TEST_DIR)/shell.qml
 	cp qml/MediaAdapter.qml $(MEDIA_TEST_DIR)/qml/
 	$(QS) -p $(MEDIA_TEST_DIR) --no-duplicate
+
+test-audio: check-quickshell | $(BUILD_DIR)
+	mkdir -p $(AUDIO_TEST_DIR)/qml
+	cp tests/audio/shell.qml $(AUDIO_TEST_DIR)/shell.qml
+	cp qml/AudioAdapter.qml qml/PipeWireAudioBridge.qml $(AUDIO_TEST_DIR)/qml/
+	$(QS) -p $(AUDIO_TEST_DIR) --no-duplicate
+
+test-audio-live: check-quickshell audio-helper | $(BUILD_DIR)
+	mkdir -p $(AUDIO_LIVE_TEST_DIR)/qml
+	cp tests/audio/live.qml $(AUDIO_LIVE_TEST_DIR)/shell.qml
+	cp qml/AudioAdapter.qml qml/PipeWireAudioBridge.qml $(AUDIO_LIVE_TEST_DIR)/qml/
+	NAGI_AUDIO_HELPER='$(abspath $(AUDIO_HELPER))' $(QS) -p $(AUDIO_LIVE_TEST_DIR) --no-duplicate
+
+test-audio-live-write: check-quickshell audio-helper | $(BUILD_DIR)
+	mkdir -p $(AUDIO_LIVE_WRITE_TEST_DIR)/qml
+	cp tests/audio/live-write.qml $(AUDIO_LIVE_WRITE_TEST_DIR)/shell.qml
+	cp qml/AudioAdapter.qml qml/PipeWireAudioBridge.qml $(AUDIO_LIVE_WRITE_TEST_DIR)/qml/
+	NAGI_AUDIO_HELPER='$(abspath $(AUDIO_HELPER))' $(QS) -p $(AUDIO_LIVE_WRITE_TEST_DIR) --no-duplicate
 
 test-surface-state: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(SURFACE_STATE_TEST_DIR)/qml
@@ -158,10 +214,10 @@ check-quickshell:
 	fi; \
 	printf 'Quickshell %s satisfies the >= %s requirement.\n' "$$version" '$(QUICKSHELL_MIN_VERSION)'
 
-launch: check-quickshell prepare helper
+launch: check-quickshell prepare helper audio-helper
 	$(QS) -p . --no-duplicate
 
-diagnose: check-quickshell prepare helper
+diagnose: check-quickshell prepare helper audio-helper
 	$(QS) -p . --no-duplicate -vv --log-times
 
 instances:
@@ -208,6 +264,6 @@ lint-advisory:
 
 check: check-nondisplay test-surface-state test-ui-primitives
 
-check-nondisplay: check-quickshell format-check test-native test-owner-lifecycle test-adapter test-coordinator test-weather test-media test-idle
+check-nondisplay: check-quickshell format-check audio-helper test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-adapter test-coordinator test-weather test-media test-audio test-idle
 clean:
 	rm -rf $(BUILD_DIR)

--- a/qml/AudioAdapter.qml
+++ b/qml/AudioAdapter.qml
@@ -1,0 +1,1482 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Services.Pipewire
+import QtQuick
+
+// PipeWire state behind Nagi's audio controls (ADR-0004 boundary).
+//
+// Quickshell owns graph/default discovery and one lazy tracker. A small native
+// bridge owns volume/mute writes and reads them back after PipeWire core
+// synchronization, so presentation sees only server-confirmed values. Raw
+// objects, properties, channels, links, and session-local IDs remain private.
+Scope {
+    id: root
+
+    // Verification seams. Production uses the Pipewire singleton, one native
+    // tracker, and the Nagi-owned confirmation bridge.
+    property var pipewireService: null
+    property bool nativeTrackingEnabled: true
+    property var nodeIdReader: null
+    property string bridgePath: ""
+    property var confirmationBridge: null
+    property var preferredSinkWriter: null
+
+    readonly property int maximumLabelCharacters: 128
+    readonly property int maximumNameCharacters: 256
+    readonly property int volumeCoalesceMs: 16
+    readonly property int requestTimeoutMs: 2000
+    readonly property int refreshLabelTimeoutMs: 3000
+    readonly property int failureTimeoutMs: 3000
+
+    // "unavailable", "tracking", or "ready". PipeWire graph readiness and
+    // tracked-default readiness are intentionally distinct.
+    readonly property string syncState: engine.syncState
+    readonly property bool isSynchronized: engine.serviceReady
+    readonly property bool available: engine.serviceReady && engine.bridgeReady
+
+    readonly property bool outputAvailable: engine.output.available
+    readonly property string outputEndpointKey: engine.output.endpointKey
+    readonly property string outputSourceToken: engine.output.sourceToken
+    readonly property int outputGeneration: engine.output.generation
+    readonly property int outputRevision: engine.output.revision
+    readonly property string outputLabel: engine.output.label
+    readonly property string outputDisplayLabel: outputAvailable ? outputLabel :
+                                                                   engine.lastOutputLabel
+    readonly property var outputVolume: engine.output.volume
+    readonly property bool outputOveramplified: engine.output.overamplified
+    readonly property bool outputMuted: engine.output.muted
+
+    readonly property bool inputAvailable: engine.input.available
+    readonly property string inputEndpointKey: engine.input.endpointKey
+    readonly property string inputSourceToken: engine.input.sourceToken
+    readonly property int inputGeneration: engine.input.generation
+    readonly property int inputRevision: engine.input.revision
+    readonly property string inputLabel: engine.input.label
+    readonly property string inputDisplayLabel: inputAvailable ? inputLabel : engine.lastInputLabel
+    readonly property var inputVolume: engine.input.volume
+    readonly property bool inputOveramplified: engine.input.overamplified
+    readonly property bool inputMuted: engine.input.muted
+
+    // Candidate entries contain only endpointKey, label, and isDefault.
+    readonly property var outputCandidates: engine.publicCandidates
+
+    readonly property bool pendingOutputVolume: engine.pendingOutputVolume
+    readonly property bool pendingInputVolume: engine.pendingInputVolume
+    readonly property bool pendingOutputMute: engine.pendingOutputMute
+    readonly property bool pendingInputMute: engine.pendingInputMute
+    readonly property bool pendingOutputSelection: engine.selectionTarget !== null
+    readonly property string failure: engine.failure
+
+    // Bounded verification visibility; no backend object is exposed.
+    readonly property int trackedObjectCount: engine.trackedObjects.length
+    readonly property bool confirmationBridgeReady: engine.bridgeReady
+    readonly property int queuedVolumeWriteCount: (engine.queuedOutputVolume === null ? 0 : 1) + (
+                                                      engine.queuedInputVolume === null ? 0 : 1)
+    readonly property int activeTimerCount: (volumeCoalesceTimer.running ? 1 : 0) + (
+                                                outputVolumeRequestTimer.running ? 1 : 0) + (
+                                                inputVolumeRequestTimer.running ? 1 : 0) + (
+                                                outputMuteRequestTimer.running ? 1 : 0) + (
+                                                inputMuteRequestTimer.running ? 1 : 0) + (
+                                                selectionRequestTimer.running ? 1 : 0) + (
+                                                outputLabelTimer.running ? 1 : 0) + (
+                                                inputLabelTimer.running ? 1 : 0) + (
+                                                failureTimer.running ? 1 : 0)
+                                            + engine.bridgeActiveTimerCount
+
+    // Transient consumers receive only opaque bounded identity and revisions.
+    // They resolve presentation through resolveConfirmedOutput/Input below.
+    signal confirmedOutputChanged(string sourceToken, int sourceGeneration, int revision)
+    signal confirmedInputChanged(string sourceToken, int sourceGeneration, int revision)
+    signal confirmedOutputInvalidated(string sourceToken, int sourceGeneration)
+    signal confirmedInputInvalidated(string sourceToken, int sourceGeneration)
+
+    function requestOutputVolume(value, finalValue) {
+        return engine.requestVolume("output", value, finalValue === true);
+    }
+
+    function requestInputVolume(value, finalValue) {
+        return engine.requestVolume("input", value, finalValue === true);
+    }
+
+    function requestOutputMute(muted) {
+        return engine.requestMute("output", muted);
+    }
+
+    function requestInputMute(muted) {
+        return engine.requestMute("input", muted);
+    }
+
+    function requestOutputSelection(endpointKey) {
+        return engine.requestSelection(endpointKey);
+    }
+
+    // Exact-latest resolution prevents a stale coordinator frame from reading
+    // newer content under an older backend revision.
+    function resolveConfirmedOutput(sourceToken, sourceGeneration, revision) {
+        return engine.resolveEndpoint("output", sourceToken, sourceGeneration, revision);
+    }
+
+    function resolveConfirmedInput(sourceToken, sourceGeneration, revision) {
+        return engine.resolveEndpoint("input", sourceToken, sourceGeneration, revision);
+    }
+
+    // Deterministic deadline/flush seams used by the focused harness. Runtime
+    // reaches the same functions through the timers below.
+    function processPendingChanges() {
+        engine.flushScheduled();
+    }
+
+    function processPendingVolumeWrites() {
+        engine.flushVolumeWrites();
+    }
+
+    function volumeDeadlineReached(role) {
+        engine.volumeDeadlineReached(role);
+    }
+
+    function muteDeadlineReached(role) {
+        engine.muteDeadlineReached(role);
+    }
+
+    function selectionDeadlineReached() {
+        engine.selectionDeadlineReached();
+    }
+
+    function refreshLabelDeadlineReached(role) {
+        engine.refreshLabelDeadlineReached(role);
+    }
+
+    function failureDeadlineReached() {
+        engine.failureDeadlineReached();
+    }
+
+    Component.onCompleted: {
+        engine.completed = true;
+        engine.synchronize();
+    }
+    Component.onDestruction: engine.cleanup()
+    onPipewireServiceChanged: {
+        if (engine.completed) {
+            engine.replaceService();
+        }
+    }
+    onConfirmationBridgeChanged: {
+        if (engine.completed) {
+            engine.replaceBridge();
+        }
+    }
+
+    PwObjectTracker {
+        objects: root.nativeTrackingEnabled ? engine.trackedObjects : []
+    }
+
+    PipeWireAudioBridge {
+        id: nativeBridge
+
+        helperPath: root.bridgePath
+        enabled: root.confirmationBridge === null && engine.serviceReady
+    }
+
+    Connections {
+        target: engine.currentBridge
+        ignoreUnknownSignals: true
+
+        function onReadyChanged() {
+            engine.handleBridgeReadyChanged();
+        }
+
+        function onStateConfirmed(role, nodeId, generation, requestId, kind, volume, muted) {
+            engine.handleBridgeState(role, nodeId, generation, requestId, kind, volume, muted);
+        }
+
+        function onRoleUnavailable(role, generation) {
+            engine.handleBridgeUnavailable(role, generation);
+        }
+
+        function onRequestFailed(role, generation, requestId, kind, reason) {
+            engine.handleBridgeRequestFailure(role, generation, requestId, kind);
+        }
+
+        function onFatalFailure() {
+            engine.handleBridgeFatal();
+        }
+    }
+
+    Timer {
+        id: volumeCoalesceTimer
+
+        interval: root.volumeCoalesceMs
+        onTriggered: engine.flushVolumeWrites()
+    }
+
+    Timer {
+        id: outputVolumeRequestTimer
+
+        interval: root.requestTimeoutMs
+        onTriggered: root.volumeDeadlineReached("output")
+    }
+
+    Timer {
+        id: inputVolumeRequestTimer
+
+        interval: root.requestTimeoutMs
+        onTriggered: root.volumeDeadlineReached("input")
+    }
+
+    Timer {
+        id: outputMuteRequestTimer
+
+        interval: root.requestTimeoutMs
+        onTriggered: root.muteDeadlineReached("output")
+    }
+
+    Timer {
+        id: inputMuteRequestTimer
+
+        interval: root.requestTimeoutMs
+        onTriggered: root.muteDeadlineReached("input")
+    }
+
+    Timer {
+        id: selectionRequestTimer
+
+        interval: root.requestTimeoutMs
+        onTriggered: root.selectionDeadlineReached()
+    }
+
+    Timer {
+        id: outputLabelTimer
+
+        interval: root.refreshLabelTimeoutMs
+        onTriggered: root.refreshLabelDeadlineReached("output")
+    }
+
+    Timer {
+        id: inputLabelTimer
+
+        interval: root.refreshLabelTimeoutMs
+        onTriggered: root.refreshLabelDeadlineReached("input")
+    }
+
+    Timer {
+        id: failureTimer
+
+        interval: root.failureTimeoutMs
+        onTriggered: root.failureDeadlineReached()
+    }
+
+    Connections {
+        target: engine.currentService
+        ignoreUnknownSignals: true
+
+        function onReadyChanged() {
+            engine.scheduleSynchronize();
+        }
+
+        function onDefaultAudioSinkChanged() {
+            engine.scheduleSynchronize();
+        }
+
+        function onDefaultAudioSourceChanged() {
+            engine.scheduleSynchronize();
+        }
+
+        function onPreferredDefaultAudioSinkChanged() {
+            engine.handlePreferredSinkChanged();
+        }
+    }
+
+    Connections {
+        target: engine.currentNodesModel
+        ignoreUnknownSignals: true
+
+        function onValuesChanged() {
+            engine.scheduleSynchronize();
+        }
+    }
+
+    Connections {
+        target: engine.outputNode
+        ignoreUnknownSignals: true
+
+        function onReadyChanged() {
+            engine.updateRole("output");
+        }
+
+        function onNameChanged() {
+            engine.updateRole("output");
+        }
+
+        function onDescriptionChanged() {
+            engine.updateRole("output");
+        }
+
+        function onNicknameChanged() {
+            engine.updateRole("output");
+        }
+
+        function onAudioChanged() {
+            engine.updateRole("output");
+        }
+
+        function onDestroyed() {
+            engine.scheduleSynchronize();
+        }
+    }
+
+    Connections {
+        target: engine.inputNode
+        ignoreUnknownSignals: true
+
+        function onReadyChanged() {
+            engine.updateRole("input");
+        }
+
+        function onNameChanged() {
+            engine.updateRole("input");
+        }
+
+        function onDescriptionChanged() {
+            engine.updateRole("input");
+        }
+
+        function onNicknameChanged() {
+            engine.updateRole("input");
+        }
+
+        function onAudioChanged() {
+            engine.updateRole("input");
+        }
+
+        function onDestroyed() {
+            engine.scheduleSynchronize();
+        }
+    }
+
+    Component {
+        id: candidateWatcher
+
+        Connections {
+            ignoreUnknownSignals: true
+
+            function onNameChanged() {
+                engine.scheduleSynchronize();
+            }
+
+            function onDescriptionChanged() {
+                engine.scheduleSynchronize();
+            }
+
+            function onNicknameChanged() {
+                engine.scheduleSynchronize();
+            }
+
+            function onIsStreamChanged() {
+                engine.scheduleSynchronize();
+            }
+
+            function onIsSinkChanged() {
+                engine.scheduleSynchronize();
+            }
+
+            function onAudioChanged() {
+                engine.scheduleSynchronize();
+            }
+        }
+    }
+
+    QtObject {
+        id: engine
+
+        property bool completed: false
+        property bool scheduled: false
+        property bool serviceReady: false
+        property string syncState: "unavailable"
+        property string failure: "unavailable"
+        property int generationCounter: 0
+
+        property var output: emptyEndpoint()
+        property var input: emptyEndpoint()
+        property var outputNode: null
+        property var inputNode: null
+        property var outputAudio: null
+        property var inputAudio: null
+        property var outputRecord: null
+        property var inputRecord: null
+        property var outputBridgeState: null
+        property var inputBridgeState: null
+        property bool outputPublishedInSession: false
+        property bool inputPublishedInSession: false
+
+        property string lastOutputLabel: ""
+        property string lastInputLabel: ""
+        property string lastOutputMatchName: ""
+        property string lastInputMatchName: ""
+
+        property var candidateRecords: []
+        property var publicCandidates: []
+        property var trackedObjects: []
+
+        property var queuedOutputVolume: null
+        property var queuedInputVolume: null
+        property bool pendingOutputVolume: false
+        property bool pendingInputVolume: false
+        property bool pendingOutputMute: false
+        property bool pendingInputMute: false
+        property int requestCounter: 0
+        property int pendingOutputVolumeRequestId: 0
+        property int pendingInputVolumeRequestId: 0
+        property int pendingOutputMuteRequestId: 0
+        property int pendingInputMuteRequestId: 0
+        property var selectionTarget: null
+
+        readonly property var currentService: root.pipewireService !== null ? root.pipewireService :
+                                                                              Pipewire
+        readonly property var currentNodesModel: safeRead(currentService, "nodes", null)
+        readonly property var currentBridge: root.confirmationBridge !== null
+                                             ? root.confirmationBridge : nativeBridge
+        readonly property bool bridgeReady: truthy(safeRead(currentBridge, "ready", false))
+        readonly property int bridgeActiveTimerCount: {
+            const count = safeRead(currentBridge, "activeTimerCount", 0);
+            return Number.isInteger(count) && count >= 0 ? count : 0;
+        }
+
+        function emptyEndpoint() {
+            return {
+                "available": false,
+                "endpointKey": "",
+                "sourceToken": "",
+                "generation": 0,
+                "revision": 0,
+                "label": "",
+                "volume": null,
+                "overamplified": false,
+                "muted": false
+            };
+        }
+
+        function safeRead(object, name, fallback) {
+            if (object === null || object === undefined) {
+                return fallback;
+            }
+
+            try {
+                const value = object[name];
+                return value === undefined ? fallback : value;
+            } catch (error) {
+                return fallback;
+            }
+        }
+
+        function truthy(value) {
+            return value === true;
+        }
+
+        function normalizeText(value, limit) {
+            if (typeof value !== "string") {
+                return "";
+            }
+
+            const cleaned = value.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ").replace(/\s+/g,
+                                                                                        " ").trim();
+            return cleaned.length > limit ? cleaned.slice(0, limit) : cleaned;
+        }
+
+        function nodeId(node) {
+            let value;
+            try {
+                value = root.nodeIdReader !== null ? root.nodeIdReader(node) : node.id;
+            } catch (error) {
+                return -1;
+            }
+
+            return typeof value === "number" && Number.isFinite(value) && value >= 0 && Math.floor(
+                        value) === value ? value : -1;
+        }
+
+        function nodeName(node) {
+            return normalizeText(safeRead(node, "name", ""), root.maximumNameCharacters);
+        }
+
+        function nodeLabel(node) {
+            const description = normalizeText(safeRead(node, "description", ""),
+                                              root.maximumLabelCharacters);
+            if (description !== "") {
+                return description;
+            }
+
+            const nickname = normalizeText(safeRead(node, "nickname", ""),
+                                           root.maximumLabelCharacters);
+            if (nickname !== "") {
+                return nickname;
+            }
+
+            return normalizeText(safeRead(node, "name", ""), root.maximumLabelCharacters);
+        }
+
+        function endpointKey(role, node) {
+            const identifier = nodeId(node);
+            if (identifier < 0) {
+                return "";
+            }
+
+            const name = nodeName(node);
+            return role + "|" + name.length + ":" + name + "|" + identifier;
+        }
+
+        function nextRecord(role, node) {
+            generationCounter += 1;
+            return {
+                "node": node,
+                "generation": generationCounter,
+                "sourceToken": "audio-" + role + "-" + generationCounter,
+                "endpointKey": ""
+            };
+        }
+
+        function disposeCandidateRecords() {
+            for (let index = 0; index < candidateRecords.length; ++index) {
+                const watcher = candidateRecords[index].watcher;
+                if (watcher !== null) {
+                    watcher.destroy();
+                }
+            }
+            candidateRecords = [];
+        }
+
+        function listValues(model) {
+            let values = safeRead(model, "values", null);
+            if (values === null || typeof values !== "object" || typeof values.length
+                    !== "number") {
+
+                values = [];
+            }
+            return values;
+        }
+
+        function isOutputCandidate(node) {
+            return node !== null && !truthy(safeRead(node, "isStream", false)) && truthy(safeRead(node, "isSink",
+                                                                                                  false))
+                    && safeRead(node, "audio", null) !== null && nodeId(node) >= 0;
+        }
+
+        function rebuildCandidates() {
+            disposeCandidateRecords();
+            if (!serviceReady) {
+                publicCandidates = [];
+                return;
+            }
+
+            const values = listValues(currentNodesModel);
+            const records = [];
+            for (let index = 0; index < values.length; ++index) {
+                const node = values[index];
+                if (!isOutputCandidate(node)) {
+                    continue;
+                }
+
+                records.push({
+                                 "node": node,
+                                 "endpointKey": endpointKey("output", node),
+                                 "label": nodeLabel(node),
+                                 "id": nodeId(node),
+                                 "watcher": candidateWatcher.createObject(root, {
+                                                                              "target": node
+                                                                          })
+                             });
+            }
+
+            const confirmedDefault = safeRead(currentService, "defaultAudioSink", null);
+            records.sort((left, right) => {
+                const leftDefault = left.node === confirmedDefault;
+                const rightDefault = right.node === confirmedDefault;
+                if (leftDefault !== rightDefault) {
+                    return leftDefault ? -1 : 1;
+                }
+
+                const leftLabel = left.label.toLowerCase();
+                const rightLabel = right.label.toLowerCase();
+                if (leftLabel < rightLabel) {
+                    return -1;
+                }
+                if (leftLabel > rightLabel) {
+                    return 1;
+                }
+                return left.id - right.id;
+            });
+            candidateRecords = records;
+
+            const normalized = [];
+            for (let recordIndex = 0; recordIndex < records.length; ++recordIndex) {
+                normalized.push({
+                                    "endpointKey": records[recordIndex].endpointKey,
+                                    "label": records[recordIndex].label,
+                                    "isDefault": records[recordIndex].node === confirmedDefault
+                                });
+            }
+            publicCandidates = normalized;
+            validateSelectionTarget();
+        }
+
+        function updateTrackedObjects() {
+            const objects = [];
+            if (serviceReady && outputNode !== null) {
+                objects.push(outputNode);
+            }
+            if (serviceReady && inputNode !== null && inputNode !== outputNode) {
+                objects.push(inputNode);
+            }
+            trackedObjects = objects;
+        }
+
+        function scheduleSynchronize() {
+            if (scheduled) {
+                return;
+            }
+            scheduled = true;
+            Qt.callLater(engine.synchronize);
+        }
+
+        function flushScheduled() {
+            if (scheduled) {
+                synchronize();
+            }
+        }
+
+        function synchronize() {
+            scheduled = false;
+            const ready = truthy(safeRead(currentService, "ready", false));
+            if (!ready) {
+                if (serviceReady || outputNode !== null || inputNode !== null
+                        || candidateRecords.length > 0) {
+                    hardReset(true);
+                }
+                serviceReady = false;
+                syncState = "unavailable";
+                failure = "unavailable";
+                failureTimer.stop();
+                return;
+            }
+
+            if (!serviceReady) {
+                serviceReady = true;
+                outputPublishedInSession = false;
+                inputPublishedInSession = false;
+                if (failure === "unavailable") {
+                    failure = "none";
+                }
+            }
+
+            const nextOutput = safeRead(currentService, "defaultAudioSink", null);
+            const nextInput = safeRead(currentService, "defaultAudioSource", null);
+            if (nextOutput !== outputNode) {
+                replaceRoleNode("output", nextOutput);
+            }
+            if (nextInput !== inputNode) {
+                replaceRoleNode("input", nextInput);
+            }
+
+            updateTrackedObjects();
+            rebuildCandidates();
+            updateRole("output");
+            updateRole("input");
+            evaluateSelectionDefault();
+            updateSyncState();
+        }
+
+        function replaceService() {
+            hardReset(true);
+            serviceReady = false;
+            syncState = "unavailable";
+            scheduleSynchronize();
+        }
+
+        function replaceRoleNode(role, node) {
+            const reconnectName = role === "output" ? lastOutputMatchName : lastInputMatchName;
+            untrackRole(role);
+            invalidateRole(role);
+            clearRoleRequests(role);
+            setRoleBridgeState(role, null);
+            if (role === "output") {
+                outputNode = node;
+                outputAudio = null;
+                outputRecord = node === null ? null : nextRecord(role, node);
+                if (node !== null && reconnectName !== "" && nodeName(node) !== reconnectName) {
+                    lastOutputLabel = "";
+                    lastOutputMatchName = "";
+                    outputLabelTimer.stop();
+                }
+            } else {
+                inputNode = node;
+                inputAudio = null;
+                inputRecord = node === null ? null : nextRecord(role, node);
+                if (node !== null && reconnectName !== "" && nodeName(node) !== reconnectName) {
+                    lastInputLabel = "";
+                    lastInputMatchName = "";
+                    inputLabelTimer.stop();
+                }
+            }
+            trackRole(role);
+        }
+
+        function roleNode(role) {
+            return role === "output" ? outputNode : inputNode;
+        }
+
+        function roleAudio(role) {
+            return role === "output" ? outputAudio : inputAudio;
+        }
+
+        function roleRecord(role) {
+            return role === "output" ? outputRecord : inputRecord;
+        }
+
+        function roleBridgeState(role) {
+            return role === "output" ? outputBridgeState : inputBridgeState;
+        }
+
+        function setRoleBridgeState(role, state) {
+            if (role === "output") {
+                outputBridgeState = state;
+            } else {
+                inputBridgeState = state;
+            }
+        }
+
+        function trackRole(role) {
+            const node = roleNode(role);
+            const record = roleRecord(role);
+            if (!bridgeReady || node === null || record === null) {
+                return false;
+            }
+            const identifier = nodeId(node);
+            if (identifier < 0) {
+                return false;
+            }
+            try {
+                return currentBridge.track(role, identifier, record.generation) === true;
+            } catch (error) {
+                return false;
+            }
+        }
+
+        function untrackRole(role) {
+            const record = roleRecord(role);
+            if (!bridgeReady || record === null) {
+                return;
+            }
+            try {
+                currentBridge.untrack(role, record.generation);
+            } catch (error) {}
+        }
+
+        function replaceBridge() {
+            setRoleBridgeState("output", null);
+            setRoleBridgeState("input", null);
+            invalidateRole("output");
+            invalidateRole("input");
+            clearRoleRequests("output");
+            clearRoleRequests("input");
+            handleBridgeReadyChanged();
+        }
+
+        function handleBridgeReadyChanged() {
+            if (!bridgeReady) {
+                setRoleBridgeState("output", null);
+                setRoleBridgeState("input", null);
+                invalidateRole("output");
+                invalidateRole("input");
+                clearRoleRequests("output");
+                clearRoleRequests("input");
+                if (serviceReady) {
+                    setFailure("bridge-unavailable");
+                }
+                updateSyncState();
+                return;
+            }
+            const outputTracked = outputNode === null || trackRole("output");
+            const inputTracked = inputNode === null || trackRole("input");
+            if (!outputTracked || !inputTracked) {
+                setFailure("bridge-unavailable");
+            }
+            updateSyncState();
+        }
+
+        function handleBridgeState(role, identifier, generation, requestId, kind, volume, muted) {
+            const node = roleNode(role);
+            const record = roleRecord(role);
+            if (node === null || record === null || record.generation !== generation || nodeId(node)
+                    !== identifier) {
+                return;
+            }
+            setRoleBridgeState(role, {
+                                   "nodeId": identifier,
+                                   "generation": generation,
+                                   "volume": volume,
+                                   "muted": muted
+                               });
+            updateRole(role);
+
+            if (kind === "volume" && requestId === pendingRequestId(role, kind)) {
+                clearVolumePending(role);
+                failure = "none";
+                failureTimer.stop();
+            } else if (kind === "mute" && requestId === pendingRequestId(role, kind)) {
+                clearMutePending(role);
+                failure = "none";
+                failureTimer.stop();
+            }
+        }
+
+        function handleBridgeUnavailable(role, generation) {
+            const record = roleRecord(role);
+            if (record === null || record.generation !== generation) {
+                return;
+            }
+            setRoleBridgeState(role, null);
+            invalidateRole(role);
+            clearRoleRequests(role);
+            setFailure("bridge-unavailable");
+            updateSyncState();
+        }
+
+        function handleBridgeRequestFailure(role, generation, requestId, kind) {
+            const record = roleRecord(role);
+            if (record === null || record.generation !== generation || requestId
+                    !== pendingRequestId(role, kind)) {
+                return;
+            }
+            if (kind === "volume") {
+                clearVolumePending(role);
+            } else if (kind === "mute") {
+                clearMutePending(role);
+            }
+            setFailure("backend");
+        }
+
+        function handleBridgeFatal() {
+            setRoleBridgeState("output", null);
+            setRoleBridgeState("input", null);
+            invalidateRole("output");
+            invalidateRole("input");
+            clearRoleRequests("output");
+            clearRoleRequests("input");
+            setFailure(serviceReady ? "bridge-unavailable" : "unavailable");
+            updateSyncState();
+        }
+
+        function pendingRequestId(role, kind) {
+            if (kind === "volume") {
+                return role === "output" ? pendingOutputVolumeRequestId :
+                                           pendingInputVolumeRequestId;
+            }
+            return role === "output" ? pendingOutputMuteRequestId : pendingInputMuteRequestId;
+        }
+
+        function roleState(role) {
+            return role === "output" ? output : input;
+        }
+
+        function setRoleAudio(role, audio) {
+            if (role === "output") {
+                outputAudio = audio;
+            } else {
+                inputAudio = audio;
+            }
+        }
+
+        function setRoleRecord(role, record) {
+            if (role === "output") {
+                outputRecord = record;
+            } else {
+                inputRecord = record;
+            }
+        }
+
+        function setRoleState(role, state) {
+            if (role === "output") {
+                output = state;
+            } else {
+                input = state;
+            }
+        }
+
+        function rolePublished(role) {
+            return role === "output" ? outputPublishedInSession : inputPublishedInSession;
+        }
+
+        function markRolePublished(role) {
+            if (role === "output") {
+                outputPublishedInSession = true;
+            } else {
+                inputPublishedInSession = true;
+            }
+        }
+
+        function endpointEquals(left, right) {
+            return left.available === right.available && left.endpointKey === right.endpointKey
+                    && left.sourceToken === right.sourceToken && left.generation
+                    === right.generation && left.label === right.label && left.volume
+                    === right.volume && left.overamplified === right.overamplified && left.muted
+                    === right.muted;
+        }
+
+        function isValidTrackedDefault(role, node) {
+            return !truthy(safeRead(node, "isStream", false)) && (role === "output" ? truthy(safeRead(node,
+                                                                                                      "isSink", false)) :
+                                                                                      !truthy(safeRead(
+                                                                                                  node, "isSink",
+                                                                                                  true)));
+        }
+
+        function updateRole(role) {
+            if (!serviceReady) {
+                invalidateRole(role);
+                return;
+            }
+
+            const node = roleNode(role);
+            if (node === null || !truthy(safeRead(node, "ready", false))) {
+                setRoleAudio(role, null);
+                invalidateRole(role);
+                updateSyncState();
+                return;
+            }
+
+            const audio = safeRead(node, "audio", null);
+            setRoleAudio(role, audio);
+            const key = endpointKey(role, node);
+            if (!isValidTrackedDefault(role, node) || audio === null || key === "") {
+                invalidateRole(role);
+                setFailure("invalid-default");
+                updateSyncState();
+                return;
+            }
+
+            let record = roleRecord(role);
+            if (record === null || record.node !== node || (record.endpointKey !== "" && record.endpointKey
+                                                            !== key)) {
+                untrackRole(role);
+                invalidateRole(role);
+                setRoleBridgeState(role, null);
+                record = nextRecord(role, node);
+                setRoleRecord(role, record);
+                trackRole(role);
+            }
+            record.endpointKey = key;
+
+            const confirmed = roleBridgeState(role);
+            if (confirmed === null || confirmed.nodeId !== nodeId(node) || confirmed.generation
+                    !== record.generation) {
+                invalidateRole(role);
+                updateSyncState();
+                return;
+            }
+            const volume = confirmed.volume;
+            const muted = confirmed.muted;
+            if (typeof volume !== "number" || !Number.isFinite(volume) || volume < 0
+                    || typeof muted !== "boolean") {
+                invalidateRole(role);
+                setFailure("invalid-default");
+                updateSyncState();
+                return;
+            }
+
+            const oldState = roleState(role);
+            const nextState = {
+                "available": true,
+                "endpointKey": key,
+                "sourceToken": record.sourceToken,
+                "generation": record.generation,
+                "revision": oldState.available && oldState.generation === record.generation
+                            ? oldState.revision : 0,
+                "label": nodeLabel(node),
+                "volume": Math.min(volume, 1),
+                "overamplified": volume > 1,
+                "muted": muted
+            };
+            if (endpointEquals(oldState, nextState)) {
+                updateSyncState();
+                return;
+            }
+
+            nextState.revision += 1;
+            setRoleState(role, nextState);
+            rememberConfirmedLabel(role, nextState.label, nodeName(node));
+            if (rolePublished(role)) {
+                emitConfirmed(role, nextState);
+            } else {
+                markRolePublished(role);
+            }
+
+            if (failure === "unavailable" || failure === "bridge-unavailable" || failure
+                    === "invalid-default" || failure === "stale" || failure === "backend") {
+                failure = "none";
+                failureTimer.stop();
+            }
+            updateSyncState();
+        }
+
+        function emitConfirmed(role, state) {
+            if (role === "output") {
+                root.confirmedOutputChanged(state.sourceToken, state.generation, state.revision);
+            } else {
+                root.confirmedInputChanged(state.sourceToken, state.generation, state.revision);
+            }
+        }
+
+        function invalidateRole(role) {
+            const state = roleState(role);
+            if (!state.available) {
+                return;
+            }
+
+            setRoleState(role, emptyEndpoint());
+            rememberConfirmedLabel(role, state.label, role === "output" ? lastOutputMatchName :
+                                                                          lastInputMatchName);
+            if (role === "output") {
+                root.confirmedOutputInvalidated(state.sourceToken, state.generation);
+            } else {
+                root.confirmedInputInvalidated(state.sourceToken, state.generation);
+            }
+        }
+
+        function rememberConfirmedLabel(role, label, matchName) {
+            if (role === "output") {
+                lastOutputLabel = label;
+                lastOutputMatchName = matchName;
+                if (output.available) {
+                    outputLabelTimer.stop();
+                } else {
+                    outputLabelTimer.restart();
+                }
+            } else {
+                lastInputLabel = label;
+                lastInputMatchName = matchName;
+                if (input.available) {
+                    inputLabelTimer.stop();
+                } else {
+                    inputLabelTimer.restart();
+                }
+            }
+        }
+
+        function updateSyncState() {
+            if (!serviceReady) {
+                syncState = "unavailable";
+                return;
+            }
+
+            const outputRecordValue = outputRecord;
+            const inputRecordValue = inputRecord;
+            const outputTracking = outputNode !== null && (!truthy(safeRead(outputNode, "ready",
+                                                                            false))
+                                                           || outputRecordValue === null
+                                                           || outputBridgeState === null
+                                                           || outputBridgeState.generation
+                                                           !== outputRecordValue.generation);
+            const inputTracking = inputNode !== null && (!truthy(safeRead(inputNode, "ready",
+                                                                          false))
+                                                         || inputRecordValue === null
+                                                         || inputBridgeState === null
+                                                         || inputBridgeState.generation
+                                                         !== inputRecordValue.generation);
+            syncState = !bridgeReady || outputTracking || inputTracking ? "tracking" : "ready";
+        }
+
+        function endpointForResolution(state, sourceToken, sourceGeneration, revision) {
+            if (!state.available || state.sourceToken !== sourceToken || state.generation
+                    !== sourceGeneration || state.revision !== revision) {
+                return null;
+            }
+
+            return {
+                "endpointKey": state.endpointKey,
+                "label": state.label,
+                "volume": state.volume,
+                "overamplified": state.overamplified,
+                "muted": state.muted
+            };
+        }
+
+        function resolveEndpoint(role, sourceToken, sourceGeneration, revision) {
+            return endpointForResolution(roleState(role), sourceToken, sourceGeneration, revision);
+        }
+
+        function validVolume(value) {
+            return typeof value === "number" && Number.isFinite(value);
+        }
+
+        function requestVolume(role, value, finalValue) {
+            const state = roleState(role);
+            const node = roleNode(role);
+            if (!state.available || node === null || !bridgeReady || !validVolume(value)) {
+                setFailure(!bridgeReady && serviceReady ? "bridge-unavailable" : state.available
+                                                          ? "invalid-request" : "unavailable");
+                return false;
+            }
+
+            const boundedValue = Math.min(Math.max(value, 0), 1);
+            if (!state.overamplified && Math.abs(state.volume - boundedValue) < 0.000001) {
+                clearVolumePending(role);
+                return true;
+            }
+
+            const write = {
+                "node": node,
+                "generation": state.generation,
+                "value": boundedValue,
+                "final": finalValue
+            };
+            if (role === "output") {
+                queuedOutputVolume = write;
+                pendingOutputVolume = true;
+            } else {
+                queuedInputVolume = write;
+                pendingInputVolume = true;
+            }
+
+            if (finalValue) {
+                takeAndDispatchVolume(role);
+                armVolumeCoalescer();
+            } else if (!volumeCoalesceTimer.running) {
+                volumeCoalesceTimer.start();
+            }
+            return true;
+        }
+
+        function armVolumeCoalescer() {
+            if (queuedOutputVolume !== null || queuedInputVolume !== null) {
+                volumeCoalesceTimer.restart();
+            } else {
+                volumeCoalesceTimer.stop();
+            }
+        }
+
+        function takeAndDispatchVolume(role) {
+            const write = role === "output" ? queuedOutputVolume : queuedInputVolume;
+            if (role === "output") {
+                queuedOutputVolume = null;
+            } else {
+                queuedInputVolume = null;
+            }
+            if (write !== null) {
+                dispatchVolume(role, write);
+            }
+        }
+
+        function flushVolumeWrites() {
+            volumeCoalesceTimer.stop();
+            takeAndDispatchVolume("output");
+            takeAndDispatchVolume("input");
+            armVolumeCoalescer();
+        }
+
+        function dispatchVolume(role, write) {
+            const state = roleState(role);
+            if (!state.available || roleNode(role) !== write.node || state.generation
+                    !== write.generation || !bridgeReady) {
+                clearVolumePending(role);
+                setFailure("stale");
+                return;
+            }
+
+            const requestId = nextRequestId();
+            if (role === "output") {
+                pendingOutputVolumeRequestId = requestId;
+            } else {
+                pendingInputVolumeRequestId = requestId;
+            }
+            restartVolumeTimer(role);
+            let accepted = false;
+            try {
+                accepted = currentBridge.setVolume(role, nodeId(write.node), write.generation,
+                                                   requestId, write.value, write.final) === true;
+            } catch (error) {
+                accepted = false;
+            }
+            if (!accepted) {
+                clearVolumePending(role);
+                setFailure("bridge-unavailable");
+            }
+        }
+
+        function restartVolumeTimer(role) {
+            if (role === "output") {
+                outputVolumeRequestTimer.restart();
+            } else {
+                inputVolumeRequestTimer.restart();
+            }
+        }
+
+        function nextRequestId() {
+            requestCounter = requestCounter >= 2147483647 ? 1 : requestCounter + 1;
+            return requestCounter;
+        }
+
+        function clearVolumePending(role) {
+            if (role === "output") {
+                pendingOutputVolume = false;
+                pendingOutputVolumeRequestId = 0;
+                queuedOutputVolume = null;
+                outputVolumeRequestTimer.stop();
+            } else {
+                pendingInputVolume = false;
+                pendingInputVolumeRequestId = 0;
+                queuedInputVolume = null;
+                inputVolumeRequestTimer.stop();
+            }
+            armVolumeCoalescer();
+        }
+
+        function requestMute(role, muted) {
+            const state = roleState(role);
+            const node = roleNode(role);
+            if (!state.available || node === null || !bridgeReady || typeof muted !== "boolean") {
+                setFailure(!bridgeReady && serviceReady ? "bridge-unavailable" : state.available
+                                                          ? "invalid-request" : "unavailable");
+                return false;
+            }
+
+            if (state.muted === muted) {
+                clearMutePending(role);
+                return true;
+            }
+
+            const requestId = nextRequestId();
+            if (role === "output") {
+                pendingOutputMute = true;
+                pendingOutputMuteRequestId = requestId;
+                outputMuteRequestTimer.restart();
+            } else {
+                pendingInputMute = true;
+                pendingInputMuteRequestId = requestId;
+                inputMuteRequestTimer.restart();
+            }
+
+            let accepted = false;
+            try {
+                accepted = currentBridge.setMute(role, nodeId(node), state.generation, requestId,
+                                                 muted) === true;
+            } catch (error) {
+                accepted = false;
+            }
+            if (!accepted) {
+                clearMutePending(role);
+                setFailure("bridge-unavailable");
+                return false;
+            }
+            return true;
+        }
+
+        function clearMutePending(role) {
+            if (role === "output") {
+                pendingOutputMute = false;
+                pendingOutputMuteRequestId = 0;
+                outputMuteRequestTimer.stop();
+            } else {
+                pendingInputMute = false;
+                pendingInputMuteRequestId = 0;
+                inputMuteRequestTimer.stop();
+            }
+        }
+
+        function candidateForKey(key) {
+            for (let index = 0; index < candidateRecords.length; ++index) {
+                if (candidateRecords[index].endpointKey === key) {
+                    return candidateRecords[index];
+                }
+            }
+            return null;
+        }
+
+        function requestSelection(key) {
+            if (!serviceReady || typeof key !== "string" || key.length === 0) {
+                setFailure(serviceReady ? "invalid-request" : "unavailable");
+                return false;
+            }
+
+            const candidate = candidateForKey(key);
+            if (candidate === null) {
+                setFailure("removed");
+                return false;
+            }
+            if (candidate.node === outputNode && output.available) {
+                clearSelection();
+                return true;
+            }
+
+            selectionTarget = {
+                "node": candidate.node,
+                "endpointKey": candidate.endpointKey,
+                "matchName": nodeName(candidate.node),
+                "startedDefault": safeRead(currentService, "defaultAudioSink", null)
+            };
+            selectionRequestTimer.restart();
+            try {
+                if (root.preferredSinkWriter !== null) {
+                    root.preferredSinkWriter(currentService, candidate.node);
+                } else {
+                    currentService.preferredDefaultAudioSink = candidate.node;
+                }
+            } catch (error) {
+                failSelection("stale");
+                return false;
+            }
+            return true;
+        }
+
+        function validateSelectionTarget() {
+            if (selectionTarget === null) {
+                return;
+            }
+
+            let found = false;
+            for (let index = 0; index < candidateRecords.length; ++index) {
+                if (candidateRecords[index].node === selectionTarget.node) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                failSelection("removed");
+            }
+        }
+
+        function evaluateSelectionDefault() {
+            if (selectionTarget === null) {
+                return;
+            }
+
+            const confirmed = safeRead(currentService, "defaultAudioSink", null);
+            if (confirmed === selectionTarget.node) {
+                clearSelection();
+                failure = "none";
+                failureTimer.stop();
+            } else if (confirmed !== null && confirmed !== selectionTarget.startedDefault) {
+                failSelection("diverged");
+            }
+        }
+
+        function handlePreferredSinkChanged() {
+            if (selectionTarget === null) {
+                return;
+            }
+
+            const preferred = safeRead(currentService, "preferredDefaultAudioSink", null);
+            if (preferred !== null && preferred !== selectionTarget.node) {
+                failSelection("rejected");
+            }
+        }
+
+        function clearSelection() {
+            selectionTarget = null;
+            selectionRequestTimer.stop();
+        }
+
+        function failSelection(kind) {
+            clearSelection();
+            setFailure(kind);
+        }
+
+        function clearRoleRequests(role) {
+            clearVolumePending(role);
+            clearMutePending(role);
+            if (role === "output" && selectionTarget !== null && selectionTarget.node
+                    === outputNode) {
+                failSelection("removed");
+            }
+        }
+
+        function volumeDeadlineReached(role) {
+            const pending = role === "output" ? pendingOutputVolume : pendingInputVolume;
+            clearVolumePending(role);
+            if (pending) {
+                setFailure("timeout");
+            }
+        }
+
+        function muteDeadlineReached(role) {
+            const pending = role === "output" ? pendingOutputMute : pendingInputMute;
+            clearMutePending(role);
+            if (pending) {
+                setFailure("timeout");
+            }
+        }
+
+        function selectionDeadlineReached() {
+            if (selectionTarget !== null) {
+                failSelection("timeout");
+            }
+        }
+
+        function refreshLabelDeadlineReached(role) {
+            if (role === "output" && !output.available) {
+                lastOutputLabel = "";
+                lastOutputMatchName = "";
+                outputLabelTimer.stop();
+            } else if (role === "input" && !input.available) {
+                lastInputLabel = "";
+                lastInputMatchName = "";
+                inputLabelTimer.stop();
+            }
+        }
+
+        function setFailure(kind) {
+            failure = kind;
+            if (kind === "unavailable" || kind === "none") {
+                failureTimer.stop();
+            } else {
+                failureTimer.restart();
+            }
+        }
+
+        function failureDeadlineReached() {
+            failure = !serviceReady ? "unavailable" : bridgeReady ? "none" : "bridge-unavailable";
+            failureTimer.stop();
+        }
+
+        function hardReset(preserveLabels) {
+            untrackRole("output");
+            untrackRole("input");
+            invalidateRole("output");
+            invalidateRole("input");
+            clearVolumePending("output");
+            clearVolumePending("input");
+            clearMutePending("output");
+            clearMutePending("input");
+            clearSelection();
+            disposeCandidateRecords();
+            publicCandidates = [];
+            outputNode = null;
+            inputNode = null;
+            outputAudio = null;
+            inputAudio = null;
+            outputRecord = null;
+            inputRecord = null;
+            outputBridgeState = null;
+            inputBridgeState = null;
+            trackedObjects = [];
+            output = emptyEndpoint();
+            input = emptyEndpoint();
+            outputPublishedInSession = false;
+            inputPublishedInSession = false;
+            if (!preserveLabels) {
+                lastOutputLabel = "";
+                lastInputLabel = "";
+                lastOutputMatchName = "";
+                lastInputMatchName = "";
+                outputLabelTimer.stop();
+                inputLabelTimer.stop();
+            }
+        }
+
+        function cleanup() {
+            hardReset(false);
+            serviceReady = false;
+            syncState = "unavailable";
+            failureTimer.stop();
+        }
+    }
+}

--- a/qml/PipeWireAudioBridge.qml
+++ b/qml/PipeWireAudioBridge.qml
@@ -1,0 +1,244 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+// Bounded JSON-lines wrapper for the Nagi-owned libpipewire confirmation
+// bridge. Raw PipeWire parameters never cross this boundary.
+Scope {
+    id: root
+
+    required property string helperPath
+    property bool enabled: false
+
+    readonly property bool ready: state.ready
+    readonly property int activeTimerCount: restartTimer.running ? 1 : 0
+    readonly property int maximumLineLength: 4096
+    readonly property int maximumDiagnostics: 4
+
+    signal stateConfirmed(string role, int nodeId, int generation, int requestId, string kind,
+                          real volume, bool muted)
+    signal roleUnavailable(string role, int generation)
+    signal requestFailed(string role, int generation, int requestId, string kind, string reason)
+    signal fatalFailure
+
+    function track(role, nodeId, generation) {
+        return send({
+                        "op": "track",
+                        "role": role,
+                        "nodeId": nodeId,
+                        "generation": generation
+                    });
+    }
+
+    function untrack(role, generation) {
+        return send({
+                        "op": "untrack",
+                        "role": role,
+                        "generation": generation
+                    });
+    }
+
+    function setVolume(role, nodeId, generation, requestId, value, finalValue) {
+        return send({
+                        "op": "setVolume",
+                        "role": role,
+                        "nodeId": nodeId,
+                        "generation": generation,
+                        "requestId": requestId,
+                        "value": value,
+                        "final": finalValue
+                    });
+    }
+
+    function setMute(role, nodeId, generation, requestId, muted) {
+        return send({
+                        "op": "setMute",
+                        "role": role,
+                        "nodeId": nodeId,
+                        "generation": generation,
+                        "requestId": requestId,
+                        "muted": muted
+                    });
+    }
+
+    function send(command) {
+        if (!state.ready || !helper.running) {
+            return false;
+        }
+        const line = JSON.stringify(command);
+        if (line.length === 0 || line.length > root.maximumLineLength) {
+            return false;
+        }
+        helper.write(line + "\n");
+        return true;
+    }
+
+    function acceptLine(line) {
+        if (typeof line !== "string" || line.length === 0 || line.length > root.maximumLineLength) {
+            warnBounded("invalid bridge line length");
+            return;
+        }
+
+        let message;
+        try {
+            message = JSON.parse(line);
+        } catch (error) {
+            warnBounded("malformed bridge line");
+            return;
+        }
+        if (message === null || typeof message !== "object" || Array.isArray(message)
+                || typeof message.type !== "string") {
+            warnBounded("invalid bridge message");
+            return;
+        }
+
+        if (message.type === "ready") {
+            state.ready = true;
+            state.restartAttempts = 0;
+            return;
+        }
+        if (message.type === "fatal") {
+            failBridge();
+            return;
+        }
+        if (message.type === "unavailable") {
+            if (validRole(message.role) && validPositiveInteger(message.generation)) {
+                root.roleUnavailable(message.role, message.generation);
+            } else {
+                warnBounded("invalid unavailable message");
+            }
+            return;
+        }
+        if (message.type === "failure") {
+            if (validRole(message.role) && validPositiveInteger(message.generation)
+                    && validPositiveInteger(message.requestId) && validKind(message.kind)) {
+                root.requestFailed(message.role, message.generation, message.requestId, message.kind,
+                                   "backend");
+            } else {
+                warnBounded("invalid failure message");
+            }
+            return;
+        }
+        if (message.type !== "state" || !validRole(message.role) || !validNodeId(message.nodeId) ||
+                !validPositiveInteger(message.generation) || !validNonNegativeInteger(
+                    message.requestId) || !validKind(message.kind) || typeof message.volume
+                !== "number" || !Number.isFinite(message.volume) || message.volume < 0
+                || typeof message.muted !== "boolean") {
+            warnBounded("invalid state message");
+            return;
+        }
+        root.stateConfirmed(message.role, message.nodeId, message.generation, message.requestId,
+                            message.kind, message.volume, message.muted);
+    }
+
+    function validRole(role) {
+        return role === "output" || role === "input";
+    }
+
+    function validKind(kind) {
+        return kind === "external" || kind === "volume" || kind === "mute";
+    }
+
+    function validNodeId(value) {
+        return Number.isInteger(value) && value >= 0 && value <= 2147483647;
+    }
+
+    function validPositiveInteger(value) {
+        return Number.isInteger(value) && value > 0 && value <= 2147483647;
+    }
+
+    function validNonNegativeInteger(value) {
+        return Number.isInteger(value) && value >= 0 && value <= 2147483647;
+    }
+
+    function warnBounded(message) {
+        if (state.diagnosticCount >= root.maximumDiagnostics) {
+            return;
+        }
+        state.diagnosticCount += 1;
+        console.warn("PipeWire audio bridge: " + message);
+    }
+
+    function forwardDiagnostic(message) {
+        if (state.diagnosticCount >= root.maximumDiagnostics) {
+            return;
+        }
+        state.diagnosticCount += 1;
+        const bounded = typeof message === "string" ? message.slice(0, 256) :
+                                                      "invalid helper diagnostic";
+        console.warn("PipeWire audio helper: " + bounded);
+    }
+
+    function failBridge() {
+        state.ready = false;
+        root.fatalFailure();
+    }
+
+    onEnabledChanged: {
+        if (enabled) {
+            state.restartAttempts = 0;
+            state.restartAllowed = true;
+        } else {
+            restartTimer.stop();
+            state.restartAllowed = false;
+            state.ready = false;
+        }
+    }
+
+    QtObject {
+        id: state
+
+        property bool ready: false
+        property bool restartAllowed: true
+        property int restartAttempts: 0
+        property int diagnosticCount: 0
+        property bool destroying: false
+    }
+
+    Timer {
+        id: restartTimer
+
+        interval: 250 * Math.pow(2, Math.max(0, state.restartAttempts - 1))
+        onTriggered: state.restartAllowed = true
+    }
+
+    Process {
+        id: helper
+
+        command: [root.helperPath]
+        stdinEnabled: true
+        running: root.enabled && root.helperPath !== "" && state.restartAllowed
+
+        stdout: SplitParser {
+            onRead: data => root.acceptLine(data)
+        }
+
+        stderr: SplitParser {
+            onRead: data => root.forwardDiagnostic(data)
+        }
+
+        onStarted: state.ready = false
+        onExited: function (exitCode, exitStatus) {
+            root.failBridge();
+            if (!state.destroying && root.enabled && state.restartAttempts < 3) {
+                state.restartAttempts += 1;
+                state.restartAllowed = false;
+                restartTimer.restart();
+            } else {
+                state.restartAllowed = false;
+            }
+        }
+    }
+
+    Component.onDestruction: {
+        state.destroying = true;
+        restartTimer.stop();
+        if (helper.running && state.ready) {
+            helper.write("{\"op\":\"shutdown\"}\n");
+        }
+        helper.running = false;
+        state.ready = false;
+    }
+}

--- a/shell.qml
+++ b/shell.qml
@@ -23,6 +23,11 @@ ShellRoot {
         id: media
     }
 
+    AudioAdapter {
+        id: audio
+        bridgePath: Quickshell.shellPath("build/nagi-pipewire-audio")
+    }
+
     ReducedMotion {
         id: motion
     }

--- a/src/pipewire-audio/main.cpp
+++ b/src/pipewire-audio/main.cpp
@@ -1,0 +1,812 @@
+#include "protocol.h"
+#include "volume.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <QCoreApplication>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMetaObject>
+#include <QSocketNotifier>
+
+#include <pipewire/pipewire.h>
+#include <spa/param/props.h>
+#include <spa/pod/builder.h>
+#include <spa/pod/iter.h>
+#include <spa/utils/result.h>
+#include <unistd.h>
+
+namespace {
+
+using nagi::audio::Command;
+using nagi::audio::Operation;
+using nagi::audio::Role;
+
+constexpr std::uint32_t InvalidNode = SPA_ID_INVALID;
+constexpr int MaximumDiagnostics = 8;
+
+struct Request {
+    Operation operation = Operation::Shutdown;
+    Role role = Role::Output;
+    std::uint32_t nodeId = 0;
+    std::uint32_t generation = 0;
+    std::uint32_t requestId = 0;
+    double volume = 0.0;
+    bool muted = false;
+    bool final = false;
+};
+
+class PipeWireBridge;
+
+struct NodeBinding {
+    PipeWireBridge *owner = nullptr;
+    std::uint32_t id = InvalidNode;
+    pw_node *node = nullptr;
+    spa_hook listener{};
+    bool subscribed = false;
+    bool hasVolumes = false;
+    bool hasMute = false;
+    std::vector<float> visualVolumes;
+    bool muted = false;
+};
+
+struct RoleState {
+    std::uint32_t nodeId = InvalidNode;
+    std::uint32_t generation = 0;
+    NodeBinding *binding = nullptr;
+    bool volumeInFlight = false;
+    bool muteInFlight = false;
+    std::optional<Request> queuedVolume;
+    std::optional<Request> queuedMute;
+};
+
+class PipeWireBridge final : public QObject {
+public:
+    explicit PipeWireBridge(QObject *parent = nullptr)
+        : QObject(parent)
+    {
+        pw_init(nullptr, nullptr);
+        threadLoop = pw_thread_loop_new("nagi-pipewire-audio", nullptr);
+        if (threadLoop == nullptr) {
+            throw std::runtime_error("could not create PipeWire thread loop");
+        }
+
+        context = pw_context_new(pw_thread_loop_get_loop(threadLoop), nullptr, 0);
+        if (context == nullptr) {
+            throw std::runtime_error("could not create PipeWire context");
+        }
+        core = pw_context_connect(context, nullptr, 0);
+        if (core == nullptr) {
+            throw std::runtime_error("could not connect to PipeWire");
+        }
+
+        static const pw_core_events coreEvents = [] {
+            pw_core_events events{};
+            events.version = PW_VERSION_CORE_EVENTS;
+            events.done = &PipeWireBridge::onCoreDone;
+            events.error = &PipeWireBridge::onCoreError;
+            return events;
+        }();
+        pw_core_add_listener(core, &coreListener, &coreEvents, this);
+
+        registry = pw_core_get_registry(core, PW_VERSION_REGISTRY, 0);
+        if (registry == nullptr) {
+            throw std::runtime_error("could not acquire PipeWire registry");
+        }
+        static const pw_registry_events registryEvents = {
+            .version = PW_VERSION_REGISTRY_EVENTS,
+            .global = &PipeWireBridge::onRegistryGlobal,
+            .global_remove = &PipeWireBridge::onRegistryGlobalRemove,
+        };
+        pw_registry_add_listener(registry, &registryListener, &registryEvents, this);
+        initialSyncSequence = pw_core_sync(core, PW_ID_CORE, 0);
+        if (initialSyncSequence < 0) {
+            throw std::runtime_error("could not synchronize PipeWire registry");
+        }
+
+        if (pw_thread_loop_start(threadLoop) < 0) {
+            throw std::runtime_error("could not start PipeWire thread loop");
+        }
+        loopStarted = true;
+
+        stdinNotifier = new QSocketNotifier(STDIN_FILENO, QSocketNotifier::Read, this);
+        connect(stdinNotifier, &QSocketNotifier::activated, this, [this] { readCommands(); });
+    }
+
+    ~PipeWireBridge() override
+    {
+        if (threadLoop != nullptr && loopStarted) {
+            pw_thread_loop_lock(threadLoop);
+        }
+        for (const auto &entry : bindings) {
+            spa_hook_remove(&entry.second->listener);
+        }
+        bindings.clear();
+        if (registry != nullptr) {
+            spa_hook_remove(&registryListener);
+            pw_proxy_destroy(reinterpret_cast<pw_proxy *>(registry));
+            registry = nullptr;
+        }
+        if (core != nullptr) {
+            spa_hook_remove(&coreListener);
+            pw_core_disconnect(core);
+            core = nullptr;
+        }
+        if (threadLoop != nullptr && loopStarted) {
+            pw_thread_loop_unlock(threadLoop);
+            pw_thread_loop_stop(threadLoop);
+            loopStarted = false;
+        }
+        if (context != nullptr) {
+            pw_context_destroy(context);
+            context = nullptr;
+        }
+        if (threadLoop != nullptr) {
+            pw_thread_loop_destroy(threadLoop);
+            threadLoop = nullptr;
+        }
+        pw_deinit();
+    }
+
+private:
+    static int roleIndex(Role role) { return role == Role::Output ? 0 : 1; }
+
+    RoleState &roleState(Role role) { return roles[roleIndex(role)]; }
+
+    const RoleState &roleState(Role role) const { return roles[roleIndex(role)]; }
+
+    void publish(const QJsonObject &message)
+    {
+        const QByteArray line = QJsonDocument(message).toJson(QJsonDocument::Compact);
+        std::fwrite(line.constData(), 1, static_cast<std::size_t>(line.size()), stdout);
+        std::fputc('\n', stdout);
+        std::fflush(stdout);
+    }
+
+    void post(const QJsonObject &message)
+    {
+        QMetaObject::invokeMethod(
+            this,
+            [this, message] { publish(message); },
+            Qt::QueuedConnection);
+    }
+
+    void diagnose(const char *message)
+    {
+        if (diagnosticCount >= MaximumDiagnostics) {
+            return;
+        }
+        ++diagnosticCount;
+        std::fprintf(stderr, "nagi-shell PipeWire bridge: %.256s\n", message);
+        std::fflush(stderr);
+    }
+
+    void postFailure(const Request &request, const QString &reason)
+    {
+        post(QJsonObject{
+            {QStringLiteral("type"), QStringLiteral("failure")},
+            {QStringLiteral("role"), nagi::audio::roleName(request.role)},
+            {QStringLiteral("nodeId"), static_cast<qint64>(request.nodeId)},
+            {QStringLiteral("generation"), static_cast<qint64>(request.generation)},
+            {QStringLiteral("requestId"), static_cast<qint64>(request.requestId)},
+            {QStringLiteral("kind"), nagi::audio::operationName(request.operation)},
+            {QStringLiteral("reason"), reason.left(64)},
+        });
+    }
+
+    void postUnavailable(Role role, std::uint32_t generation)
+    {
+        post(QJsonObject{
+            {QStringLiteral("type"), QStringLiteral("unavailable")},
+            {QStringLiteral("role"), nagi::audio::roleName(role)},
+            {QStringLiteral("generation"), static_cast<qint64>(generation)},
+        });
+    }
+
+    void postState(const RoleState &role, const NodeBinding &binding, const Request *request)
+    {
+        if (!binding.hasVolumes || !binding.hasMute || binding.visualVolumes.empty()) {
+            return;
+        }
+        double total = 0.0;
+        for (float volume : binding.visualVolumes) {
+            total += volume;
+        }
+        const double average = total / static_cast<double>(binding.visualVolumes.size());
+        post(QJsonObject{
+            {QStringLiteral("type"), QStringLiteral("state")},
+            {QStringLiteral("role"),
+             nagi::audio::roleName(request == nullptr ? roleForState(role) : request->role)},
+            {QStringLiteral("nodeId"), static_cast<qint64>(binding.id)},
+            {QStringLiteral("generation"), static_cast<qint64>(role.generation)},
+            {QStringLiteral("requestId"),
+             static_cast<qint64>(request == nullptr ? 0 : request->requestId)},
+            {QStringLiteral("kind"),
+             request == nullptr ? QStringLiteral("external")
+                                : nagi::audio::operationName(request->operation)},
+            {QStringLiteral("volume"), average},
+            {QStringLiteral("muted"), binding.muted},
+        });
+    }
+
+    Role roleForState(const RoleState &state) const
+    {
+        return &state == &roles[0] ? Role::Output : Role::Input;
+    }
+
+    static void onCoreDone(void *data, std::uint32_t id, int sequence)
+    {
+        auto *bridge = static_cast<PipeWireBridge *>(data);
+        if (id != PW_ID_CORE) {
+            return;
+        }
+        if (sequence == bridge->initialSyncSequence) {
+            bridge->helperReady = true;
+            bridge->post(QJsonObject{{QStringLiteral("type"), QStringLiteral("ready")}});
+            bridge->ensureTrackedBindings();
+            return;
+        }
+
+        const auto iterator = bridge->syncRequests.find(sequence);
+        if (iterator == bridge->syncRequests.end()) {
+            return;
+        }
+        const Request request = iterator->second;
+        bridge->syncRequests.erase(iterator);
+        bridge->beginReadback(request);
+    }
+
+    static void onCoreError(
+        void *data,
+        std::uint32_t id,
+        int,
+        int result,
+        const char *)
+    {
+        auto *bridge = static_cast<PipeWireBridge *>(data);
+        if (id != PW_ID_CORE || result >= 0) {
+            return;
+        }
+        bridge->post(QJsonObject{
+            {QStringLiteral("type"), QStringLiteral("fatal")},
+            {QStringLiteral("reason"), QStringLiteral("pipewire-core")},
+        });
+        QMetaObject::invokeMethod(
+            QCoreApplication::instance(),
+            [] { QCoreApplication::exit(2); },
+            Qt::QueuedConnection);
+    }
+
+    static void onRegistryGlobal(
+        void *data,
+        std::uint32_t id,
+        std::uint32_t,
+        const char *type,
+        std::uint32_t version,
+        const spa_dict *)
+    {
+        auto *bridge = static_cast<PipeWireBridge *>(data);
+        if (std::strcmp(type, PW_TYPE_INTERFACE_Node) != 0) {
+            return;
+        }
+        bridge->knownNodes[id] = version;
+        bridge->ensureTrackedBindings();
+    }
+
+    static void onRegistryGlobalRemove(void *data, std::uint32_t id)
+    {
+        auto *bridge = static_cast<PipeWireBridge *>(data);
+        bridge->knownNodes.erase(id);
+        bridge->removeBinding(id);
+    }
+
+    static void onNodeInfo(void *data, const pw_node_info *)
+    {
+        auto *binding = static_cast<NodeBinding *>(data);
+        if (binding->subscribed) {
+            return;
+        }
+        binding->subscribed = true;
+        std::uint32_t params[] = {SPA_PARAM_Props};
+        pw_node_subscribe_params(binding->node, params, 1);
+        pw_node_enum_params(binding->node, 0, SPA_PARAM_Props, 0, 1, nullptr);
+    }
+
+    static void onNodeParam(
+        void *data,
+        int sequence,
+        std::uint32_t id,
+        std::uint32_t,
+        std::uint32_t,
+        const spa_pod *parameter)
+    {
+        auto *binding = static_cast<NodeBinding *>(data);
+        if (id != SPA_PARAM_Props || parameter == nullptr) {
+            return;
+        }
+        if (!binding->owner->updateState(*binding, parameter)) {
+            return;
+        }
+
+        auto readback = binding->owner->readbackRequests.find(sequence);
+        if (readback == binding->owner->readbackRequests.end()) {
+            auto candidate = binding->owner->readbackRequests.end();
+            for (auto iterator = binding->owner->readbackRequests.begin();
+                 iterator != binding->owner->readbackRequests.end();
+                 ++iterator) {
+                if (iterator->second.nodeId != binding->id) {
+                    continue;
+                }
+                if (candidate != binding->owner->readbackRequests.end()) {
+                    candidate = binding->owner->readbackRequests.end();
+                    break;
+                }
+                candidate = iterator;
+            }
+            readback = candidate;
+        }
+        if (readback != binding->owner->readbackRequests.end()) {
+            const Request request = readback->second;
+            binding->owner->readbackRequests.erase(readback);
+            binding->owner->completeRequest(request, *binding);
+            return;
+        }
+        binding->owner->publishExternalState(*binding);
+    }
+
+    bool updateState(NodeBinding &binding, const spa_pod *parameter)
+    {
+        const spa_pod_prop *volumesProperty =
+            spa_pod_find_prop(parameter, nullptr, SPA_PROP_channelVolumes);
+        if (volumesProperty != nullptr && spa_pod_is_array(&volumesProperty->value)) {
+            const auto *array = reinterpret_cast<const spa_pod_array *>(&volumesProperty->value);
+            const std::uint32_t count = SPA_POD_ARRAY_N_VALUES(array);
+            if (SPA_POD_ARRAY_VALUE_TYPE(array) == SPA_TYPE_Float
+                && SPA_POD_ARRAY_VALUE_SIZE(array) == sizeof(float) && count > 0 && count <= 64) {
+                const auto *values =
+                    reinterpret_cast<const float *>(SPA_POD_ARRAY_VALUES(array));
+                std::vector<float> volumes;
+                volumes.reserve(count);
+                for (std::uint32_t index = 0; index < count; ++index) {
+                    const float cubic = values[index];
+                    if (!std::isfinite(cubic) || cubic < 0.0F) {
+                        volumes.clear();
+                        break;
+                    }
+                    volumes.push_back(std::cbrt(cubic));
+                }
+                if (!volumes.empty()) {
+                    binding.visualVolumes = std::move(volumes);
+                    binding.hasVolumes = true;
+                }
+            }
+        }
+
+        const spa_pod_prop *muteProperty = spa_pod_find_prop(parameter, nullptr, SPA_PROP_mute);
+        if (muteProperty != nullptr) {
+            bool muted = false;
+            if (spa_pod_get_bool(&muteProperty->value, &muted) == 0) {
+                binding.muted = muted;
+                binding.hasMute = true;
+            }
+        }
+        return binding.hasVolumes && binding.hasMute;
+    }
+
+    void publishExternalState(const NodeBinding &binding)
+    {
+        for (Role role : {Role::Output, Role::Input}) {
+            const RoleState &state = roleState(role);
+            if (state.binding != &binding || state.volumeInFlight || state.muteInFlight) {
+                continue;
+            }
+            postState(state, binding, nullptr);
+        }
+    }
+
+    void ensureTrackedBindings()
+    {
+        if (!helperReady) {
+            return;
+        }
+        for (Role role : {Role::Output, Role::Input}) {
+            RoleState &state = roleState(role);
+            if (state.nodeId == InvalidNode || state.binding != nullptr
+                || !knownNodes.contains(state.nodeId)) {
+                continue;
+            }
+            state.binding = ensureBinding(state.nodeId);
+            if (state.binding != nullptr && state.binding->hasVolumes && state.binding->hasMute) {
+                postState(state, *state.binding, nullptr);
+            }
+        }
+    }
+
+    NodeBinding *ensureBinding(std::uint32_t id)
+    {
+        const auto existing = bindings.find(id);
+        if (existing != bindings.end()) {
+            return existing->second.get();
+        }
+        const auto version = knownNodes.find(id);
+        if (version == knownNodes.end()) {
+            return nullptr;
+        }
+
+        auto binding = std::make_unique<NodeBinding>();
+        binding->owner = this;
+        binding->id = id;
+        binding->node = static_cast<pw_node *>(pw_registry_bind(
+            registry,
+            id,
+            PW_TYPE_INTERFACE_Node,
+            std::min(version->second, static_cast<std::uint32_t>(PW_VERSION_NODE)),
+            0));
+        if (binding->node == nullptr) {
+            return nullptr;
+        }
+        static const pw_node_events nodeEvents = [] {
+            pw_node_events events{};
+            events.version = PW_VERSION_NODE_EVENTS;
+            events.info = &PipeWireBridge::onNodeInfo;
+            events.param = &PipeWireBridge::onNodeParam;
+            return events;
+        }();
+        pw_node_add_listener(binding->node, &binding->listener, &nodeEvents, binding.get());
+        NodeBinding *result = binding.get();
+        bindings.emplace(id, std::move(binding));
+        return result;
+    }
+
+    void removeBinding(std::uint32_t id)
+    {
+        const auto bindingIterator = bindings.find(id);
+        if (bindingIterator == bindings.end()) {
+            return;
+        }
+        NodeBinding *binding = bindingIterator->second.get();
+        for (Role role : {Role::Output, Role::Input}) {
+            RoleState &state = roleState(role);
+            if (state.binding != binding) {
+                continue;
+            }
+            state.binding = nullptr;
+            state.volumeInFlight = false;
+            state.muteInFlight = false;
+            state.queuedVolume.reset();
+            state.queuedMute.reset();
+            postUnavailable(role, state.generation);
+        }
+        eraseRequestsForNode(id);
+        spa_hook_remove(&binding->listener);
+        pw_proxy_destroy(reinterpret_cast<pw_proxy *>(binding->node));
+        bindings.erase(bindingIterator);
+    }
+
+    void eraseRequestsForNode(std::uint32_t id)
+    {
+        std::erase_if(syncRequests, [id](const auto &entry) { return entry.second.nodeId == id; });
+        std::erase_if(
+            readbackRequests,
+            [id](const auto &entry) { return entry.second.nodeId == id; });
+    }
+
+    bool bindingUsed(std::uint32_t id) const
+    {
+        return std::any_of(roles.begin(), roles.end(), [id](const RoleState &state) {
+            return state.nodeId == id;
+        });
+    }
+
+    void releaseBindingIfUnused(std::uint32_t id)
+    {
+        if (id != InvalidNode && !bindingUsed(id)) {
+            removeBinding(id);
+        }
+    }
+
+    void track(const Command &command)
+    {
+        RoleState &state = roleState(command.role);
+        const std::uint32_t oldNode = state.nodeId;
+        RoleState replacement;
+        replacement.nodeId = command.nodeId;
+        replacement.generation = command.generation;
+        state = std::move(replacement);
+        releaseBindingIfUnused(oldNode);
+        ensureTrackedBindings();
+        if (state.binding == nullptr && helperReady && !knownNodes.contains(command.nodeId)) {
+            postUnavailable(command.role, command.generation);
+        }
+    }
+
+    void untrack(const Command &command)
+    {
+        RoleState &state = roleState(command.role);
+        if (state.generation != command.generation) {
+            return;
+        }
+        const std::uint32_t oldNode = state.nodeId;
+        state = RoleState{};
+        releaseBindingIfUnused(oldNode);
+    }
+
+    Request makeRequest(const Command &command) const
+    {
+        return Request{
+            .operation = command.operation,
+            .role = command.role,
+            .nodeId = command.nodeId,
+            .generation = command.generation,
+            .requestId = command.requestId,
+            .volume = command.volume,
+            .muted = command.muted,
+            .final = command.final,
+        };
+    }
+
+    void request(const Command &command)
+    {
+        RoleState &state = roleState(command.role);
+        const Request request = makeRequest(command);
+        if (state.nodeId != request.nodeId || state.generation != request.generation
+            || state.binding == nullptr) {
+            postFailure(request, QStringLiteral("stale"));
+            return;
+        }
+
+        if (state.volumeInFlight || state.muteInFlight) {
+            if (request.operation == Operation::SetVolume) {
+                state.queuedVolume = request;
+            } else {
+                state.queuedMute = request;
+            }
+            return;
+        }
+        dispatch(request);
+    }
+
+    void dispatch(const Request &request)
+    {
+        RoleState &state = roleState(request.role);
+        NodeBinding *binding = state.binding;
+        if (binding == nullptr || binding->id != request.nodeId) {
+            postFailure(request, QStringLiteral("stale"));
+            return;
+        }
+
+        int result = 0;
+        if (request.operation == Operation::SetVolume) {
+            if (!binding->hasVolumes || binding->visualVolumes.empty()) {
+                postFailure(request, QStringLiteral("not-ready"));
+                return;
+            }
+            const auto cubicVolumes =
+                nagi::audio::proportionalCubicVolumes(binding->visualVolumes, request.volume);
+            if (!cubicVolumes) {
+                postFailure(request, QStringLiteral("invalid-state"));
+                return;
+            }
+            std::array<std::uint8_t, 1024> buffer{};
+            spa_pod_builder builder{};
+            spa_pod_builder_init(
+                &builder,
+                buffer.data(),
+                static_cast<std::uint32_t>(buffer.size()));
+            auto *parameter = static_cast<spa_pod *>(spa_pod_builder_add_object(
+                &builder,
+                SPA_TYPE_OBJECT_Props,
+                SPA_PARAM_Props,
+                SPA_PROP_channelVolumes,
+                SPA_POD_Array(
+                    sizeof(float),
+                    SPA_TYPE_Float,
+                    static_cast<std::uint32_t>(cubicVolumes->size()),
+                    cubicVolumes->data())));
+            result = pw_node_set_param(binding->node, SPA_PARAM_Props, 0, parameter);
+            if (result >= 0) {
+                state.volumeInFlight = true;
+            }
+        } else {
+            std::array<std::uint8_t, 256> buffer{};
+            spa_pod_builder builder{};
+            spa_pod_builder_init(
+                &builder,
+                buffer.data(),
+                static_cast<std::uint32_t>(buffer.size()));
+            auto *parameter = static_cast<spa_pod *>(spa_pod_builder_add_object(
+                &builder,
+                SPA_TYPE_OBJECT_Props,
+                SPA_PARAM_Props,
+                SPA_PROP_mute,
+                SPA_POD_Bool(request.muted)));
+            result = pw_node_set_param(binding->node, SPA_PARAM_Props, 0, parameter);
+            if (result >= 0) {
+                state.muteInFlight = true;
+            }
+        }
+
+        if (result < 0) {
+            postFailure(request, QString::fromLatin1(spa_strerror(result)));
+            return;
+        }
+        const int sequence = pw_core_sync(core, PW_ID_CORE, 0);
+        if (sequence < 0) {
+            clearInFlight(request);
+            postFailure(request, QStringLiteral("sync-failed"));
+            return;
+        }
+        syncRequests[sequence] = request;
+    }
+
+    void beginReadback(const Request &request)
+    {
+        const RoleState &state = roleState(request.role);
+        if (state.nodeId != request.nodeId || state.generation != request.generation
+            || state.binding == nullptr) {
+            clearInFlight(request);
+            return;
+        }
+        const int sequence = ++nextReadbackSequence;
+        readbackRequests[sequence] = request;
+        const int result = pw_node_enum_params(
+            state.binding->node,
+            sequence,
+            SPA_PARAM_Props,
+            0,
+            1,
+            nullptr);
+        if (result < 0) {
+            readbackRequests.erase(sequence);
+            clearInFlight(request);
+            postFailure(request, QStringLiteral("readback-failed"));
+        }
+    }
+
+    void completeRequest(const Request &request, const NodeBinding &binding)
+    {
+        RoleState &state = roleState(request.role);
+        if (state.nodeId != request.nodeId || state.generation != request.generation
+            || state.binding != &binding) {
+            return;
+        }
+        postState(state, binding, &request);
+        clearInFlight(request);
+        dispatchQueued(request.role);
+    }
+
+    void clearInFlight(const Request &request)
+    {
+        RoleState &state = roleState(request.role);
+        if (state.nodeId != request.nodeId || state.generation != request.generation) {
+            return;
+        }
+        if (request.operation == Operation::SetVolume) {
+            state.volumeInFlight = false;
+        } else if (request.operation == Operation::SetMute) {
+            state.muteInFlight = false;
+        }
+    }
+
+    void dispatchQueued(Role role)
+    {
+        RoleState &state = roleState(role);
+        if (state.muteInFlight || state.volumeInFlight) {
+            return;
+        }
+        if (state.queuedMute) {
+            const Request request = *state.queuedMute;
+            state.queuedMute.reset();
+            dispatch(request);
+        } else if (state.queuedVolume) {
+            const Request request = *state.queuedVolume;
+            state.queuedVolume.reset();
+            dispatch(request);
+        }
+    }
+
+    void handleCommand(const Command &command)
+    {
+        if (command.operation == Operation::Shutdown) {
+            QCoreApplication::quit();
+            return;
+        }
+
+        pw_thread_loop_lock(threadLoop);
+        if (command.operation == Operation::Track) {
+            track(command);
+        } else if (command.operation == Operation::Untrack) {
+            untrack(command);
+        } else {
+            request(command);
+        }
+        pw_thread_loop_unlock(threadLoop);
+    }
+
+    void readCommands()
+    {
+        std::array<char, 4096> bytes{};
+        const ssize_t count = ::read(STDIN_FILENO, bytes.data(), bytes.size());
+        if (count == 0) {
+            QCoreApplication::quit();
+            return;
+        }
+        if (count < 0) {
+            if (errno != EAGAIN && errno != EINTR) {
+                diagnose("stdin read failed");
+                QCoreApplication::exit(2);
+            }
+            return;
+        }
+
+        commandBuffer.append(bytes.data(), count);
+        if (commandBuffer.size() > nagi::audio::MaximumCommandBytes * 2) {
+            diagnose("command buffer exceeded limit");
+            commandBuffer.clear();
+        }
+
+        while (true) {
+            const qsizetype newline = commandBuffer.indexOf('\n');
+            if (newline < 0) {
+                break;
+            }
+            QByteArray line = commandBuffer.left(newline);
+            commandBuffer.remove(0, newline + 1);
+            if (line.endsWith('\r')) {
+                line.chop(1);
+            }
+            QString error;
+            const auto command = nagi::audio::parseCommand(line, &error);
+            if (!command) {
+                diagnose(error.toUtf8().constData());
+                continue;
+            }
+            handleCommand(*command);
+        }
+    }
+
+    pw_thread_loop *threadLoop = nullptr;
+    pw_context *context = nullptr;
+    pw_core *core = nullptr;
+    pw_registry *registry = nullptr;
+    spa_hook coreListener{};
+    spa_hook registryListener{};
+    bool loopStarted = false;
+    bool helperReady = false;
+    int initialSyncSequence = -1;
+    int nextReadbackSequence = 1000;
+    int diagnosticCount = 0;
+    QSocketNotifier *stdinNotifier = nullptr;
+    QByteArray commandBuffer;
+    std::array<RoleState, 2> roles{};
+    std::unordered_map<std::uint32_t, std::uint32_t> knownNodes;
+    std::unordered_map<std::uint32_t, std::unique_ptr<NodeBinding>> bindings;
+    std::unordered_map<int, Request> syncRequests;
+    std::unordered_map<int, Request> readbackRequests;
+};
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    QCoreApplication application(argc, argv);
+    try {
+        PipeWireBridge bridge;
+        return application.exec();
+    } catch (const std::exception &error) {
+        std::fprintf(stderr, "nagi-shell PipeWire bridge: %.256s\n", error.what());
+        return 2;
+    }
+}

--- a/src/pipewire-audio/protocol.cpp
+++ b/src/pipewire-audio/protocol.cpp
@@ -1,0 +1,230 @@
+#include "protocol.h"
+
+#include <cmath>
+#include <limits>
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
+#include <QSet>
+
+namespace nagi::audio {
+namespace {
+
+void setError(QString *error, const QString &message)
+{
+    if (error != nullptr) {
+        *error = message;
+    }
+}
+
+std::optional<Role> parseRole(const QJsonValue &value)
+{
+    if (!value.isString()) {
+        return std::nullopt;
+    }
+    if (value.toString() == QStringLiteral("output")) {
+        return Role::Output;
+    }
+    if (value.toString() == QStringLiteral("input")) {
+        return Role::Input;
+    }
+    return std::nullopt;
+}
+
+std::optional<std::uint32_t> parseUnsigned(
+    const QJsonValue &value,
+    bool allowZero = false)
+{
+    if (!value.isDouble()) {
+        return std::nullopt;
+    }
+    const double number = value.toDouble();
+    if (!std::isfinite(number) || std::floor(number) != number || number < 0
+        || (!allowZero && number == 0)
+        || number > static_cast<double>(std::numeric_limits<std::int32_t>::max())) {
+        return std::nullopt;
+    }
+    return static_cast<std::uint32_t>(number);
+}
+
+bool hasExactKeys(const QJsonObject &object, const QSet<QString> &expected)
+{
+    if (object.size() != expected.size()) {
+        return false;
+    }
+    for (auto iterator = object.constBegin(); iterator != object.constEnd(); ++iterator) {
+        if (!expected.contains(iterator.key())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+std::optional<Command> parseCommand(const QByteArray &line, QString *error)
+{
+    if (line.isEmpty() || line.size() > MaximumCommandBytes) {
+        setError(error, QStringLiteral("command length is invalid"));
+        return std::nullopt;
+    }
+
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(line, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+        setError(error, QStringLiteral("command is not a JSON object"));
+        return std::nullopt;
+    }
+
+    const QJsonObject object = document.object();
+    const QJsonValue operationValue = object.value(QStringLiteral("op"));
+    if (!operationValue.isString()) {
+        setError(error, QStringLiteral("command operation is invalid"));
+        return std::nullopt;
+    }
+
+    const QString operation = operationValue.toString();
+    if (operation == QStringLiteral("shutdown")) {
+        if (!hasExactKeys(object, {QStringLiteral("op")})) {
+            setError(error, QStringLiteral("shutdown command schema is invalid"));
+            return std::nullopt;
+        }
+        return Command{.operation = Operation::Shutdown};
+    }
+
+    const auto role = parseRole(object.value(QStringLiteral("role")));
+    const auto generation = parseUnsigned(object.value(QStringLiteral("generation")));
+    if (!role || !generation) {
+        setError(error, QStringLiteral("command role or generation is invalid"));
+        return std::nullopt;
+    }
+
+    if (operation == QStringLiteral("untrack")) {
+        if (!hasExactKeys(
+                object,
+                {QStringLiteral("op"), QStringLiteral("role"), QStringLiteral("generation")})) {
+            setError(error, QStringLiteral("untrack command schema is invalid"));
+            return std::nullopt;
+        }
+        return Command{
+            .operation = Operation::Untrack,
+            .role = *role,
+            .generation = *generation,
+        };
+    }
+
+    const auto nodeId = parseUnsigned(object.value(QStringLiteral("nodeId")), true);
+    if (!nodeId) {
+        setError(error, QStringLiteral("command node ID is invalid"));
+        return std::nullopt;
+    }
+
+    if (operation == QStringLiteral("track")) {
+        if (!hasExactKeys(
+                object,
+                {QStringLiteral("op"),
+                 QStringLiteral("role"),
+                 QStringLiteral("nodeId"),
+                 QStringLiteral("generation")})) {
+            setError(error, QStringLiteral("track command schema is invalid"));
+            return std::nullopt;
+        }
+        return Command{
+            .operation = Operation::Track,
+            .role = *role,
+            .nodeId = *nodeId,
+            .generation = *generation,
+        };
+    }
+
+    const auto requestId = parseUnsigned(object.value(QStringLiteral("requestId")));
+    if (!requestId) {
+        setError(error, QStringLiteral("request ID is invalid"));
+        return std::nullopt;
+    }
+
+    if (operation == QStringLiteral("setVolume")) {
+        const QJsonValue volumeValue = object.value(QStringLiteral("value"));
+        const QJsonValue finalValue = object.value(QStringLiteral("final"));
+        if (!hasExactKeys(
+                object,
+                {QStringLiteral("op"),
+                 QStringLiteral("role"),
+                 QStringLiteral("nodeId"),
+                 QStringLiteral("generation"),
+                 QStringLiteral("requestId"),
+                 QStringLiteral("value"),
+                 QStringLiteral("final")})
+            || !volumeValue.isDouble() || !finalValue.isBool()) {
+            setError(error, QStringLiteral("volume command schema is invalid"));
+            return std::nullopt;
+        }
+        const double volume = volumeValue.toDouble();
+        if (!std::isfinite(volume) || volume < 0.0 || volume > 1.0) {
+            setError(error, QStringLiteral("volume command value is invalid"));
+            return std::nullopt;
+        }
+        return Command{
+            .operation = Operation::SetVolume,
+            .role = *role,
+            .nodeId = *nodeId,
+            .generation = *generation,
+            .requestId = *requestId,
+            .volume = volume,
+            .final = finalValue.toBool(),
+        };
+    }
+
+    if (operation == QStringLiteral("setMute")) {
+        const QJsonValue mutedValue = object.value(QStringLiteral("muted"));
+        if (!hasExactKeys(
+                object,
+                {QStringLiteral("op"),
+                 QStringLiteral("role"),
+                 QStringLiteral("nodeId"),
+                 QStringLiteral("generation"),
+                 QStringLiteral("requestId"),
+                 QStringLiteral("muted")})
+            || !mutedValue.isBool()) {
+            setError(error, QStringLiteral("mute command schema is invalid"));
+            return std::nullopt;
+        }
+        return Command{
+            .operation = Operation::SetMute,
+            .role = *role,
+            .nodeId = *nodeId,
+            .generation = *generation,
+            .requestId = *requestId,
+            .muted = mutedValue.toBool(),
+        };
+    }
+
+    setError(error, QStringLiteral("command operation is unsupported"));
+    return std::nullopt;
+}
+
+QString roleName(Role role)
+{
+    return role == Role::Output ? QStringLiteral("output") : QStringLiteral("input");
+}
+
+QString operationName(Operation operation)
+{
+    switch (operation) {
+    case Operation::Track:
+        return QStringLiteral("track");
+    case Operation::Untrack:
+        return QStringLiteral("untrack");
+    case Operation::SetVolume:
+        return QStringLiteral("volume");
+    case Operation::SetMute:
+        return QStringLiteral("mute");
+    case Operation::Shutdown:
+        return QStringLiteral("shutdown");
+    }
+    return QStringLiteral("unknown");
+}
+
+} // namespace nagi::audio

--- a/src/pipewire-audio/protocol.h
+++ b/src/pipewire-audio/protocol.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+#include <cstdint>
+#include <optional>
+
+namespace nagi::audio {
+
+enum class Operation {
+    Track,
+    Untrack,
+    SetVolume,
+    SetMute,
+    Shutdown,
+};
+
+enum class Role {
+    Output,
+    Input,
+};
+
+struct Command {
+    Operation operation = Operation::Shutdown;
+    Role role = Role::Output;
+    std::uint32_t nodeId = 0;
+    std::uint32_t generation = 0;
+    std::uint32_t requestId = 0;
+    double volume = 0.0;
+    bool muted = false;
+    bool final = false;
+};
+
+constexpr qsizetype MaximumCommandBytes = 4096;
+
+std::optional<Command> parseCommand(const QByteArray &line, QString *error = nullptr);
+QString roleName(Role role);
+QString operationName(Operation operation);
+
+} // namespace nagi::audio

--- a/src/pipewire-audio/volume.cpp
+++ b/src/pipewire-audio/volume.cpp
@@ -1,0 +1,42 @@
+#include "volume.h"
+
+#include <cmath>
+#include <limits>
+#include <numeric>
+
+namespace nagi::audio {
+
+std::optional<std::vector<float>> proportionalCubicVolumes(
+    const std::vector<float> &confirmedVisualVolumes,
+    double targetAverage)
+{
+    if (confirmedVisualVolumes.empty() || confirmedVisualVolumes.size() > 64
+        || !std::isfinite(targetAverage) || targetAverage < 0.0 || targetAverage > 1.0) {
+        return std::nullopt;
+    }
+    for (float volume : confirmedVisualVolumes) {
+        if (!std::isfinite(volume) || volume < 0.0F) {
+            return std::nullopt;
+        }
+    }
+
+    const double average = std::accumulate(
+                               confirmedVisualVolumes.begin(),
+                               confirmedVisualVolumes.end(),
+                               0.0)
+        / static_cast<double>(confirmedVisualVolumes.size());
+    std::vector<float> cubicVolumes;
+    cubicVolumes.reserve(confirmedVisualVolumes.size());
+    for (float current : confirmedVisualVolumes) {
+        const double visual = average <= 0.000001 ? targetAverage
+                                                 : current * targetAverage / average;
+        const double cubic = visual * visual * visual;
+        if (!std::isfinite(cubic) || cubic > std::numeric_limits<float>::max()) {
+            return std::nullopt;
+        }
+        cubicVolumes.push_back(static_cast<float>(cubic));
+    }
+    return cubicVolumes;
+}
+
+} // namespace nagi::audio

--- a/src/pipewire-audio/volume.h
+++ b/src/pipewire-audio/volume.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+namespace nagi::audio {
+
+std::optional<std::vector<float>> proportionalCubicVolumes(
+    const std::vector<float> &confirmedVisualVolumes,
+    double targetAverage);
+
+} // namespace nagi::audio

--- a/tests/audio/live-write.qml
+++ b/tests/audio/live-write.qml
@@ -1,0 +1,336 @@
+import Quickshell
+import QtQuick
+import "qml"
+
+ShellRoot {
+    id: test
+
+    property var actions: []
+    property int actionIndex: 0
+    property bool waiting: false
+    property bool restoringAfterFailure: false
+    property int finalExitCode: 0
+    property string finalMessage: ""
+    property var original: null
+
+    AudioAdapter {
+        id: audio
+        bridgePath: Quickshell.env("NAGI_AUDIO_HELPER") ?? ""
+    }
+
+    function near(left, right) {
+        return Math.abs(left - right) <= 0.02;
+    }
+
+    function volumeTarget(value) {
+        return value <= 0.9 ? value + 0.05 : value - 0.05;
+    }
+
+    function start() {
+        if (original !== null || audio.syncState !== "ready") {
+            return;
+        }
+        if (!audio.outputAvailable || !audio.inputAvailable) {
+            fail("live confirmed-write probe requires default output and input");
+            return;
+        }
+
+        original = {
+            "outputEndpointKey": audio.outputEndpointKey,
+            "outputVolume": audio.outputVolume,
+            "outputMuted": audio.outputMuted,
+            "inputVolume": audio.inputVolume,
+            "inputMuted": audio.inputMuted,
+            "outputOveramplified": audio.outputOveramplified,
+            "inputOveramplified": audio.inputOveramplified
+        };
+        const requested = [];
+        let alternateOutput = null;
+        for (let index = 0; index < audio.outputCandidates.length; ++index) {
+            if (!audio.outputCandidates[index].isDefault) {
+                alternateOutput = audio.outputCandidates[index];
+                break;
+            }
+        }
+        if (alternateOutput !== null) {
+            requested.push({
+                               "role": "output",
+                               "kind": "selection",
+                               "value": alternateOutput.endpointKey
+                           }, {
+                               "role": "output",
+                               "kind": "selection",
+                               "value": original.outputEndpointKey
+                           });
+        }
+        if (!original.outputOveramplified) {
+            requested.push({
+                               "role": "output",
+                               "kind": "volume",
+                               "value": volumeTarget(original.outputVolume)
+                           }, {
+                               "role": "output",
+                               "kind": "volume",
+                               "value": original.outputVolume
+                           });
+        }
+        requested.push({
+                           "role": "output",
+                           "kind": "mute",
+                           "value": !original.outputMuted
+                       }, {
+                           "role": "output",
+                           "kind": "mute",
+                           "value": original.outputMuted
+                       });
+        if (!original.inputOveramplified) {
+            requested.push({
+                               "role": "input",
+                               "kind": "volume",
+                               "value": volumeTarget(original.inputVolume)
+                           }, {
+                               "role": "input",
+                               "kind": "volume",
+                               "value": original.inputVolume
+                           });
+        }
+        requested.push({
+                           "role": "input",
+                           "kind": "mute",
+                           "value": !original.inputMuted
+                       }, {
+                           "role": "input",
+                           "kind": "mute",
+                           "value": original.inputMuted
+                       });
+        actions = requested;
+        actionIndex = 0;
+        dispatchNext();
+    }
+
+    function dispatchNext() {
+        if (waiting) {
+            return;
+        }
+        if (actionIndex >= actions.length) {
+            finish();
+            return;
+        }
+
+        const action = actions[actionIndex];
+        waiting = true;
+        stageTimeout.restart();
+        let accepted = false;
+        if (action.kind === "selection") {
+            accepted = audio.requestOutputSelection(action.value);
+        } else if (action.kind === "volume") {
+            accepted = action.role === "output" ? audio.requestOutputVolume(action.value, true) :
+                                                  audio.requestInputVolume(action.value, true);
+        } else {
+            accepted = action.role === "output" ? audio.requestOutputMute(action.value) :
+                                                  audio.requestInputMute(action.value);
+        }
+        if (!accepted) {
+            stageTimeout.stop();
+            waiting = false;
+            fail("audio adapter rejected a live confirmed-write action");
+            return;
+        }
+        if (!pendingFor(action)) {
+            Qt.callLater(completeAction);
+        }
+    }
+
+    function pendingFor(action) {
+        if (action.kind === "selection") {
+            return audio.pendingOutputSelection;
+        }
+        if (action.kind === "volume") {
+            return action.role === "output" ? audio.pendingOutputVolume : audio.pendingInputVolume;
+        }
+        return action.role === "output" ? audio.pendingOutputMute : audio.pendingInputMute;
+    }
+
+    function confirmedValue(action) {
+        if (action.kind === "selection") {
+            return audio.outputEndpointKey;
+        }
+        if (action.kind === "volume") {
+            return action.role === "output" ? audio.outputVolume : audio.inputVolume;
+        }
+        return action.role === "output" ? audio.outputMuted : audio.inputMuted;
+    }
+
+    function pendingChanged() {
+        if (!waiting || pendingFor(actions[actionIndex])) {
+            return;
+        }
+        Qt.callLater(completeAction);
+    }
+
+    function completeAction() {
+        if (!waiting) {
+            return;
+        }
+        const action = actions[actionIndex];
+        const confirmed = confirmedValue(action);
+        const matches = action.kind === "volume" ? near(confirmed, action.value) : confirmed
+                                                   === action.value;
+        if (action.kind === "selection" && !matches && audio.failure === "none") {
+            return;
+        }
+        if (!matches || audio.failure !== "none") {
+            stageTimeout.stop();
+            waiting = false;
+            fail("PipeWire did not confirm action " + actionIndex + " " + action.role + " "
+                 + action.kind + " target=" + action.value + " confirmed=" + confirmed
+                 + " failure=" + audio.failure);
+            return;
+        }
+        waiting = false;
+        stageTimeout.stop();
+        actionIndex += 1;
+        dispatchNext();
+    }
+
+    function restorationActions() {
+        if (original === null) {
+            return [];
+        }
+        const restore = [];
+        let originalOutputPresent = false;
+        for (let index = 0; index < audio.outputCandidates.length; ++index) {
+            originalOutputPresent = originalOutputPresent
+                    || audio.outputCandidates[index].endpointKey === original.outputEndpointKey;
+        }
+        if (originalOutputPresent) {
+            restore.push({
+                             "role": "output",
+                             "kind": "selection",
+                             "value": original.outputEndpointKey
+                         });
+        }
+        if (!original.outputOveramplified && audio.outputAvailable) {
+            restore.push({
+                             "role": "output",
+                             "kind": "volume",
+                             "value": original.outputVolume
+                         });
+        }
+        if (audio.outputAvailable) {
+            restore.push({
+                             "role": "output",
+                             "kind": "mute",
+                             "value": original.outputMuted
+                         });
+        }
+        if (!original.inputOveramplified && audio.inputAvailable) {
+            restore.push({
+                             "role": "input",
+                             "kind": "volume",
+                             "value": original.inputVolume
+                         });
+        }
+        if (audio.inputAvailable) {
+            restore.push({
+                             "role": "input",
+                             "kind": "mute",
+                             "value": original.inputMuted
+                         });
+        }
+        return restore;
+    }
+
+    function fail(message) {
+        if (restoringAfterFailure || original === null) {
+            console.error("FAIL: " + message);
+            Qt.exit(2);
+            return;
+        }
+        restoringAfterFailure = true;
+        finalExitCode = 2;
+        finalMessage = message;
+        audio.volumeDeadlineReached("output");
+        audio.volumeDeadlineReached("input");
+        audio.muteDeadlineReached("output");
+        audio.muteDeadlineReached("input");
+        audio.failureDeadlineReached();
+        waiting = false;
+        actions = restorationActions();
+        actionIndex = 0;
+        dispatchNext();
+    }
+
+    function finish() {
+        stageTimeout.stop();
+        startupTimeout.stop();
+        if (finalExitCode !== 0) {
+            console.error("FAIL: " + finalMessage + " (audio state restored)");
+            Qt.exit(finalExitCode);
+            return;
+        }
+        if (audio.outputEndpointKey !== original.outputEndpointKey || (
+                    !original.outputOveramplified && !near(audio.outputVolume,
+                                                           original.outputVolume))
+                || audio.outputMuted !== original.outputMuted || (!original.inputOveramplified &&
+                                                                  !near(audio.inputVolume,
+                                                                        original.inputVolume))
+                || audio.inputMuted !== original.inputMuted) {
+            fail("live audio state did not restore exactly");
+            return;
+        }
+        console.warn("audio live confirmed-write probe passed and restored defaults");
+        Qt.exit(0);
+    }
+
+    Connections {
+        target: audio
+
+        function onSyncStateChanged() {
+            Qt.callLater(test.start);
+        }
+
+        function onOutputEndpointKeyChanged() {
+            test.pendingChanged();
+        }
+        function onPendingOutputSelectionChanged() {
+            test.pendingChanged();
+        }
+
+        function onPendingOutputVolumeChanged() {
+            test.pendingChanged();
+        }
+
+        function onPendingInputVolumeChanged() {
+            test.pendingChanged();
+        }
+
+        function onPendingOutputMuteChanged() {
+            test.pendingChanged();
+        }
+
+        function onPendingInputMuteChanged() {
+            test.pendingChanged();
+        }
+    }
+
+    Timer {
+        id: startupTimeout
+
+        interval: 5000
+        running: true
+        onTriggered: test.fail("live PipeWire synchronization timed out")
+    }
+
+    Timer {
+        id: stageTimeout
+
+        interval: 5000
+        onTriggered: {
+            waiting = false;
+            test.fail("live PipeWire confirmation timed out");
+        }
+    }
+
+    Component.onCompleted: Qt.callLater(start)
+}

--- a/tests/audio/live.qml
+++ b/tests/audio/live.qml
@@ -1,0 +1,125 @@
+import Quickshell
+import Quickshell.Services.Pipewire
+import QtQuick
+import "qml"
+
+ShellRoot {
+    id: test
+
+    property bool finished: false
+
+    AudioAdapter {
+        id: audio
+        bridgePath: Quickshell.env("NAGI_AUDIO_HELPER") ?? ""
+    }
+
+    function require(condition, message) {
+        if (!condition) {
+            console.error("FAIL: " + message);
+            Qt.exit(1);
+            throw new Error(message);
+        }
+    }
+
+    function inspect() {
+        if (finished || audio.syncState !== "ready") {
+            return;
+        }
+
+        let values = Pipewire.nodes.values;
+        if (values === null || typeof values !== "object" || typeof values.length !== "number") {
+            values = [];
+        }
+        let expectedOutputs = 0;
+        for (let index = 0; index < values.length; ++index) {
+            const node = values[index];
+            if (!node.isStream && node.isSink && node.audio !== null) {
+                expectedOutputs += 1;
+            }
+        }
+
+        require(audio.isSynchronized && audio.syncState === "ready",
+                "live graph and tracked defaults are ready");
+        require(audio.trackedObjectCount <= 2,
+                "live adapter tracks no more than confirmed sink and source");
+        require(audio.outputCandidates.length === expectedOutputs,
+                "live unbound output discovery is complete");
+        for (let candidateIndex = 0; candidateIndex
+             < audio.outputCandidates.length; ++candidateIndex) {
+            const candidate = audio.outputCandidates[candidateIndex];
+            require(candidate.node === undefined && candidate.properties === undefined,
+                    "live candidates expose no PipeWire objects or raw properties");
+        }
+
+        if (Pipewire.defaultAudioSink !== null) {
+            require(audio.outputAvailable && audio.outputCandidates.length > 0
+                    && audio.outputCandidates[0].isDefault,
+                    "live confirmed default output is tracked and ordered first");
+            require(audio.resolveConfirmedOutput(audio.outputSourceToken, audio.outputGeneration,
+                                                 audio.outputRevision) !== null,
+                    "live output revision resolves normalized state");
+            require(audio.requestOutputVolume(audio.outputVolume, true) &&
+                    !audio.pendingOutputVolume,
+                    "already-confirmed output volume is a bounded no-op");
+            require(audio.requestOutputMute(audio.outputMuted) && !audio.pendingOutputMute,
+                    "already-confirmed output mute is a bounded no-op");
+            require(audio.requestOutputSelection(audio.outputEndpointKey) &&
+                    !audio.pendingOutputSelection,
+                    "already-confirmed output selection is a bounded no-op");
+        } else {
+            require(!audio.outputAvailable, "nullable live output never claims stale controls");
+        }
+
+        if (Pipewire.defaultAudioSource !== null) {
+            require(audio.inputAvailable,
+                    "live confirmed default input is tracked after synchronization");
+            require(audio.resolveConfirmedInput(audio.inputSourceToken, audio.inputGeneration,
+                                                audio.inputRevision) !== null,
+                    "live input revision resolves normalized state");
+            require(audio.requestInputVolume(audio.inputVolume, true) && !audio.pendingInputVolume,
+                    "already-confirmed input volume is a bounded no-op");
+            require(audio.requestInputMute(audio.inputMuted) && !audio.pendingInputMute,
+                    "already-confirmed input mute is a bounded no-op");
+        } else {
+            require(!audio.inputAvailable, "nullable live input never claims stale controls");
+        }
+
+        require(audio.activeTimerCount === 0 && audio.queuedVolumeWriteCount === 0,
+                "idle live adapter has no polling timer or queued write");
+
+        finished = true;
+        timeout.stop();
+        console.warn("audio live probe passed: outputs=" + audio.outputCandidates.length
+                     + " tracked=" + audio.trackedObjectCount + " timers=" + audio.activeTimerCount
+                     + " output=" + audio.outputAvailable + " input=" + audio.inputAvailable);
+        Qt.exit(0);
+    }
+
+    Connections {
+        target: audio
+
+        function onSyncStateChanged() {
+            Qt.callLater(test.inspect);
+        }
+    }
+
+    Timer {
+        id: timeout
+
+        interval: 5000
+        running: true
+        onTriggered: {
+            console.error("FAIL: live PipeWire synchronization timed out: sync=" + audio.syncState
+                          + " bridge=" + audio.confirmationBridgeReady + " tracked="
+                          + audio.trackedObjectCount + " output=" + audio.outputAvailable
+                          + " input=" + audio.inputAvailable + " sinkId=" + (
+                              Pipewire.defaultAudioSink === null ? -1 :
+                                                                   Pipewire.defaultAudioSink.id)
+                          + " sourceId=" + (Pipewire.defaultAudioSource === null ? -1 :
+                                                                                   Pipewire.defaultAudioSource.id));
+            Qt.exit(2);
+        }
+    }
+
+    Component.onCompleted: Qt.callLater(inspect)
+}

--- a/tests/audio/shell.qml
+++ b/tests/audio/shell.qml
@@ -1,0 +1,573 @@
+import Quickshell
+import QtQuick
+import "qml"
+
+ShellRoot {
+    id: test
+
+    function require(condition, message) {
+        if (!condition) {
+            console.error("FAIL: " + message);
+            Qt.exit(1);
+            throw new Error(message);
+        }
+    }
+
+    function near(left, right) {
+        return Math.abs(left - right) < 0.000001;
+    }
+
+    function makeAudio(volume, muted, volumes) {
+        return audioFactory.createObject(test, {
+                                             "volume": volume,
+                                             "muted": muted,
+                                             "volumes": volumes.slice()
+                                         });
+    }
+
+    function makeNode(properties) {
+        return nodeFactory.createObject(test, properties);
+    }
+
+    function makeBundle() {
+        const model = modelFactory.createObject(test);
+        const service = serviceFactory.createObject(test, {
+                                                        "nodes": model
+                                                    });
+        const bridge = bridgeFactory.createObject(test);
+        const capture = {
+            "preferredWrites": [],
+            "outputChanges": [],
+            "inputChanges": [],
+            "outputInvalidations": [],
+            "inputInvalidations": []
+        };
+        const adapter = adapterFactory.createObject(test, {
+                                                        "pipewireService": service,
+                                                        "nativeTrackingEnabled": false,
+                                                        "nodeIdReader": node => node.pipewireId,
+                                                        "confirmationBridge": bridge,
+                                                        "preferredSinkWriter": (backend, node)
+                                                                               => capture.preferredWrites.push(
+                                                                                      {
+                                                                                          "backend":
+                                                                                          backend,
+                                                                                          "node": node
+                                                                                      })
+                                                    });
+        adapter.confirmedOutputChanged.connect((token, generation, revision)
+                                               => capture.outputChanges.push({
+                                                                                 "token": token,
+                                                                                 "generation":
+                                                                                 generation,
+                                                                                 "revision":
+                                                                                 revision
+                                                                             }));
+        adapter.confirmedInputChanged.connect((token, generation, revision)
+                                              => capture.inputChanges.push({
+                                                                               "token": token,
+                                                                               "generation":
+                                                                               generation,
+                                                                               "revision": revision
+                                                                           }));
+        adapter.confirmedOutputInvalidated.connect((token, generation)
+                                                   => capture.outputInvalidations.push({
+                                                                                           "token": token,
+                                                                                           "generation":
+                                                                                           generation
+                                                                                       }));
+        adapter.confirmedInputInvalidated.connect((token, generation)
+                                                  => capture.inputInvalidations.push({
+                                                                                         "token": token,
+                                                                                         "generation":
+                                                                                         generation
+                                                                                     }));
+        return {
+            "adapter": adapter,
+            "capture": capture,
+            "model": model,
+            "service": service,
+            "bridge": bridge,
+            "objects": []
+        };
+    }
+
+    function own(bundle, object) {
+        bundle.objects.push(object);
+        return object;
+    }
+
+    function apply(bundle, mutation) {
+        mutation();
+        bundle.adapter.processPendingChanges();
+    }
+
+    function candidate(bundle, label) {
+        for (let index = 0; index < bundle.adapter.outputCandidates.length; ++index) {
+            if (bundle.adapter.outputCandidates[index].label === label) {
+                return bundle.adapter.outputCandidates[index];
+            }
+        }
+        return null;
+    }
+
+    function destroyBundle(bundle) {
+        bundle.adapter.destroy();
+        bundle.bridge.destroy();
+        bundle.service.destroy();
+        bundle.model.destroy();
+        for (let index = 0; index < bundle.objects.length; ++index) {
+            bundle.objects[index].destroy();
+        }
+    }
+
+    Component {
+        id: audioFactory
+
+        QtObject {
+            property real volume: 0
+            property bool muted: false
+            property var volumes: []
+        }
+    }
+
+    Component {
+        id: nodeFactory
+
+        QtObject {
+            property int pipewireId: 0
+            property string name: ""
+            property string description: ""
+            property string nickname: ""
+            property bool ready: false
+            property bool isStream: false
+            property bool isSink: false
+            property var audio: null
+        }
+    }
+
+    Component {
+        id: modelFactory
+
+        QtObject {
+            property var values: []
+        }
+    }
+
+    Component {
+        id: serviceFactory
+
+        QtObject {
+            property bool ready: false
+            property var nodes: null
+            property var defaultAudioSink: null
+            property var defaultAudioSource: null
+            property var preferredDefaultAudioSink: null
+        }
+    }
+
+    Component {
+        id: bridgeFactory
+
+        QtObject {
+            property bool ready: true
+            property var tracks: ({})
+            property var volumeWrites: []
+            property var muteWrites: []
+
+            signal stateConfirmed(string role, int nodeId, int generation, int requestId, string kind,
+                                  real volume, bool muted)
+            signal roleUnavailable(string role, int generation)
+            signal requestFailed(string role, int generation, int requestId, string kind,
+                                 string reason)
+            signal fatalFailure
+
+            function track(role, nodeId, generation) {
+                const next = Object.assign({}, tracks);
+                next[role] = {
+                    "nodeId": nodeId,
+                    "generation": generation
+                };
+                tracks = next;
+                return true;
+            }
+
+            function untrack(role, generation) {
+                if (tracks[role] !== undefined && tracks[role].generation === generation) {
+                    const next = Object.assign({}, tracks);
+                    delete next[role];
+                    tracks = next;
+                }
+                return true;
+            }
+
+            function setVolume(role, nodeId, generation, requestId, value, finalValue) {
+                volumeWrites = volumeWrites.concat([
+                                                       {
+                                                           "role": role,
+                                                           "nodeId": nodeId,
+                                                           "generation": generation,
+                                                           "requestId": requestId,
+                                                           "value": value,
+                                                           "final": finalValue
+                                                       }
+                                                   ]);
+                return true;
+            }
+
+            function setMute(role, nodeId, generation, requestId, muted) {
+                muteWrites = muteWrites.concat([
+                                                   {
+                                                       "role": role,
+                                                       "nodeId": nodeId,
+                                                       "generation": generation,
+                                                       "requestId": requestId,
+                                                       "muted": muted
+                                                   }
+                                               ]);
+                return true;
+            }
+
+            function confirmTracked(role, volume, muted) {
+                const track = tracks[role];
+                test.require(track !== undefined, "bridge role is tracked before confirmation");
+                stateConfirmed(role, track.nodeId, track.generation, 0, "external", volume, muted);
+            }
+
+            function confirmLastVolume(volume, muted) {
+                test.require(volumeWrites.length > 0, "volume request exists before confirmation");
+                const write = volumeWrites[volumeWrites.length - 1];
+                stateConfirmed(write.role, write.nodeId, write.generation, write.requestId, "volume",
+                               volume, muted);
+            }
+
+            function confirmLastMute(volume, muted) {
+                test.require(muteWrites.length > 0, "mute request exists before confirmation");
+                const write = muteWrites[muteWrites.length - 1];
+                stateConfirmed(write.role, write.nodeId, write.generation, write.requestId, "mute",
+                               volume, muted);
+            }
+        }
+    }
+
+    Component {
+        id: adapterFactory
+
+        AudioAdapter {}
+    }
+
+    Component.onCompleted: Qt.callLater(run)
+
+    function run() {
+        console.warn("audio: synchronization and discovery");
+        const bundle = makeBundle();
+        const outputAudio = own(bundle, makeAudio(1.25, false, [0.5, 1.0]));
+        const inputAudio = own(bundle, makeAudio(0.4, false, [0.4]));
+        const virtualAudio = own(bundle, makeAudio(0.62, false, [0.62, 0.62]));
+        const otherAudio = own(bundle, makeAudio(0.8, false, [0.8, 0.8]));
+        const streamAudio = own(bundle, makeAudio(0.3, false, [0.3, 0.3]));
+        const physical = own(bundle, makeNode({
+                                                  "pipewireId": 10,
+                                                  "name": "alsa_output.main",
+                                                  "description": "  Main\u0001   Output  ",
+                                                  "nickname": "Main",
+                                                  "ready": false,
+                                                  "isSink": true,
+                                                  "audio": outputAudio
+                                              }));
+        const virtual = own(bundle, makeNode({
+                                                 "pipewireId": 20,
+                                                 "name": "easyeffects_sink",
+                                                 "description": "EasyEffects Sink",
+                                                 "ready": false,
+                                                 "isSink": true,
+                                                 "audio": virtualAudio
+                                             }));
+        const other = own(bundle, makeNode({
+                                               "pipewireId": 30,
+                                               "name": "hdmi_output",
+                                               "description": "HDMI Output",
+                                               "ready": false,
+                                               "isSink": true,
+                                               "audio": otherAudio
+                                           }));
+        const source = own(bundle, makeNode({
+                                                "pipewireId": 40,
+                                                "name": "alsa_input.main",
+                                                "nickname": "Desk Microphone",
+                                                "ready": false,
+                                                "isSink": false,
+                                                "audio": inputAudio
+                                            }));
+        const stream = own(bundle, makeNode({
+                                                "pipewireId": 50,
+                                                "name": "application.stream",
+                                                "description": "Application Stream",
+                                                "ready": true,
+                                                "isStream": true,
+                                                "isSink": true,
+                                                "audio": streamAudio
+                                            }));
+
+        require(!bundle.adapter.available && bundle.adapter.syncState === "unavailable"
+                && bundle.adapter.failure === "unavailable",
+                "cold unavailable PipeWire publishes no writable state");
+        apply(bundle, () => {
+            bundle.model.values = [stream, virtual, source, other, physical];
+            bundle.service.defaultAudioSink = physical;
+            bundle.service.defaultAudioSource = source;
+            bundle.service.ready = true;
+        });
+        require(bundle.adapter.isSynchronized && bundle.adapter.syncState === "tracking",
+                "PipeWire readiness precedes tracked-default readiness");
+        require(!bundle.adapter.outputAvailable && !bundle.adapter.inputAvailable,
+                "unready defaults publish no audio values");
+        require(bundle.adapter.trackedObjectCount === 2,
+                "one tracker contains only the default sink and source");
+        require(bundle.adapter.outputCandidates.length === 3,
+                "unbound discovery includes all non-stream sinks and excludes source and stream");
+        require(bundle.adapter.outputCandidates[0].label === "Main Output"
+                && bundle.adapter.outputCandidates[0].isDefault,
+                "confirmed default sorts first and its label is normalized");
+        require(bundle.adapter.outputCandidates[1].label === "EasyEffects Sink"
+                && bundle.adapter.outputCandidates[2].label === "HDMI Output",
+                "remaining outputs sort by normalized label");
+        require(bundle.adapter.outputCandidates[0].node === undefined,
+                "candidate contract exposes no backend node");
+
+        bundle.bridge.ready = false;
+        require(!bundle.adapter.available && bundle.adapter.syncState === "tracking"
+                && bundle.adapter.failure === "bridge-unavailable",
+                "confirmation bridge loss disables controls without dropping graph discovery");
+        bundle.bridge.ready = true;
+        require(bundle.adapter.confirmationBridgeReady && bundle.adapter.syncState === "tracking",
+                "confirmation bridge recovery reacquires tracked defaults");
+
+        apply(bundle, () => {
+            bundle.service.defaultAudioSink = stream;
+        });
+        require(!bundle.adapter.outputAvailable && bundle.adapter.failure === "invalid-default",
+                "application streams are never published even if reported as a default sink");
+        apply(bundle, () => {
+            bundle.service.defaultAudioSink = physical;
+        });
+
+        apply(bundle, () => {
+            physical.ready = true;
+            source.ready = true;
+        });
+        require(bundle.adapter.syncState === "tracking" && !bundle.adapter.outputAvailable &&
+                !bundle.adapter.inputAvailable,
+                "tracked defaults wait for independent server readback");
+        bundle.bridge.confirmTracked("output", 1.25, false);
+        bundle.bridge.confirmTracked("input", 0.4, false);
+        require(bundle.adapter.syncState === "ready" && bundle.adapter.outputAvailable
+                && bundle.adapter.inputAvailable, "tracked ready defaults publish atomically");
+        require(bundle.adapter.outputLabel === "Main Output" && bundle.adapter.inputLabel
+                === "Desk Microphone", "description, nickname, then name derive bounded labels");
+        require(bundle.adapter.outputVolume === 1 && bundle.adapter.outputOveramplified &&
+                !bundle.adapter.outputMuted,
+                "external amplification is clamped and represented separately");
+        require(near(bundle.adapter.inputVolume, 0.4) && !bundle.adapter.inputOveramplified,
+                "input state is normalized independently");
+        require(bundle.capture.outputChanges.length === 0 && bundle.capture.inputChanges.length
+                === 0, "initial synchronized publication does not replay a transient");
+
+        console.warn("audio: confirmed external changes");
+        outputAudio.volume = 0.73;
+        require(bundle.adapter.outputVolume === 1,
+                "Quickshell's optimistic cache never publishes as confirmed state");
+        bundle.bridge.confirmTracked("output", 0.73, false);
+        require(near(bundle.adapter.outputVolume, 0.73) && !bundle.adapter.outputOveramplified
+                && bundle.capture.outputChanges.length === 1,
+                "external output volume publishes immediately from server readback");
+        outputAudio.muted = true;
+        require(!bundle.adapter.outputMuted,
+                "Quickshell's optimistic mute never publishes as confirmed state");
+        bundle.bridge.confirmTracked("output", 0.73, true);
+        require(bundle.adapter.outputMuted && bundle.capture.outputChanges.length === 2,
+                "external output mute publishes immediately from server readback");
+        inputAudio.volume = 1.4;
+        bundle.bridge.confirmTracked("input", 1.4, false);
+        require(bundle.adapter.inputVolume === 1 && bundle.adapter.inputOveramplified
+                && bundle.capture.inputChanges.length === 1,
+                "input amplification remains a confirmed input-only event");
+        const latest = bundle.capture.outputChanges[bundle.capture.outputChanges.length - 1];
+        const resolved = bundle.adapter.resolveConfirmedOutput(latest.token, latest.generation,
+                                                               latest.revision);
+        require(resolved !== null && resolved.label === "Main Output" && resolved.muted,
+                "opaque latest output revision resolves to normalized presentation");
+        require(bundle.adapter.resolveConfirmedOutput(latest.token, latest.generation,
+                                                      latest.revision - 1) === null,
+                "superseded backend revisions cannot resolve newer content");
+
+        console.warn("audio: requested controls and coalescing");
+        const channelSnapshot = outputAudio.volumes.slice();
+        require(bundle.adapter.requestOutputVolume(0.2, false) && bundle.adapter.requestOutputVolume(
+                    0.3, false) && bundle.adapter.requestOutputVolume(0.4, false),
+                "rapid slider writes are accepted");
+        require(bundle.bridge.volumeWrites.length === 0 && bundle.adapter.queuedVolumeWriteCount
+                === 1 && bundle.adapter.pendingOutputVolume,
+                "rapid writes occupy one last-write-wins slot with no queue");
+        bundle.adapter.processPendingVolumeWrites();
+        require(bundle.bridge.volumeWrites.length === 1 && near(bundle.bridge.volumeWrites[0].value,
+                                                                0.4), "coalesced dispatch writes only the latest value");
+        require(outputAudio.volumes[0] === channelSnapshot[0] && outputAudio.volumes[1]
+                === channelSnapshot[1], "adapter never replaces individual channel volumes");
+        require(near(bundle.adapter.outputVolume, 0.73),
+                "requested volume is not published optimistically");
+        bundle.bridge.confirmLastVolume(0.39, true);
+        require(!bundle.adapter.pendingOutputVolume && near(bundle.adapter.outputVolume, 0.39),
+                "backend minimum-step result clears pending and remains authoritative");
+        require(bundle.adapter.requestOutputVolume(1.8, true) && bundle.bridge.volumeWrites.length
+                === 2 && bundle.bridge.volumeWrites[1].value === 1,
+                "final release dispatches immediately and cannot create amplification");
+        bundle.bridge.confirmLastVolume(1, true);
+        require(bundle.adapter.requestOutputVolume(-1, true)
+                && bundle.bridge.volumeWrites[bundle.bridge.volumeWrites.length - 1].value === 0,
+                "negative requests are bounded before dispatch");
+        bundle.bridge.confirmLastVolume(0, true);
+        require(!bundle.adapter.requestOutputVolume(Number.NaN, true) && bundle.adapter.failure === "invalid-request",
+                "non-finite volume is rejected at the adapter boundary");
+        bundle.adapter.failureDeadlineReached();
+
+        require(bundle.adapter.requestOutputMute(false) && bundle.adapter.pendingOutputMute
+                && bundle.bridge.muteWrites.length === 1 && bundle.adapter.outputMuted,
+                "mute remains pending without optimistic publication");
+        bundle.bridge.confirmLastMute(0, false);
+        require(!bundle.adapter.pendingOutputMute && !bundle.adapter.outputMuted,
+                "confirmed mute clears pending");
+        require(bundle.adapter.requestInputVolume(0.25, true)
+                && bundle.bridge.volumeWrites[bundle.bridge.volumeWrites.length - 1].role
+                === "input", "input volume uses the same bounded average-volume contract");
+        bundle.bridge.confirmLastVolume(0.24, false);
+        require(!bundle.adapter.pendingInputVolume && near(bundle.adapter.inputVolume, 0.24),
+                "input minimum-step confirmation clears pending");
+        require(bundle.adapter.requestInputMute(true) && bundle.adapter.pendingInputMute,
+                "input mute request is tracked independently");
+        bundle.bridge.confirmLastMute(0.24, true);
+        require(!bundle.adapter.pendingInputMute && bundle.adapter.inputMuted,
+                "input mute publishes only the confirmed result");
+        require(bundle.adapter.requestOutputVolume(0.5, true) && bundle.adapter.pendingOutputVolume,
+                "unconfirmed output request remains pending");
+        bundle.adapter.volumeDeadlineReached("output");
+        require(!bundle.adapter.pendingOutputVolume && bundle.adapter.failure === "timeout",
+                "bounded request timeout clears pending state");
+        bundle.adapter.failureDeadlineReached();
+
+        console.warn("audio: preferred versus confirmed output");
+        virtual.ready = true;
+        other.ready = true;
+        bundle.adapter.processPendingChanges();
+        const virtualCandidate = candidate(bundle, "EasyEffects Sink");
+        const physicalCandidate = candidate(bundle, "Main Output");
+        const otherCandidate = candidate(bundle, "HDMI Output");
+        require(virtualCandidate !== null && physicalCandidate !== null && otherCandidate !== null,
+                "physical and virtual candidate keys remain available");
+        require(bundle.adapter.requestOutputSelection(virtualCandidate.endpointKey)
+                && bundle.adapter.pendingOutputSelection && bundle.capture.preferredWrites.length
+                === 1 && bundle.capture.preferredWrites[0].node === virtual,
+                "selection writes the live candidate as the preferred sink");
+        require(bundle.adapter.outputLabel === "Main Output",
+                "preferred output never replaces the confirmed displayed truth");
+        apply(bundle, () => {
+            bundle.service.defaultAudioSink = virtual;
+        });
+        bundle.bridge.confirmTracked("output", virtualAudio.volume, virtualAudio.muted);
+        require(!bundle.adapter.pendingOutputSelection && bundle.adapter.outputLabel
+                === "EasyEffects Sink", "selection succeeds only after confirmed default matches");
+
+        require(bundle.adapter.requestOutputSelection(physicalCandidate.endpointKey),
+                "second selection request is accepted");
+        apply(bundle, () => {
+            bundle.service.defaultAudioSink = other;
+        });
+        bundle.bridge.confirmTracked("output", otherAudio.volume, otherAudio.muted);
+        require(!bundle.adapter.pendingOutputSelection && bundle.adapter.failure === "diverged"
+                && bundle.adapter.outputLabel === "HDMI Output",
+                "divergent confirmed default fails selection without stale target labels");
+        bundle.adapter.failureDeadlineReached();
+
+        require(bundle.adapter.requestOutputSelection(physicalCandidate.endpointKey),
+                "rejection scenario starts pending");
+        bundle.service.preferredDefaultAudioSink = virtual;
+        require(!bundle.adapter.pendingOutputSelection && bundle.adapter.failure === "rejected",
+                "divergent preferred default is rejected");
+        bundle.adapter.failureDeadlineReached();
+
+        require(bundle.adapter.requestOutputSelection(physicalCandidate.endpointKey),
+                "removal scenario starts pending");
+        apply(bundle, () => {
+            bundle.model.values = [stream, virtual, source, other];
+        });
+        require(!bundle.adapter.pendingOutputSelection && bundle.adapter.failure === "removed",
+                "removed target clears pending state");
+        bundle.adapter.failureDeadlineReached();
+        require(bundle.adapter.requestOutputSelection(virtualCandidate.endpointKey),
+                "timeout scenario starts pending");
+        bundle.adapter.selectionDeadlineReached();
+        require(!bundle.adapter.pendingOutputSelection && bundle.adapter.failure === "timeout",
+                "selection timeout is bounded");
+        bundle.adapter.failureDeadlineReached();
+
+        console.warn("audio: nullable defaults and graph replacement");
+        const oldGeneration = bundle.adapter.outputGeneration;
+        const oldKey = bundle.adapter.outputEndpointKey;
+        const oldSourceToken = bundle.adapter.outputSourceToken;
+        const oldLabel = bundle.adapter.outputLabel;
+        apply(bundle, () => {
+            bundle.service.defaultAudioSink = null;
+        });
+        require(!bundle.adapter.outputAvailable && bundle.adapter.outputEndpointKey === ""
+                && bundle.adapter.outputDisplayLabel === oldLabel,
+                "brief null default disables controls and preserves only presentation label");
+        require(!bundle.adapter.requestOutputVolume(0.4, true),
+                "brief null default rejects writes without claiming the old node");
+        bundle.adapter.refreshLabelDeadlineReached("output");
+        require(bundle.adapter.outputDisplayLabel === "",
+                "short-refresh label expires at its bounded deadline");
+
+        const replacementAudio = own(bundle, makeAudio(0.66, false, [0.5, 0.82]));
+        const replacement = own(bundle, makeNode({
+                                                     "pipewireId": 30,
+                                                     "name": "hdmi_output",
+                                                     "description": "HDMI Output",
+                                                     "ready": true,
+                                                     "isSink": true,
+                                                     "audio": replacementAudio
+                                                 }));
+        apply(bundle, () => {
+            bundle.model.values = [stream, virtual, source, replacement];
+            bundle.service.defaultAudioSink = replacement;
+        });
+        bundle.bridge.confirmTracked("output", replacementAudio.volume, replacementAudio.muted);
+        require(bundle.adapter.outputAvailable && bundle.adapter.outputGeneration > oldGeneration
+                && bundle.adapter.outputEndpointKey === oldKey,
+                "reacquired QObject gets a new generation even when role, name, and session ID match");
+        require(bundle.adapter.outputSourceToken !== oldSourceToken,
+                "reconnect matching never reuses the old live source generation");
+
+        const changesBeforeFatal = bundle.capture.outputChanges.length;
+        apply(bundle, () => {
+            bundle.service.ready = false;
+        });
+        require(!bundle.adapter.available && bundle.adapter.syncState === "unavailable"
+                && bundle.adapter.trackedObjectCount === 0
+                && bundle.adapter.outputCandidates.length === 0,
+                "fatal graph loss discards tracked QObjects, candidates, and writable state");
+        require(bundle.adapter.outputGeneration === 0 && bundle.adapter.outputEndpointKey === "",
+                "fatal graph loss discards old session IDs and generations");
+        apply(bundle, () => {
+            bundle.service.ready = true;
+        });
+        bundle.bridge.confirmTracked("output", replacementAudio.volume, replacementAudio.muted);
+        bundle.bridge.confirmTracked("input", inputAudio.volume, inputAudio.muted);
+        require(bundle.adapter.outputAvailable && bundle.adapter.outputGeneration > oldGeneration
+                && bundle.capture.outputChanges.length === changesBeforeFatal,
+                "fatal recovery reacquires defaults without replaying initial confirmed state");
+
+        destroyBundle(bundle);
+        console.warn("audio tests passed");
+        Qt.exit(0);
+    }
+}

--- a/tests/pipewire_audio_protocol_test.cpp
+++ b/tests/pipewire_audio_protocol_test.cpp
@@ -1,0 +1,68 @@
+#include "protocol.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+void require(bool condition, const char *message)
+{
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        std::exit(1);
+    }
+}
+
+} // namespace
+
+int main()
+{
+    using nagi::audio::Operation;
+    using nagi::audio::Role;
+    using nagi::audio::parseCommand;
+
+    const auto track = parseCommand(
+        R"({"op":"track","role":"output","nodeId":42,"generation":7})");
+    require(
+        track && track->operation == Operation::Track && track->role == Role::Output
+            && track->nodeId == 42 && track->generation == 7,
+        "valid track command parses");
+
+    const auto volume = parseCommand(
+        R"({"op":"setVolume","role":"input","nodeId":9,"generation":3,"requestId":11,"value":0.75,"final":true})");
+    require(
+        volume && volume->operation == Operation::SetVolume && volume->role == Role::Input
+            && volume->nodeId == 9 && volume->generation == 3 && volume->requestId == 11
+            && volume->volume == 0.75 && volume->final,
+        "valid volume command parses");
+
+    const auto mute = parseCommand(
+        R"({"op":"setMute","role":"output","nodeId":4,"generation":2,"requestId":8,"muted":false})");
+    require(
+        mute && mute->operation == Operation::SetMute && !mute->muted,
+        "valid mute command parses");
+
+    require(
+        !parseCommand(
+            R"({"op":"setVolume","role":"output","nodeId":4,"generation":2,"requestId":8,"value":1.01,"final":false})"),
+        "amplified volume command is rejected");
+    require(
+        !parseCommand(
+            R"({"op":"setMute","role":"output","nodeId":4,"generation":2,"requestId":8,"muted":true,"extra":1})"),
+        "unexpected command fields are rejected");
+    require(
+        !parseCommand(
+            R"({"op":"track","role":"stream","nodeId":4,"generation":2})"),
+        "unknown roles are rejected");
+    require(
+        !parseCommand(
+            R"({"op":"track","role":"output","nodeId":4,"generation":0})"),
+        "zero generations are rejected");
+    require(!parseCommand("not-json"), "malformed JSON is rejected");
+    require(
+        !parseCommand(QByteArray(nagi::audio::MaximumCommandBytes + 1, 'x')),
+        "oversized commands are rejected");
+
+    std::puts("pipewire audio protocol tests passed");
+    return 0;
+}

--- a/tests/pipewire_audio_volume_test.cpp
+++ b/tests/pipewire_audio_volume_test.cpp
@@ -1,0 +1,54 @@
+#include "volume.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const char *message)
+{
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        std::exit(1);
+    }
+}
+
+bool near(double left, double right)
+{
+    return std::abs(left - right) < 0.000001;
+}
+
+} // namespace
+
+int main()
+{
+    const auto unequal = nagi::audio::proportionalCubicVolumes({0.5F, 1.0F}, 0.6);
+    require(unequal && unequal->size() == 2, "unequal channels scale");
+    const double left = std::cbrt((*unequal)[0]);
+    const double right = std::cbrt((*unequal)[1]);
+    require(near((left + right) / 2.0, 0.6), "scaled average matches target");
+    require(near(right / left, 2.0), "channel proportion is preserved");
+
+    const auto silent = nagi::audio::proportionalCubicVolumes({0.0F, 0.0F}, 0.5);
+    require(
+        silent && near((*silent)[0], 0.125) && near((*silent)[1], 0.125),
+        "silent channels receive the requested average equally");
+
+    require(
+        !nagi::audio::proportionalCubicVolumes({}, 0.5),
+        "empty channel state is rejected");
+    require(
+        !nagi::audio::proportionalCubicVolumes({0.5F}, 1.01),
+        "amplified Nagi target is rejected");
+    require(
+        !nagi::audio::proportionalCubicVolumes({-0.1F, 0.5F}, 0.4),
+        "invalid confirmed channel state is rejected");
+    require(
+        !nagi::audio::proportionalCubicVolumes(std::vector<float>(65, 0.5F), 0.4),
+        "channel state is bounded");
+
+    std::puts("pipewire audio volume tests passed");
+    return 0;
+}


### PR DESCRIPTION
Use a bounded native bridge for server-confirmed volume and mute state because Quickshell exposes optimistic setter updates.

Closes #22