### PR TITLE
feat(applications): add pinning and recency

### DIFF
--- a/.github/actions/install-toolchain/action.yml
+++ b/.github/actions/install-toolchain/action.yml
@@ -1,7 +1,7 @@
 name: 'Install Fedora 44 toolchain'
 description: >-
-  Installs the pinned Fedora 44 CI toolchain: native Qt and PipeWire build
-  dependencies, QML tools, and Quickshell from the stable COPR.
+  Installs the pinned Fedora 44 CI toolchain: native Qt, PipeWire, and GIO
+  development dependencies, QML tools, and Quickshell from the stable COPR.
 runs:
   using: composite
   steps:
@@ -15,6 +15,7 @@ runs:
         gcc-c++
         pkgconf-pkg-config
         pipewire-devel
+        glib2-devel
         qt6-qtbase-devel
         qt6-qtdeclarative-devel
         dbus-daemon

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ CONNECTIVITY_HELPER := $(BUILD_DIR)/nagi-connectivity
 CONNECTIVITY_MOC := $(BUILD_DIR)/connectivity/main.moc
 CONNECTIVITY_DBUS_TEST := $(BUILD_DIR)/connectivity-dbus-test
 CONNECTIVITY_DBUS_TEST_MOC := $(BUILD_DIR)/connectivity_dbus_test.moc
+APPLICATION_HELPER := $(BUILD_DIR)/nagi-applications
 CONNECTIVITY_TEST_DIR := $(BUILD_DIR)/connectivity-test
 CONNECTIVITY_LIVE_WRITE_TEST_DIR := $(BUILD_DIR)/connectivity-live-write-test
 COORDINATOR_TEST_DIR := $(BUILD_DIR)/coordinator-test
@@ -33,14 +34,19 @@ AUDIO_LIVE_WRITE_TEST_DIR := $(BUILD_DIR)/audio-live-write-test
 SURFACE_STATE_TEST_DIR := $(BUILD_DIR)/surface-state-test
 UI_PRIMITIVES_TEST_DIR := $(BUILD_DIR)/ui-primitives-test
 IDLE_TEST_DIR := $(BUILD_DIR)/idle-test
+APPLICATION_TEST := $(BUILD_DIR)/applications-helper-test
+APPLICATION_QML_TEST_DIR := $(BUILD_DIR)/applications-test
 HELPER_SOURCES := src/kwin-virtual-desktops/main.cpp src/kwin-virtual-desktops/desktop_snapshot.cpp
 HELPER_HEADERS := src/kwin-virtual-desktops/desktop_snapshot.h
 AUDIO_HELPER_SOURCES := src/pipewire-audio/main.cpp src/pipewire-audio/protocol.cpp src/pipewire-audio/volume.cpp
 AUDIO_HELPER_HEADERS := src/pipewire-audio/protocol.h src/pipewire-audio/volume.h
+APPLICATION_HELPER_SOURCE := src/applications/main.cpp
 QT_CFLAGS := $(shell $(PKG_CONFIG) --cflags Qt6Core Qt6DBus)
 QT_LIBS := $(shell $(PKG_CONFIG) --libs Qt6Core Qt6DBus)
 PIPEWIRE_CFLAGS := $(shell $(PKG_CONFIG) --cflags libpipewire-0.3)
 PIPEWIRE_LIBS := $(shell $(PKG_CONFIG) --libs libpipewire-0.3)
+GIO_CFLAGS := $(shell $(PKG_CONFIG) --cflags gio-unix-2.0)
+GIO_LIBS := $(shell $(PKG_CONFIG) --libs gio-unix-2.0)
 NATIVE_CXXFLAGS := -std=c++20 -O2 -Wall -Wextra -Wpedantic
 AUDIO_NATIVE_CXXFLAGS := -std=gnu++20 -O2 -Wall -Wextra -Wno-sfinae-incomplete
 
@@ -50,7 +56,7 @@ QUICKSHELL_CHANNEL := stable
 FEDORA_QUICKSHELL_COPR := errornointernet/quickshell
 FEDORA_QUICKSHELL_PACKAGE := quickshell
 
-.PHONY: help requirements prepare check-quickshell check-helper-toolchain check-audio-toolchain helper audio-helper connectivity-helper test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-adapter test-coordinator test-weather test-media test-audio test-audio-live test-audio-live-write test-connectivity test-connectivity-live-write test-idle test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
+.PHONY: help requirements prepare check-quickshell check-helper-toolchain check-audio-toolchain check-application-toolchain helper audio-helper connectivity-helper application-helper test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-applications test-adapter test-coordinator test-weather test-media test-audio test-audio-live test-audio-live-write test-connectivity test-connectivity-live-write test-idle test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
 
 help:
 	@printf '%s\n' \
@@ -58,11 +64,13 @@ help:
 		'make helper          Build the KWin virtual desktop helper' \
 		'make audio-helper    Build the confirmed PipeWire audio bridge' \
 		'make connectivity-helper  Build the Wi-Fi and Bluetooth bridge' \
+		'make application-helper  Build desktop-entry and persistence bridge' \
 		'make test-native     Test KWin tuple normalization' \
 		'make test-owner-lifecycle  Test KWin owner loss and replacement' \
 		'make test-audio-protocol  Test the audio bridge command boundary' \
 		'make test-audio-volume  Test proportional average-volume writes' \
 		'make test-connectivity-dbus  Test D-Bus state, denial, and lifecycle' \
+		'make test-applications  Test desktop discovery and persistence bridge' \
 		'make test-adapter    Test the QML adapter boundary' \
 		'make test-coordinator  Test island ownership and restoration' \
 		'make test-surface-state  Exercise coordinator in the actual island surface' \
@@ -90,11 +98,12 @@ help:
 requirements:
 	@printf 'Quickshell >= %s from the %s release channel\n' '$(QUICKSHELL_MIN_VERSION)' '$(QUICKSHELL_CHANNEL)'
 	@printf 'Fedora 44 source: COPR %s, package %s (never quickshell-git)\n' '$(FEDORA_QUICKSHELL_COPR)' '$(FEDORA_QUICKSHELL_PACKAGE)'
-	@printf 'Install: sudo dnf copr enable %s && sudo dnf install %s pipewire-devel\n' '$(FEDORA_QUICKSHELL_COPR)' '$(FEDORA_QUICKSHELL_PACKAGE)'
-	@printf 'Native builds: C++20, Qt 6 Core/DBus, and libpipewire 0.3 development files\n'
+	@printf 'Install: sudo dnf copr enable %s && sudo dnf install %s pipewire-devel glib2-devel\n' '$(FEDORA_QUICKSHELL_COPR)' '$(FEDORA_QUICKSHELL_PACKAGE)'
+	@printf 'Native builds: C++20, Qt 6 Core/DBus, libpipewire 0.3, and GIO Unix development files\n'
 	@$(MAKE) --no-print-directory check-quickshell
 	@$(MAKE) --no-print-directory check-helper-toolchain
 	@$(MAKE) --no-print-directory check-audio-toolchain
+	@$(MAKE) --no-print-directory check-application-toolchain
 
 prepare:
 	@touch .qmlls.ini
@@ -105,6 +114,9 @@ check-helper-toolchain:
 
 check-audio-toolchain:
 	@$(PKG_CONFIG) --exists Qt6Core libpipewire-0.3
+
+check-application-toolchain:
+	@$(PKG_CONFIG) --exists Qt6Core gio-unix-2.0
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
@@ -146,11 +158,36 @@ $(CONNECTIVITY_HELPER): src/connectivity/main.cpp $(CONNECTIVITY_MOC) | $(BUILD_
 $(CONNECTIVITY_DBUS_TEST): tests/connectivity_dbus_test.cpp $(CONNECTIVITY_DBUS_TEST_MOC) | $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(QT_CFLAGS) -I$(BUILD_DIR) tests/connectivity_dbus_test.cpp -o $@ $(LDFLAGS) $(QT_LIBS)
 
+$(APPLICATION_HELPER): $(APPLICATION_HELPER_SOURCE) | $(BUILD_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(QT_CFLAGS) $(GIO_CFLAGS) $(APPLICATION_HELPER_SOURCE) -o $@ $(LDFLAGS) $(QT_LIBS) $(GIO_LIBS)
+
+$(APPLICATION_TEST): tests/applications_helper_test.cpp | $(BUILD_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(QT_CFLAGS) tests/applications_helper_test.cpp -o $@ $(LDFLAGS) $(QT_LIBS)
+
 helper: check-helper-toolchain $(HELPER)
 
 audio-helper: check-audio-toolchain $(AUDIO_HELPER)
 
 connectivity-helper: check-helper-toolchain $(CONNECTIVITY_HELPER)
+
+application-helper: check-application-toolchain $(APPLICATION_HELPER)
+
+test-applications: check-application-toolchain $(APPLICATION_HELPER) $(APPLICATION_TEST)
+	$(APPLICATION_TEST) $(abspath $(APPLICATION_HELPER))
+	rm -rf $(APPLICATION_QML_TEST_DIR)
+	mkdir -p $(APPLICATION_QML_TEST_DIR)/qml $(APPLICATION_QML_TEST_DIR)/empty-data
+	cp -R tests/applications/fixtures/. $(APPLICATION_QML_TEST_DIR)/
+	chmod 0700 $(APPLICATION_QML_TEST_DIR)/config/nagi-shell $(APPLICATION_QML_TEST_DIR)/state/nagi-shell
+	chmod 0600 $(APPLICATION_QML_TEST_DIR)/config/nagi-shell/application-pins.json $(APPLICATION_QML_TEST_DIR)/state/nagi-shell/application-recency.json
+	cp tests/applications/shell.qml $(APPLICATION_QML_TEST_DIR)/shell.qml
+	cp qml/ApplicationModel.qml qml/ApplicationBridge.qml $(APPLICATION_QML_TEST_DIR)/qml/
+	XDG_DATA_HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/data' XDG_DATA_DIRS='$(abspath $(APPLICATION_QML_TEST_DIR))/empty-data' XDG_CONFIG_HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/config' XDG_STATE_HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/state' HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/home' XDG_CURRENT_DESKTOP='KDE' NAGI_APPLICATION_HELPER='$(abspath $(APPLICATION_HELPER))' NAGI_APPLICATION_TEST_PHASE='mutate' $(QS) -p $(APPLICATION_QML_TEST_DIR) --no-duplicate
+	XDG_DATA_HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/data' XDG_DATA_DIRS='$(abspath $(APPLICATION_QML_TEST_DIR))/empty-data' XDG_CONFIG_HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/config' XDG_STATE_HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/state' HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/home' XDG_CURRENT_DESKTOP='KDE' NAGI_APPLICATION_HELPER='$(abspath $(APPLICATION_HELPER))' NAGI_APPLICATION_TEST_PHASE='restart' $(QS) -p $(APPLICATION_QML_TEST_DIR) --no-duplicate
+	chmod 0644 $(APPLICATION_QML_TEST_DIR)/config/nagi-shell/application-pins.json
+	XDG_DATA_HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/data' XDG_DATA_DIRS='$(abspath $(APPLICATION_QML_TEST_DIR))/empty-data' XDG_CONFIG_HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/config' XDG_STATE_HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/state' HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/home' XDG_CURRENT_DESKTOP='KDE' NAGI_APPLICATION_HELPER='$(abspath $(APPLICATION_HELPER))' NAGI_APPLICATION_TEST_PHASE='unsafe' $(QS) -p $(APPLICATION_QML_TEST_DIR) --no-duplicate
+	rm -rf $(APPLICATION_QML_TEST_DIR)/default-home
+	mkdir -p $(APPLICATION_QML_TEST_DIR)/default-home
+	XDG_DATA_HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/data' XDG_DATA_DIRS='$(abspath $(APPLICATION_QML_TEST_DIR))/empty-data' XDG_CONFIG_HOME='relative-config' XDG_STATE_HOME='relative-state' HOME='$(abspath $(APPLICATION_QML_TEST_DIR))/default-home' XDG_CURRENT_DESKTOP='KDE' NAGI_APPLICATION_HELPER='$(abspath $(APPLICATION_HELPER))' NAGI_APPLICATION_TEST_PHASE='defaults' $(QS) -p $(APPLICATION_QML_TEST_DIR) --no-duplicate
 
 test-native: check-helper-toolchain $(HELPER_TEST)
 	$(HELPER_TEST)
@@ -255,10 +292,10 @@ check-quickshell:
 	fi; \
 	printf 'Quickshell %s satisfies the >= %s requirement.\n' "$$version" '$(QUICKSHELL_MIN_VERSION)'
 
-launch: check-quickshell prepare helper audio-helper connectivity-helper
+launch: check-quickshell prepare helper audio-helper connectivity-helper application-helper
 	$(QS) -p . --no-duplicate
 
-diagnose: check-quickshell prepare helper audio-helper connectivity-helper
+diagnose: check-quickshell prepare helper audio-helper connectivity-helper application-helper
 	$(QS) -p . --no-duplicate -vv --log-times
 
 instances:
@@ -305,6 +342,6 @@ lint-advisory:
 
 check: check-nondisplay test-surface-state test-ui-primitives
 
-check-nondisplay: check-quickshell format-check audio-helper connectivity-helper test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-adapter test-coordinator test-weather test-media test-audio test-connectivity test-idle
+check-nondisplay: check-quickshell format-check audio-helper connectivity-helper application-helper test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-applications test-adapter test-coordinator test-weather test-media test-audio test-connectivity test-idle
 clean:
 	rm -rf $(BUILD_DIR)

--- a/qml/ApplicationBridge.qml
+++ b/qml/ApplicationBridge.qml
@@ -1,0 +1,272 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+Scope {
+    id: root
+
+    required property string helperPath
+    required property string pinsPath
+    required property string recencyPath
+    property bool enabled: true
+
+    readonly property bool ready: state.ready
+    readonly property int maximumLineLength: 20 * 1024 * 1024
+    readonly property int maximumCommandLength: 8192
+    readonly property int maximumDiagnostics: 4
+
+    signal initialized(var stores)
+    signal generationReceived(var generation)
+    signal writeReady(string store, int serial, bool success, string category)
+    signal writeVerified(string store, int serial, bool success, string category)
+    signal fatalFailure
+
+    function scan(generation) {
+        return send({
+                        "op": "scan",
+                        "generation": generation
+                    });
+    }
+
+    function prepareWrite(store, serial) {
+        return send({
+                        "op": "prepare-write",
+                        "store": store,
+                        "serial": serial
+                    });
+    }
+
+    function verifyWrite(store, serial) {
+        return send({
+                        "op": "verify-write",
+                        "store": store,
+                        "serial": serial
+                    });
+    }
+
+    function send(command) {
+        if (!state.ready || !helper.running) {
+            return false;
+        }
+        const line = JSON.stringify(command);
+        if (line.length === 0 || line.length > root.maximumCommandLength) {
+            return false;
+        }
+        helper.write(line + "\n");
+        return true;
+    }
+
+    function acceptLine(line) {
+        if (typeof line !== "string" || line.length === 0 || line.length > root.maximumLineLength) {
+            warnBounded("invalid helper line length");
+            return;
+        }
+
+        let message;
+        try {
+            message = JSON.parse(line);
+        } catch (error) {
+            warnBounded("malformed helper line");
+            return;
+        }
+        if (message === null || typeof message !== "object" || Array.isArray(message)
+                || typeof message.type !== "string") {
+            warnBounded("invalid helper message");
+            return;
+        }
+
+        if (message.type === "initialized") {
+            if (!validStores(message.stores)) {
+                warnBounded("invalid initialization");
+                return;
+            }
+            state.ready = true;
+            state.restartAttempts = 0;
+            root.initialized(message.stores);
+            return;
+        }
+        if (message.type === "generation") {
+            if (!validGeneration(message)) {
+                warnBounded("invalid discovery generation");
+                return;
+            }
+            root.generationReceived(message);
+            return;
+        }
+        if (message.type === "write-ready" || message.type === "write-verified") {
+            if (!validWriteResponse(message)) {
+                warnBounded("invalid write response");
+                return;
+            }
+            if (message.type === "write-ready") {
+                root.writeReady(message.store, message.serial, message.success, message.category);
+            } else {
+                root.writeVerified(message.store, message.serial, message.success,
+                                   message.category);
+            }
+            return;
+        }
+        if (message.type === "error") {
+            warnBounded("helper protocol failure");
+            return;
+        }
+        warnBounded("unknown helper message");
+    }
+
+    function validStores(stores) {
+        return stores !== null && typeof stores === "object" && !Array.isArray(stores) && validStore(
+                    stores.pins) && validStore(stores.recency);
+    }
+
+    function validStore(store) {
+        if (store === null || typeof store !== "object" || Array.isArray(store)
+                || typeof store.available !== "boolean" || !validCategory(store.category)) {
+            return false;
+        }
+        const hasText = store.category === "loaded" || store.category === "empty";
+        return hasText ? typeof store.text === "string" && store.text.length <= 128 * 1024 :
+                         typeof store.text === "undefined";
+    }
+
+    function validGeneration(message) {
+        if (!Number.isInteger(message.generation) || message.generation < 0 || message.generation
+                > 2147483647 || typeof message.complete !== "boolean") {
+            return false;
+        }
+        if (!message.complete) {
+            return message.failure === "discovery";
+        }
+        if (!Array.isArray(message.entries) || message.entries.length > 4096) {
+            return false;
+        }
+        const seen = {};
+        for (let index = 0; index < message.entries.length; ++index) {
+            const entry = message.entries[index];
+            if (entry === null || typeof entry !== "object" || Array.isArray(entry) || !validDesktopId(
+                        entry.id) || typeof entry.quickshellId !== "string"
+                    || entry.quickshellId.length === 0 || entry.quickshellId + ".desktop"
+                    !== entry.id || seen[entry.id] === true) {
+                return false;
+            }
+            seen[entry.id] = true;
+        }
+        return true;
+    }
+
+    function validWriteResponse(message) {
+        return (message.store === "pins" || message.store === "recency") && Number.isInteger(message.serial)
+                && message.serial >= 0 && message.serial <= 2147483647 && typeof message.success === "boolean"
+                && validCategory(message.category);
+    }
+
+    function validDesktopId(id) {
+        if (typeof id !== "string" || id.length <= 8 || !id.endsWith(".desktop") || id.indexOf("\u0000")
+                !== -1) {
+            return false;
+        }
+        try {
+            return unescape(encodeURIComponent(id)).length <= 4096;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function validCategory(category) {
+        return category === "none" || category === "missing" || category === "empty" || category
+                === "loaded" || category === "oversized" || category === "utf8" || category
+                === "path" || category === "directory" || category === "read" || category
+                === "write" || category === "symlink" || category === "permissions" || category
+                === "protocol" || category === "unavailable";
+    }
+
+    function warnBounded(message) {
+        if (state.diagnosticCount >= root.maximumDiagnostics) {
+            return;
+        }
+        state.diagnosticCount += 1;
+        console.warn("Application bridge: " + message);
+    }
+
+    function forwardDiagnostic(message) {
+        if (state.diagnosticCount >= root.maximumDiagnostics) {
+            return;
+        }
+        state.diagnosticCount += 1;
+        const bounded = typeof message === "string" ? message.slice(0, 256) :
+                                                      "invalid helper diagnostic";
+        console.warn("Application helper: " + bounded);
+    }
+
+    function failBridge() {
+        state.ready = false;
+        root.fatalFailure();
+    }
+
+    onEnabledChanged: {
+        if (enabled) {
+            state.restartAttempts = 0;
+            state.restartAllowed = true;
+        } else {
+            restartTimer.stop();
+            state.restartAllowed = false;
+            state.ready = false;
+        }
+    }
+
+    QtObject {
+        id: state
+
+        property bool ready: false
+        property bool restartAllowed: true
+        property bool destroying: false
+        property int restartAttempts: 0
+        property int diagnosticCount: 0
+    }
+
+    Timer {
+        id: restartTimer
+
+        interval: 250 * Math.pow(2, Math.max(0, state.restartAttempts - 1))
+        onTriggered: state.restartAllowed = true
+    }
+
+    Process {
+        id: helper
+
+        command: [root.helperPath, root.pinsPath, root.recencyPath]
+        stdinEnabled: true
+        running: root.enabled && root.helperPath !== "" && state.restartAllowed
+
+        stdout: SplitParser {
+            onRead: data => root.acceptLine(data)
+        }
+
+        stderr: SplitParser {
+            onRead: data => root.forwardDiagnostic(data)
+        }
+
+        onStarted: state.ready = false
+        onExited: function (exitCode, exitStatus) {
+            root.failBridge();
+            if (!state.destroying && root.enabled && state.restartAttempts < 3) {
+                state.restartAttempts += 1;
+                state.restartAllowed = false;
+                restartTimer.restart();
+            } else {
+                state.restartAllowed = false;
+            }
+        }
+    }
+
+    Component.onDestruction: {
+        state.destroying = true;
+        restartTimer.stop();
+        if (helper.running && state.ready) {
+            helper.write("{\"op\":\"shutdown\"}\n");
+        }
+        helper.running = false;
+        state.ready = false;
+    }
+}

--- a/qml/ApplicationModel.qml
+++ b/qml/ApplicationModel.qml
@@ -1,0 +1,671 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+Scope {
+    id: root
+
+    required property string helperPath
+    property string pinsPathOverride: ""
+    property string recencyPathOverride: ""
+
+    readonly property bool available: state.discoveryAvailable
+    readonly property bool initialized: state.readyForUse
+    readonly property var applications: state.applications
+    readonly property var pinnedApplications: state.pinnedApplications
+    readonly property var recentApplications: state.recentApplications
+    readonly property var pinIds: state.committedPins
+    readonly property var recencyIds: state.recencyIds
+    readonly property string pinFailure: state.pinFailure
+    readonly property string recencyFailure: state.recencyFailure
+    readonly property string pinsPath: state.pinsPath
+    readonly property string recencyPath: state.recencyPath
+    readonly property int maximumPins: 8
+    readonly property int maximumRecency: 20
+    readonly property int maximumRecentRows: 8
+    readonly property int maximumStoreBytes: 128 * 1024
+    readonly property int maximumDiagnosticsPerStore: 4
+
+    signal pinCommitted(string desktopFileId)
+    signal pinRemoved(string desktopFileId)
+    signal pinReordered(string desktopFileId)
+    signal pinMutationFailed(string category)
+    signal recencyPersisted
+
+    function pin(desktopFileId) {
+        if (!state.pinStoreAvailable || !bridge.ready) {
+            state.pinFailure = "unavailable";
+            return false;
+        }
+        if (!eligible(desktopFileId)) {
+            return false;
+        }
+        const target = state.desiredPins.slice();
+        if (target.indexOf(desktopFileId) !== -1) {
+            return false;
+        }
+        if (target.length >= root.maximumPins) {
+            state.pinFailure = "limit";
+            return false;
+        }
+        target.push(desktopFileId);
+        state.pinFailure = "none";
+        schedulePins(target, "pin", desktopFileId);
+        return true;
+    }
+
+    function unpin(desktopFileId) {
+        if (!state.pinStoreAvailable || !bridge.ready) {
+            state.pinFailure = "unavailable";
+            return false;
+        }
+        const target = state.desiredPins.slice();
+        const index = target.indexOf(desktopFileId);
+        if (index === -1) {
+            return false;
+        }
+        target.splice(index, 1);
+        state.pinFailure = "none";
+        schedulePins(target, "unpin", desktopFileId);
+        return true;
+    }
+
+    function movePin(desktopFileId, newIndex) {
+        if (!state.pinStoreAvailable || !bridge.ready || !Number.isInteger(newIndex)) {
+            state.pinFailure = state.pinStoreAvailable && bridge.ready ? "none" : "unavailable";
+            return false;
+        }
+        const target = state.desiredPins.slice();
+        const oldIndex = target.indexOf(desktopFileId);
+        if (oldIndex === -1 || newIndex < 0 || newIndex >= target.length || newIndex === oldIndex) {
+            return false;
+        }
+        target.splice(oldIndex, 1);
+        target.splice(newIndex, 0, desktopFileId);
+        state.pinFailure = "none";
+        schedulePins(target, "reorder", desktopFileId);
+        return true;
+    }
+
+    function recordAcceptedLaunch(desktopFileId) {
+        if (!eligible(desktopFileId)) {
+            return false;
+        }
+        const target = state.recencyIds.slice();
+        const previous = target.indexOf(desktopFileId);
+        if (previous !== -1) {
+            target.splice(previous, 1);
+        }
+        target.unshift(desktopFileId);
+        if (target.length > root.maximumRecency) {
+            target.length = root.maximumRecency;
+        }
+        if (arraysEqual(target, state.recencyIds)) {
+            return true;
+        }
+        state.recencyIds = target;
+        rebuildSections();
+        if (state.recencyStoreAvailable && bridge.ready) {
+            state.recencyFailure = "none";
+            scheduleRecency(target);
+        } else {
+            state.recencyFailure = "unavailable";
+        }
+        return true;
+    }
+
+    function eligible(desktopFileId) {
+        return validDesktopId(desktopFileId) && state.entryById[desktopFileId] !== undefined;
+    }
+
+    function markDiscoveryIncomplete(category) {
+        state.discoveryAvailable = false;
+        warnBounded("discovery", category);
+    }
+
+    function captureDiscoveryGeneration() {
+        const values = DesktopEntries.applications.values;
+        const snapshot = [];
+        if (values !== null && typeof values === "object" && typeof values.length === "number") {
+            for (let index = 0; index < values.length; ++index) {
+                snapshot.push(values[index]);
+            }
+        }
+        state.nextDiscoveryGeneration += 1;
+        state.pendingDiscoveryGeneration = state.nextDiscoveryGeneration;
+        state.pendingDiscoveryEntries = snapshot;
+        startDiscoveryScan();
+    }
+
+    function startDiscoveryScan() {
+        if (!bridge.ready || state.scanInFlight || state.pendingDiscoveryGeneration === 0) {
+            return;
+        }
+        const generation = state.pendingDiscoveryGeneration;
+        const entries = state.pendingDiscoveryEntries;
+        if (!bridge.scan(generation)) {
+            return;
+        }
+        state.pendingDiscoveryGeneration = 0;
+        state.pendingDiscoveryEntries = [];
+        state.scanInFlight = true;
+        state.inFlightDiscoveryGeneration = generation;
+        state.inFlightDiscoveryEntries = entries;
+    }
+
+    function acceptDiscoveryGeneration(generation) {
+        if (!state.scanInFlight || generation.generation !== state.inFlightDiscoveryGeneration) {
+            return;
+        }
+        const sourceEntries = state.inFlightDiscoveryEntries;
+        state.scanInFlight = false;
+        state.inFlightDiscoveryGeneration = 0;
+        state.inFlightDiscoveryEntries = [];
+
+        if (generation.complete) {
+            const quickshellById = {};
+            let complete = (sourceEntries.length === 0) === (generation.entries.length === 0);
+            for (let index = 0; index < sourceEntries.length; ++index) {
+                const entry = sourceEntries[index];
+                if (entry === null || typeof entry !== "object" || typeof entry.id !== "string"
+                        || entry.id.length === 0 || quickshellById[entry.id] !== undefined) {
+                    complete = false;
+                    break;
+                }
+                quickshellById[entry.id] = entry;
+            }
+
+            const map = {};
+            const applications = [];
+            if (complete) {
+                for (let index = 0; index < generation.entries.length; ++index) {
+                    const validated = generation.entries[index];
+                    const entry = quickshellById[validated.quickshellId]
+                          ?? quickshellById[validated.id];
+                    if (entry === undefined) {
+                        continue;
+                    }
+                    const row = normalizedEntry(validated.id, entry);
+                    if (row === null || map[row.id] !== undefined) {
+                        complete = false;
+                        break;
+                    }
+                    map[row.id] = row;
+                    applications.push(row);
+                }
+            }
+
+            if (complete) {
+                applications.sort(compareApplications);
+                state.entryById = map;
+                state.applications = applications;
+                state.discoveryAvailable = true;
+                state.hasCompleteDiscovery = true;
+                reconcileCompleteGeneration();
+            } else {
+                markDiscoveryIncomplete("inconsistent complete generation");
+            }
+        } else {
+            markDiscoveryIncomplete("incomplete generation");
+        }
+        startDiscoveryScan();
+    }
+
+    function normalizedEntry(desktopFileId, entry) {
+        if (!validDesktopId(desktopFileId) || typeof entry.name !== "string") {
+            return null;
+        }
+        const name = entry.name.trim();
+        if (name.length === 0) {
+            return null;
+        }
+        const keywords = [];
+        const seenKeywords = {};
+        const sourceKeywords = entry.keywords;
+        if (sourceKeywords !== null && typeof sourceKeywords === "object"
+                && typeof sourceKeywords.length === "number") {
+            for (let index = 0; index < sourceKeywords.length; ++index) {
+                if (typeof sourceKeywords[index] !== "string") {
+                    continue;
+                }
+                const keyword = sourceKeywords[index].trim();
+                if (keyword.length > 0 && seenKeywords[keyword] !== true) {
+                    seenKeywords[keyword] = true;
+                    keywords.push(keyword);
+                }
+            }
+        }
+        return {
+            "id": desktopFileId,
+            "name": name,
+            "keywords": keywords,
+            "icon": typeof entry.icon === "string" ? entry.icon.trim() : "",
+            "desktopEntry": entry
+        };
+    }
+
+    function compareApplications(left, right) {
+        const byName = left.name.localeCompare(right.name);
+        return byName !== 0 ? byName : left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+    }
+
+    function reconcileCompleteGeneration() {
+        if (!state.storageInitialized || !state.hasCompleteDiscovery) {
+            return;
+        }
+        const pruned = [];
+        for (let index = 0; index < state.recencyIds.length; ++index) {
+            const id = state.recencyIds[index];
+            if (eligible(id)) {
+                pruned.push(id);
+            }
+        }
+        const changed = !arraysEqual(pruned, state.recencyIds);
+        if (changed) {
+            state.recencyIds = pruned;
+            if (state.recencyStoreAvailable) {
+                scheduleRecency(pruned);
+            } else {
+                state.recencyFailure = "unavailable";
+            }
+        }
+        rebuildSections();
+        state.readyForUse = true;
+    }
+
+    function rebuildSections() {
+        const pins = [];
+        const pinned = {};
+        for (let index = 0; index < state.committedPins.length; ++index) {
+            const id = state.committedPins[index];
+            const entry = state.entryById[id];
+            if (entry !== undefined) {
+                pins.push(entry);
+                pinned[id] = true;
+            }
+        }
+
+        const recents = [];
+        for (let index = 0; index < state.recencyIds.length && recents.length
+             < root.maximumRecentRows; ++index) {
+            const id = state.recencyIds[index];
+            const entry = state.entryById[id];
+            if (entry !== undefined && pinned[id] !== true) {
+                recents.push(entry);
+            }
+        }
+        state.pinnedApplications = pins;
+        state.recentApplications = recents;
+    }
+
+    function acceptStores(stores) {
+        if (state.storageInitialized) {
+            startDiscoveryScan();
+            startStoreWrite("pins");
+            startStoreWrite("recency");
+            return;
+        }
+        const pins = parseStore("pins", stores.pins, root.maximumPins);
+        const recency = parseStore("recency", stores.recency, root.maximumRecency);
+        state.pinStoreAvailable = stores.pins.available;
+        state.recencyStoreAvailable = stores.recency.available;
+        state.committedPins = pins;
+        state.desiredPins = pins.slice();
+        state.recencyIds = recency;
+        state.storageInitialized = true;
+        state.pinFailure = stores.pins.available ? "none" : "unavailable";
+        state.recencyFailure = stores.recency.available ? "none" : "unavailable";
+        reconcileCompleteGeneration();
+        startDiscoveryScan();
+    }
+
+    function parseStore(kind, store, limit) {
+        if (!store.available || store.category === "missing" || store.category === "empty") {
+            return [];
+        }
+        if (store.category !== "loaded") {
+            warnBounded(kind, store.category);
+            return [];
+        }
+        let document;
+        try {
+            document = JSON.parse(store.text);
+        } catch (error) {
+            warnBounded(kind, "malformed");
+            return [];
+        }
+        if (document === null || typeof document !== "object" || Array.isArray(document) || !Number.isInteger(
+                    document.version) || document.version !== 1 || !Array.isArray(
+                    document.desktopFileIds)) {
+            warnBounded(kind, Number.isInteger(document?.version) && document.version !== 1
+                        ? "version" : "schema");
+            return [];
+        }
+        return normalizeIds(document.desktopFileIds, limit);
+    }
+
+    function normalizeIds(values, limit) {
+        const result = [];
+        const seen = {};
+        for (let index = 0; index < values.length && result.length < limit; ++index) {
+            const value = values[index];
+            if (validDesktopId(value) && seen[value] !== true) {
+                seen[value] = true;
+                result.push(value);
+            }
+        }
+        return result;
+    }
+
+    function validDesktopId(value) {
+        if (typeof value !== "string" || value.length <= 8 || !value.endsWith(".desktop")
+                || value.indexOf("\u0000") !== -1) {
+            return false;
+        }
+        try {
+            return unescape(encodeURIComponent(value)).length <= 4096;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function schedulePins(ids, operation, desktopFileId) {
+        state.desiredPins = ids.slice();
+        state.pendingPins = {
+            "ids": ids.slice(),
+            "operation": operation,
+            "desktopFileId": desktopFileId
+        };
+        startStoreWrite("pins");
+    }
+
+    function scheduleRecency(ids) {
+        state.pendingRecency = ids.slice();
+        startStoreWrite("recency");
+    }
+
+    function startStoreWrite(store) {
+        if (!bridge.ready) {
+            return;
+        }
+        if (store === "pins") {
+            if (state.pinsWritePhase !== "idle" || state.pendingPins === null) {
+                return;
+            }
+            state.currentPinsWrite = state.pendingPins;
+            state.pendingPins = null;
+            state.pinsWriteSerial += 1;
+            state.pinsWritePhase = "preparing";
+            if (!bridge.prepareWrite("pins", state.pinsWriteSerial)) {
+                failStoreWrite("pins", "unavailable");
+            }
+            return;
+        }
+        if (state.recencyWritePhase !== "idle" || state.pendingRecency === null) {
+            return;
+        }
+        state.currentRecencyWrite = state.pendingRecency;
+        state.pendingRecency = null;
+        state.recencyWriteSerial += 1;
+        state.recencyWritePhase = "preparing";
+        if (!bridge.prepareWrite("recency", state.recencyWriteSerial)) {
+            failStoreWrite("recency", "unavailable");
+        }
+    }
+
+    function acceptWriteReady(store, serial, success, category) {
+        if (store === "pins") {
+            if (state.pinsWritePhase !== "preparing" || serial !== state.pinsWriteSerial) {
+                return;
+            }
+            if (!success) {
+                failStoreWrite("pins", category);
+                return;
+            }
+            state.pinsWritePhase = "saving";
+            pinsWriter.setText(serialize(state.currentPinsWrite.ids));
+            return;
+        }
+        if (state.recencyWritePhase !== "preparing" || serial !== state.recencyWriteSerial) {
+            return;
+        }
+        if (!success) {
+            failStoreWrite("recency", category);
+            return;
+        }
+        state.recencyWritePhase = "saving";
+        recencyWriter.setText(serialize(state.currentRecencyWrite));
+    }
+
+    function fileSaved(store) {
+        if (store === "pins" && state.pinsWritePhase === "saving") {
+            state.pinsWritePhase = "verifying";
+            if (!bridge.verifyWrite("pins", state.pinsWriteSerial)) {
+                failStoreWrite("pins", "unavailable");
+            }
+        } else if (store === "recency" && state.recencyWritePhase === "saving") {
+            state.recencyWritePhase = "verifying";
+            if (!bridge.verifyWrite("recency", state.recencyWriteSerial)) {
+                failStoreWrite("recency", "unavailable");
+            }
+        }
+    }
+
+    function acceptWriteVerified(store, serial, success, category) {
+        if (store === "pins") {
+            if (state.pinsWritePhase !== "verifying" || serial !== state.pinsWriteSerial) {
+                return;
+            }
+            if (!success) {
+                failStoreWrite("pins", category);
+                return;
+            }
+            const mutation = state.currentPinsWrite;
+            state.committedPins = mutation.ids.slice();
+            state.currentPinsWrite = null;
+            state.pinsWritePhase = "idle";
+            state.pinFailure = "none";
+            rebuildSections();
+            if (mutation.operation === "pin") {
+                root.pinCommitted(mutation.desktopFileId);
+            } else if (mutation.operation === "unpin") {
+                root.pinRemoved(mutation.desktopFileId);
+            } else {
+                root.pinReordered(mutation.desktopFileId);
+            }
+            startStoreWrite("pins");
+            return;
+        }
+        if (state.recencyWritePhase !== "verifying" || serial !== state.recencyWriteSerial) {
+            return;
+        }
+        if (!success) {
+            failStoreWrite("recency", category);
+            return;
+        }
+        state.currentRecencyWrite = null;
+        state.recencyWritePhase = "idle";
+        state.recencyFailure = "none";
+        root.recencyPersisted();
+        startStoreWrite("recency");
+    }
+
+    function failStoreWrite(store, category) {
+        if (store === "pins") {
+            state.currentPinsWrite = null;
+            state.pendingPins = null;
+            state.pinsWritePhase = "idle";
+            state.desiredPins = state.committedPins.slice();
+            state.pinFailure = "write";
+            root.pinMutationFailed(category === "none" ? "write" : category);
+            return;
+        }
+        state.currentRecencyWrite = null;
+        state.recencyWritePhase = "idle";
+        state.recencyFailure = "write";
+        startStoreWrite("recency");
+    }
+
+    function serialize(ids) {
+        return JSON.stringify({
+                                  "version": 1,
+                                  "desktopFileIds": ids
+                              }, null, 2) + "\n";
+    }
+
+    function arraysEqual(left, right) {
+        if (left.length !== right.length) {
+            return false;
+        }
+        for (let index = 0; index < left.length; ++index) {
+            if (left[index] !== right[index]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function resolveStorePath(environmentName, fallbackSuffix, fileName) {
+        const configured = Quickshell.env(environmentName);
+        let base = typeof configured === "string" ? configured : "";
+        if (!base.startsWith("/")) {
+            const home = Quickshell.env("HOME");
+            if (typeof home !== "string" || !home.startsWith("/")) {
+                return "";
+            }
+            base = home.replace(/\/+$/, "") + fallbackSuffix;
+        }
+        base = base.replace(/\/+$/, "");
+        return base + "/nagi-shell/" + fileName;
+    }
+
+    function warnBounded(store, category) {
+        const key = store === "pins" ? "pinDiagnosticCount" : store === "recency"
+                                       ? "recencyDiagnosticCount" : "discoveryDiagnosticCount";
+        if (state[key] >= root.maximumDiagnosticsPerStore) {
+            return;
+        }
+        state[key] += 1;
+        console.warn("Application model: " + store + " " + String(category).slice(0, 64));
+    }
+
+    Connections {
+        target: DesktopEntries
+
+        function onApplicationsChanged() {
+            root.captureDiscoveryGeneration();
+        }
+    }
+
+    ApplicationBridge {
+        id: bridge
+
+        helperPath: root.helperPath
+        pinsPath: state.pinsPath
+        recencyPath: state.recencyPath
+        enabled: state.pathsInitialized
+
+        onInitialized: stores => root.acceptStores(stores)
+        onGenerationReceived: generation => root.acceptDiscoveryGeneration(generation)
+        onWriteReady: (store, serial, success, category) => root.acceptWriteReady(store, serial, success,
+                                                                                  category)
+        onWriteVerified: (store, serial, success, category) => root.acceptWriteVerified(store,
+                                                                                        serial, success,
+                                                                                        category)
+        onFatalFailure: {
+            root.markDiscoveryIncomplete("helper unavailable");
+            state.scanInFlight = false;
+            if (state.inFlightDiscoveryGeneration !== 0) {
+                state.pendingDiscoveryGeneration = state.inFlightDiscoveryGeneration;
+                state.pendingDiscoveryEntries = state.inFlightDiscoveryEntries;
+            }
+            state.inFlightDiscoveryGeneration = 0;
+            state.inFlightDiscoveryEntries = [];
+            if (state.pinsWritePhase !== "idle") {
+                root.failStoreWrite("pins", "unavailable");
+            }
+            if (state.recencyWritePhase !== "idle") {
+                root.failStoreWrite("recency", "unavailable");
+            }
+        }
+    }
+
+    FileView {
+        id: pinsWriter
+
+        path: state.pinStoreAvailable ? state.pinsPath : ""
+        atomicWrites: true
+        preload: false
+        printErrors: false
+        onSaved: root.fileSaved("pins")
+        onSaveFailed: error => root.failStoreWrite("pins", "write")
+    }
+
+    FileView {
+        id: recencyWriter
+
+        path: state.recencyStoreAvailable ? state.recencyPath : ""
+        atomicWrites: true
+        preload: false
+        printErrors: false
+        onSaved: root.fileSaved("recency")
+        onSaveFailed: error => root.failStoreWrite("recency", "write")
+    }
+
+    QtObject {
+        id: state
+
+        property string pinsPath: ""
+        property string recencyPath: ""
+        property bool pathsInitialized: false
+        property bool storageInitialized: false
+        property bool readyForUse: false
+        property bool pinStoreAvailable: false
+        property bool recencyStoreAvailable: false
+        property bool discoveryAvailable: false
+        property bool hasCompleteDiscovery: false
+        property var entryById: ({})
+        property var applications: []
+        property var pinnedApplications: []
+        property var recentApplications: []
+        property var committedPins: []
+        property var desiredPins: []
+        property var recencyIds: []
+        property string pinFailure: "none"
+        property string recencyFailure: "none"
+        property int nextDiscoveryGeneration: 0
+        property int pendingDiscoveryGeneration: 0
+        property var pendingDiscoveryEntries: []
+        property bool scanInFlight: false
+        property int inFlightDiscoveryGeneration: 0
+        property var inFlightDiscoveryEntries: []
+        property string pinsWritePhase: "idle"
+        property int pinsWriteSerial: 0
+        property var currentPinsWrite: null
+        property var pendingPins: null
+        property string recencyWritePhase: "idle"
+        property int recencyWriteSerial: 0
+        property var currentRecencyWrite: null
+        property var pendingRecency: null
+        property int pinDiagnosticCount: 0
+        property int recencyDiagnosticCount: 0
+        property int discoveryDiagnosticCount: 0
+    }
+
+    Component.onCompleted: {
+        state.pinsPath = root.pinsPathOverride !== "" ? root.pinsPathOverride :
+                                                        root.resolveStorePath("XDG_CONFIG_HOME",
+                                                                              "/.config",
+                                                                              "application-pins.json");
+        state.recencyPath = root.recencyPathOverride !== "" ? root.recencyPathOverride :
+                                                              root.resolveStorePath("XDG_STATE_HOME",
+                                                                                    "/.local/state",
+                                                                                    "application-recency.json");
+        state.pathsInitialized = true;
+        if (DesktopEntries.applications.values.length > 0) {
+            root.captureDiscoveryGeneration();
+        }
+    }
+}

--- a/shell.qml
+++ b/shell.qml
@@ -32,6 +32,12 @@ ShellRoot {
         helperPath: Quickshell.shellPath("build/nagi-connectivity")
     }
 
+    ApplicationModel {
+        id: applications
+
+        helperPath: Quickshell.shellPath("build/nagi-applications")
+    }
+
     ReducedMotion {
         id: motion
     }

--- a/src/applications/main.cpp
+++ b/src/applications/main.cpp
@@ -1,0 +1,501 @@
+#define QT_NO_KEYWORDS
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSet>
+#include <QStringList>
+#include <QSocketNotifier>
+#include <QStringDecoder>
+
+#include <gio/gdesktopappinfo.h>
+#include <gio/gio.h>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <fcntl.h>
+#include <limits>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace {
+constexpr qint64 kMaximumStoreBytes = 128 * 1024;
+constexpr qsizetype kMaximumInputLineBytes = 8192;
+constexpr qsizetype kMaximumApplications = 4096;
+constexpr qsizetype kMaximumDesktopIdBytes = 4096;
+
+struct StoreInspection {
+    bool available = false;
+    QString category = QStringLiteral("unavailable");
+    QString text;
+};
+
+bool isPrivateRegularFile(const struct stat &status)
+{
+    return S_ISREG(status.st_mode) && status.st_uid == getuid()
+        && (status.st_mode & 0777) == 0600;
+}
+
+bool validDesktopId(const QString &id)
+{
+    const QByteArray bytes = id.toUtf8();
+    return !id.isEmpty() && id.endsWith(QStringLiteral(".desktop"))
+        && bytes.size() <= kMaximumDesktopIdBytes && !bytes.contains('\0');
+}
+
+bool validExecFieldCodes(const char *exec)
+{
+    if (exec == nullptr || *exec == '\0') {
+        return false;
+    }
+
+    constexpr char allowed[] = "fFuUick%";
+    for (const char *cursor = exec; *cursor != '\0'; ++cursor) {
+        if (*cursor != '%') {
+            continue;
+        }
+        ++cursor;
+        if (*cursor == '\0' || std::find(std::begin(allowed), std::end(allowed) - 1, *cursor)
+                == std::end(allowed) - 1) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool validDbusActivation(GDesktopAppInfo *info, const QString &id)
+{
+    if (!g_desktop_app_info_get_boolean(info, G_KEY_FILE_DESKTOP_KEY_DBUS_ACTIVATABLE)) {
+        return false;
+    }
+    const QString busName = id.chopped(QStringLiteral(".desktop").size());
+    return !busName.isEmpty() && g_dbus_is_name(busName.toUtf8().constData())
+        && !busName.startsWith(u':');
+}
+
+bool discoveryPathsAccessible()
+{
+    QStringList roots;
+    QString dataHome = qEnvironmentVariable("XDG_DATA_HOME");
+    if (!dataHome.startsWith(u'/')) {
+        const QString home = qEnvironmentVariable("HOME");
+        dataHome = home.startsWith(u'/') ? home + QStringLiteral("/.local/share") : QString();
+    }
+    if (!dataHome.isEmpty()) {
+        roots.append(dataHome);
+    }
+
+    const QString configuredDataDirs = qEnvironmentVariable("XDG_DATA_DIRS");
+    const QStringList dataDirs = configuredDataDirs.isEmpty()
+        ? QStringList {QStringLiteral("/usr/local/share"), QStringLiteral("/usr/share")}
+        : configuredDataDirs.split(u':', Qt::SkipEmptyParts);
+    for (const QString &dataDir : dataDirs) {
+        if (dataDir.startsWith(u'/')) {
+            roots.append(dataDir);
+        }
+    }
+
+    for (const QString &root : roots) {
+        const QByteArray path = QFile::encodeName(root + QStringLiteral("/applications"));
+        struct stat status {};
+        if (::stat(path.constData(), &status) != 0) {
+            if (errno == ENOENT) {
+                continue;
+            }
+            return false;
+        }
+        if (!S_ISDIR(status.st_mode) || ::access(path.constData(), R_OK | X_OK) != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+QJsonObject discoveryGeneration(qint64 generation)
+{
+    QJsonObject response {{QStringLiteral("type"), QStringLiteral("generation")},
+                          {QStringLiteral("generation"), generation},
+                          {QStringLiteral("complete"), false}};
+    if (!discoveryPathsAccessible()) {
+        response.insert(QStringLiteral("failure"), QStringLiteral("discovery"));
+        return response;
+    }
+    QVector<QJsonObject> records;
+    QSet<QString> seen;
+    GList *applications = g_app_info_get_all();
+
+    bool valid = true;
+    qsizetype count = 0;
+    for (GList *node = applications; node != nullptr; node = node->next) {
+        GAppInfo *appInfo = G_APP_INFO(node->data);
+        if (!G_IS_DESKTOP_APP_INFO(appInfo) || !g_app_info_should_show(appInfo)) {
+            continue;
+        }
+
+        auto *desktopInfo = G_DESKTOP_APP_INFO(appInfo);
+        const char *rawId = g_app_info_get_id(appInfo);
+        if (rawId == nullptr || !g_utf8_validate(rawId, -1, nullptr)) {
+            valid = false;
+            break;
+        }
+        const QString id = QString::fromUtf8(rawId);
+        if (!validDesktopId(id)) {
+            valid = false;
+            break;
+        }
+        if (seen.contains(id)) {
+            valid = false;
+            break;
+        }
+
+        const bool terminal = g_desktop_app_info_get_boolean(
+            desktopInfo, G_KEY_FILE_DESKTOP_KEY_TERMINAL);
+        char *exec = g_desktop_app_info_get_string(desktopInfo, G_KEY_FILE_DESKTOP_KEY_EXEC);
+        const bool hasExec = exec != nullptr && *exec != '\0';
+        const bool launchable = !terminal
+            && (hasExec ? validExecFieldCodes(exec) : validDbusActivation(desktopInfo, id));
+        g_free(exec);
+        if (!launchable) {
+            continue;
+        }
+
+        if (++count > kMaximumApplications) {
+            valid = false;
+            break;
+        }
+        seen.insert(id);
+        records.append(QJsonObject {
+            {QStringLiteral("id"), id},
+            {QStringLiteral("quickshellId"), id.chopped(QStringLiteral(".desktop").size())},
+        });
+    }
+    g_list_free_full(applications, g_object_unref);
+
+    if (!valid) {
+        response.insert(QStringLiteral("failure"), QStringLiteral("discovery"));
+        return response;
+    }
+
+    std::sort(records.begin(), records.end(), [](const QJsonObject &left, const QJsonObject &right) {
+        return left[QStringLiteral("id")].toString().toUtf8()
+            < right[QStringLiteral("id")].toString().toUtf8();
+    });
+    QJsonArray entries;
+    for (const QJsonObject &record : records) {
+        entries.append(record);
+    }
+    response.insert(QStringLiteral("complete"), true);
+    response.insert(QStringLiteral("entries"), entries);
+    return response;
+}
+
+bool ensureStoreDirectory(const QString &filePath, QString *category)
+{
+    const QFileInfo file(filePath);
+    if (!file.isAbsolute()) {
+        *category = QStringLiteral("path");
+        return false;
+    }
+
+    const QString parentPath = file.absolutePath();
+    if (QFileInfo(parentPath).fileName() != QStringLiteral("nagi-shell")) {
+        *category = QStringLiteral("path");
+        return false;
+    }
+
+    struct stat status {};
+    const QByteArray nativeParent = QFile::encodeName(parentPath);
+    if (::lstat(nativeParent.constData(), &status) != 0) {
+        if (errno != ENOENT || !QDir().mkpath(parentPath)
+            || ::chmod(nativeParent.constData(), 0700) != 0
+            || ::lstat(nativeParent.constData(), &status) != 0) {
+            *category = QStringLiteral("directory");
+            return false;
+        }
+    }
+
+    if (!S_ISDIR(status.st_mode) || status.st_uid != getuid()
+        || ::access(nativeParent.constData(), W_OK | X_OK) != 0) {
+        *category = QStringLiteral("directory");
+        return false;
+    }
+    return true;
+}
+
+StoreInspection inspectStore(const QString &filePath)
+{
+    StoreInspection result;
+    if (!ensureStoreDirectory(filePath, &result.category)) {
+        return result;
+    }
+
+    const QByteArray nativePath = QFile::encodeName(filePath);
+    struct stat before {};
+    if (::lstat(nativePath.constData(), &before) != 0) {
+        if (errno == ENOENT) {
+            result.available = true;
+            result.category = QStringLiteral("missing");
+        } else {
+            result.category = QStringLiteral("read");
+        }
+        return result;
+    }
+
+    if (!isPrivateRegularFile(before)) {
+        result.category = S_ISLNK(before.st_mode) ? QStringLiteral("symlink")
+                                                  : QStringLiteral("permissions");
+        return result;
+    }
+    result.available = true;
+    if (before.st_size > kMaximumStoreBytes) {
+        result.category = QStringLiteral("oversized");
+        return result;
+    }
+
+    const int descriptor = ::open(nativePath.constData(), O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    if (descriptor < 0) {
+        result.available = false;
+        result.category = QStringLiteral("read");
+        return result;
+    }
+
+    struct stat after {};
+    QByteArray bytes;
+    bytes.resize(static_cast<qsizetype>(before.st_size));
+    qsizetype offset = 0;
+    while (offset < bytes.size()) {
+        const ssize_t readCount = ::read(descriptor, bytes.data() + offset,
+                                         static_cast<size_t>(bytes.size() - offset));
+        if (readCount <= 0) {
+            result.available = false;
+            result.category = QStringLiteral("read");
+            break;
+        }
+        offset += readCount;
+    }
+    const bool stable = ::fstat(descriptor, &after) == 0 && isPrivateRegularFile(after)
+        && before.st_dev == after.st_dev && before.st_ino == after.st_ino
+        && after.st_size == before.st_size;
+    ::close(descriptor);
+    if (!result.available || !stable) {
+        result.available = false;
+        result.category = QStringLiteral("read");
+        result.text.clear();
+        return result;
+    }
+
+    QStringDecoder decoder(QStringDecoder::Utf8);
+    result.text = decoder.decode(bytes);
+    if (decoder.hasError()) {
+        result.text.clear();
+        result.category = QStringLiteral("utf8");
+        return result;
+    }
+    result.category = bytes.isEmpty() ? QStringLiteral("empty") : QStringLiteral("loaded");
+    return result;
+}
+
+bool prepareWrite(const QString &filePath, QString *category)
+{
+    if (!ensureStoreDirectory(filePath, category)) {
+        return false;
+    }
+
+    const QByteArray nativePath = QFile::encodeName(filePath);
+    struct stat status {};
+    if (::lstat(nativePath.constData(), &status) == 0) {
+        if (!isPrivateRegularFile(status)) {
+            *category = S_ISLNK(status.st_mode) ? QStringLiteral("symlink")
+                                                : QStringLiteral("permissions");
+            return false;
+        }
+        if (::access(nativePath.constData(), W_OK) != 0) {
+            *category = QStringLiteral("write");
+            return false;
+        }
+        return true;
+    }
+    if (errno != ENOENT) {
+        *category = QStringLiteral("write");
+        return false;
+    }
+
+    const int descriptor = ::open(nativePath.constData(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC
+                                      | O_NOFOLLOW,
+                                  0600);
+    if (descriptor < 0) {
+        *category = QStringLiteral("write");
+        return false;
+    }
+    const bool secured = ::fchmod(descriptor, 0600) == 0;
+    ::close(descriptor);
+    if (!secured) {
+        *category = QStringLiteral("permissions");
+        return false;
+    }
+    return true;
+}
+
+bool verifyWrite(const QString &filePath, QString *category)
+{
+    const StoreInspection inspection = inspectStore(filePath);
+    if (!inspection.available || inspection.category == QStringLiteral("oversized")) {
+        *category = inspection.category;
+        return false;
+    }
+    return true;
+}
+
+QJsonObject storeJson(const StoreInspection &inspection)
+{
+    QJsonObject store {{QStringLiteral("available"), inspection.available},
+                       {QStringLiteral("category"), inspection.category}};
+    if (inspection.category == QStringLiteral("loaded")
+        || inspection.category == QStringLiteral("empty")) {
+        store.insert(QStringLiteral("text"), inspection.text);
+    }
+    return store;
+}
+
+class Helper final : public QObject {
+public:
+    Helper(QString pinsPath, QString recencyPath, QObject *parent = nullptr)
+        : QObject(parent)
+        , m_pinsPath(std::move(pinsPath))
+        , m_recencyPath(std::move(recencyPath))
+        , m_input()
+        , m_output()
+        , m_notifier(STDIN_FILENO, QSocketNotifier::Read, this)
+    {
+        if (!m_input.open(STDIN_FILENO, QIODevice::ReadOnly, QFileDevice::DontCloseHandle)
+            || !m_output.open(STDOUT_FILENO, QIODevice::WriteOnly, QFileDevice::DontCloseHandle)) {
+            QCoreApplication::exit(2);
+            return;
+        }
+        connect(&m_notifier, &QSocketNotifier::activated, this, [this] { readInput(); });
+
+        write(QJsonObject {
+            {QStringLiteral("type"), QStringLiteral("initialized")},
+            {QStringLiteral("stores"),
+             QJsonObject {{QStringLiteral("pins"), storeJson(inspectStore(m_pinsPath))},
+                          {QStringLiteral("recency"), storeJson(inspectStore(m_recencyPath))}}},
+        });
+    }
+
+private:
+    void write(const QJsonObject &message)
+    {
+        m_output.write(QJsonDocument(message).toJson(QJsonDocument::Compact));
+        m_output.write("\n");
+        m_output.flush();
+    }
+
+    void readInput()
+    {
+        std::array<char, kMaximumInputLineBytes> bytes {};
+        const ssize_t count = ::read(STDIN_FILENO, bytes.data(), bytes.size());
+        if (count == 0) {
+            QCoreApplication::quit();
+            return;
+        }
+        if (count < 0) {
+            if (errno != EINTR && errno != EAGAIN) {
+                QCoreApplication::exit(2);
+            }
+            return;
+        }
+        m_buffer.append(bytes.data(), count);
+        if (m_buffer.size() > kMaximumInputLineBytes && !m_buffer.contains('\n')) {
+            QCoreApplication::exit(2);
+            return;
+        }
+
+        qsizetype newline = -1;
+        while ((newline = m_buffer.indexOf('\n')) >= 0) {
+            const QByteArray line = m_buffer.first(newline);
+            m_buffer.remove(0, newline + 1);
+            if (line.isEmpty() || line.size() > kMaximumInputLineBytes) {
+                write(QJsonObject {{QStringLiteral("type"), QStringLiteral("error")},
+                                   {QStringLiteral("category"), QStringLiteral("protocol")}});
+                continue;
+            }
+            QJsonParseError error {};
+            const QJsonDocument document = QJsonDocument::fromJson(line, &error);
+            if (error.error != QJsonParseError::NoError || !document.isObject()) {
+                write(QJsonObject {{QStringLiteral("type"), QStringLiteral("error")},
+                                   {QStringLiteral("category"), QStringLiteral("protocol")}});
+                continue;
+            }
+            handle(document.object());
+        }
+    }
+
+    void handle(const QJsonObject &command)
+    {
+        const QString operation = command.value(QStringLiteral("op")).toString();
+        if (operation == QStringLiteral("shutdown")) {
+            QCoreApplication::quit();
+            return;
+        }
+        if (operation == QStringLiteral("scan")) {
+            const QJsonValue value = command.value(QStringLiteral("generation"));
+            const qint64 generation = value.isDouble() ? value.toInteger(-1) : -1;
+            if (generation < 0 || generation > std::numeric_limits<int>::max()) {
+                write(QJsonObject {{QStringLiteral("type"), QStringLiteral("error")},
+                                   {QStringLiteral("category"), QStringLiteral("protocol")}});
+            } else {
+                write(discoveryGeneration(generation));
+            }
+            return;
+        }
+        if (operation == QStringLiteral("prepare-write")
+            || operation == QStringLiteral("verify-write")) {
+            const QString store = command.value(QStringLiteral("store")).toString();
+            const qint64 serial = command.value(QStringLiteral("serial")).toInteger(-1);
+            const QString *path = store == QStringLiteral("pins") ? &m_pinsPath
+                : store == QStringLiteral("recency")             ? &m_recencyPath
+                                                                  : nullptr;
+            QString category = QStringLiteral("protocol");
+            const bool success = path != nullptr && serial >= 0
+                && (operation == QStringLiteral("prepare-write") ? prepareWrite(*path, &category)
+                                                                  : verifyWrite(*path, &category));
+            write(QJsonObject {
+                {QStringLiteral("type"),
+                 operation == QStringLiteral("prepare-write") ? QStringLiteral("write-ready")
+                                                               : QStringLiteral("write-verified")},
+                {QStringLiteral("store"), store},
+                {QStringLiteral("serial"), serial},
+                {QStringLiteral("success"), success},
+                {QStringLiteral("category"), success ? QStringLiteral("none") : category},
+            });
+            return;
+        }
+
+        write(QJsonObject {{QStringLiteral("type"), QStringLiteral("error")},
+                           {QStringLiteral("category"), QStringLiteral("protocol")}});
+    }
+
+    QString m_pinsPath;
+    QString m_recencyPath;
+    QFile m_input;
+    QFile m_output;
+    QSocketNotifier m_notifier;
+    QByteArray m_buffer;
+};
+}
+
+int main(int argc, char **argv)
+{
+    QCoreApplication application(argc, argv);
+    if (application.arguments().size() != 3) {
+        return 2;
+    }
+
+    Helper helper(application.arguments().at(1), application.arguments().at(2));
+    return application.exec();
+}

--- a/tests/applications/fixtures/config/nagi-shell/application-pins.json
+++ b/tests/applications/fixtures/config/nagi-shell/application-pins.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "desktopFileIds": [
+    "dormant.desktop",
+    "app0.desktop",
+    "app0.desktop",
+    "invalid",
+    7
+  ],
+  "ignored": true
+}

--- a/tests/applications/fixtures/data/applications/app0.desktop
+++ b/tests/applications/fixtures/data/applications/app0.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Fixture 0
+Exec=/usr/bin/true
+Icon=fixture-zero
+Keywords=zero;fixture;

--- a/tests/applications/fixtures/data/applications/app1.desktop
+++ b/tests/applications/fixtures/data/applications/app1.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Fixture 1
+Exec=/usr/bin/true
+Icon=fixture-one
+Keywords=one;fixture;

--- a/tests/applications/fixtures/data/applications/app2.desktop
+++ b/tests/applications/fixtures/data/applications/app2.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=Fixture 2
+Exec=/usr/bin/true

--- a/tests/applications/fixtures/data/applications/app3.desktop
+++ b/tests/applications/fixtures/data/applications/app3.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=Fixture 3
+Exec=/usr/bin/true

--- a/tests/applications/fixtures/data/applications/app4.desktop
+++ b/tests/applications/fixtures/data/applications/app4.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=Fixture 4
+Exec=/usr/bin/true

--- a/tests/applications/fixtures/data/applications/app5.desktop
+++ b/tests/applications/fixtures/data/applications/app5.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=Fixture 5
+Exec=/usr/bin/true

--- a/tests/applications/fixtures/data/applications/app6.desktop
+++ b/tests/applications/fixtures/data/applications/app6.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=Fixture 6
+Exec=/usr/bin/true

--- a/tests/applications/fixtures/data/applications/app7.desktop
+++ b/tests/applications/fixtures/data/applications/app7.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=Fixture 7
+Exec=/usr/bin/true

--- a/tests/applications/fixtures/data/applications/app8.desktop
+++ b/tests/applications/fixtures/data/applications/app8.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=Fixture 8
+Exec=/usr/bin/true

--- a/tests/applications/fixtures/data/applications/app9.desktop
+++ b/tests/applications/fixtures/data/applications/app9.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=Fixture 9
+Exec=/usr/bin/true

--- a/tests/applications/fixtures/state/nagi-shell/application-recency.json
+++ b/tests/applications/fixtures/state/nagi-shell/application-recency.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "desktopFileIds": [
+    "app8.desktop",
+    "missing.desktop",
+    "app0.desktop",
+    "app8.desktop"
+  ]
+}

--- a/tests/applications/shell.qml
+++ b/tests/applications/shell.qml
@@ -1,0 +1,296 @@
+import Quickshell
+import Quickshell.Io
+import QtQuick
+import "qml"
+
+ShellRoot {
+    id: test
+
+    property string phase: Quickshell.env("NAGI_APPLICATION_TEST_PHASE")
+    property string stage: "startup"
+    property bool started: false
+
+    function require(condition, message) {
+        if (!condition) {
+            console.error("FAIL: " + message);
+            Qt.exit(1);
+            return false;
+        }
+        return true;
+    }
+
+    function ids(rows) {
+        const result = [];
+        for (let index = 0; index < rows.length; ++index) {
+            result.push(rows[index].id);
+        }
+        return result;
+    }
+
+    function equal(left, right) {
+        return JSON.stringify(left) === JSON.stringify(right);
+    }
+
+    function runInitialAssertions() {
+        if (started || !applications.initialized) {
+            return;
+        }
+        started = true;
+        if (phase === "defaults") {
+            const home = Quickshell.env("HOME");
+            if (!require(applications.pinsPath === home
+                         + "/.config/nagi-shell/application-pins.json",
+                         "relative config base did not use the XDG default") || !require(
+                        applications.recencyPath === home
+                        + "/.local/state/nagi-shell/application-recency.json",
+                        "relative state base did not use the XDG default") || !require(
+                        applications.pinIds.length === 0 && applications.recencyIds.length === 0,
+                        "missing default stores were not clean first-run state") || !require(
+                        applications.pinFailure === "none" && applications.recencyFailure === "none",
+                        "missing default store directories were not initialized")) {
+                return;
+            }
+            console.log("application model XDG default tests passed");
+            Qt.exit(0);
+            return;
+        }
+        if (phase === "unsafe") {
+            if (!require(applications.pinFailure === "unavailable",
+                         "unsafe pin store was not disabled") || !require(
+                        applications.pinIds.length === 0, "unsafe pin store content was read") ||
+                    !require(!applications.pin("app0.desktop"),
+                             "unsafe pin store accepted a mutation") || !require(
+                        applications.recordAcceptedLaunch("app7.desktop"),
+                        "independent recency store was blocked")) {
+                return;
+            }
+            stage = "unsafe-launch";
+            return;
+        }
+        if (phase === "restart") {
+            if (!require(equal(applications.pinIds, ["app6.desktop", "dormant.desktop",
+                                                     "app1.desktop", "app2.desktop", "app3.desktop",
+                                                     "app4.desktop", "app5.desktop"]),
+                         "pins did not survive restart") || !require(equal(applications.recencyIds,
+                                                                           ["app9.desktop",
+                                                                            "app8.desktop"]),
+                                                                     "recency did not survive restart")
+                    || !require(equal(ids(applications.pinnedApplications), ["app6.desktop",
+                                                                             "app1.desktop",
+                                                                             "app2.desktop",
+                                                                             "app3.desktop",
+                                                                             "app4.desktop",
+                                                                             "app5.desktop"]),
+                                "dormant pin was not hidden after restart") || !require(equal(ids(
+                                                                                                  applications.recentApplications),
+                                                                                              ["app9.desktop",
+                                                                                               "app8.desktop"]),
+                                                                                        "restart recent rows are incorrect")) {
+                return;
+            }
+            console.log("application model restart tests passed");
+            Qt.exit(0);
+            return;
+        }
+
+        const many = [];
+        for (let index = 0; index < 25; ++index) {
+            many.push("bounded" + index + ".desktop");
+        }
+        many.splice(2, 0, "bounded0.desktop", "bad", 3);
+        if (!require(applications.applications.length === 10,
+                     "eligible fixtures did not appear exactly once") || !require(
+                    applications.applications[0].name === "Fixture 0",
+                    "current display metadata was not exposed") || !require(equal(
+                                                                                applications.applications[0].keywords,
+                                                                                ["zero", "fixture"]),
+                                                                            "current keywords were not normalized")
+                || !require(equal(applications.pinIds, ["dormant.desktop", "app0.desktop"]),
+                            "pin startup normalization changed order") || !require(equal(ids(
+                                                                                             applications.pinnedApplications),
+                                                                                         ["app0.desktop"]),
+                                                                                   "dormant pin was not hidden")
+                || !require(equal(applications.recencyIds, ["app8.desktop", "app0.desktop"]),
+                            "MRU was not deduplicated and pruned") || !require(equal(ids(
+                                                                                         applications.recentApplications),
+                                                                                     ["app8.desktop"]),
+                                                                               "pinned ID was not excluded from recents")
+                || !require(applications.normalizeIds(many, 20).length === 20,
+                            "ID normalization did not enforce the MRU bound") || !require(
+                    applications.parseStore("pins", {
+                                                "available": true,
+                                                "category": "loaded",
+                                                "text": "{\"version\":2,\"desktopFileIds\":[\"app0.desktop\"]}"
+                                            }, 8).length === 0,
+                    "unknown store version was partially recovered") || !require(
+                    applications.parseStore("pins", {
+                                                "available": true,
+                                                "category": "loaded",
+                                                "text": "not json"
+                                            }, 8).length === 0,
+                    "malformed store was partially recovered")) {
+            return;
+        }
+
+        const retainedApplications = ids(applications.applications);
+        const retainedPins = applications.pinIds.slice();
+        const retainedRecency = applications.recencyIds.slice();
+        applications.markDiscoveryIncomplete("controlled incomplete generation");
+        if (!require(!applications.available, "incomplete generation remained available") ||
+                !require(equal(ids(applications.applications), retainedApplications),
+                         "incomplete generation replaced the last complete model") || !require(equal(
+                                                                                                   applications.pinIds,
+                                                                                                   retainedPins),
+                                                                                               "incomplete generation rewrote pins")
+                || !require(equal(applications.recencyIds, retainedRecency),
+                            "incomplete generation rewrote MRU")) {
+            return;
+        }
+        stage = "restore-discovery";
+        applications.captureDiscoveryGeneration();
+    }
+
+    function beginLifecycle() {
+        stage = "hidden-write";
+        appWriter.setText(
+                    "[Desktop Entry]\nType=Application\nName=Fixture 0\nHidden=true\nExec=/usr/bin/true\n");
+        renamedWriter.setText(
+                    "[Desktop Entry]\nType=Application\nName=Renamed Fixture\nExec=/usr/bin/true\n");
+    }
+
+    function checkLifecycle() {
+        if (stage === "hidden-wait" && ids(applications.pinnedApplications).indexOf("app0.desktop")
+                === -1 && ids(applications.applications).indexOf("renamed.desktop") !== -1) {
+            if (!require(applications.pinIds.indexOf("app0.desktop") !== -1,
+                         "missing pin was not kept dormant") || !require(ids(
+                                                                             applications.pinnedApplications).indexOf(
+                                                                             "renamed.desktop") ===
+                                                                         -1, "pin migrated to a changed desktop ID")) {
+                return;
+            }
+            stage = "restore-write";
+            appWriter.setText(
+                        "[Desktop Entry]\nType=Application\nName=Fixture 0 Restored\nExec=/usr/bin/true\nIcon=restored\nKeywords=restored;\n");
+        } else if (stage === "restore-wait" && ids(applications.pinnedApplications).indexOf(
+                       "app0.desktop") !== -1) {
+            if (!require(applications.entryById === undefined,
+                         "private exact-ID map leaked through the public API") || !require(
+                        applications.recencyIds.indexOf("app0.desktop") === -1,
+                        "pruned MRU returned after same-ID reinstall")) {
+                return;
+            }
+            beginPinMutations();
+        }
+    }
+
+    function beginPinMutations() {
+        stage = "pinning";
+        for (let index = 1; index <= 6; ++index) {
+            if (!require(applications.pin("app" + index + ".desktop"),
+                         "eligible pin request was rejected")) {
+                return;
+            }
+        }
+    }
+
+    ApplicationModel {
+        id: applications
+
+        helperPath: Quickshell.env("NAGI_APPLICATION_HELPER")
+
+        onInitializedChanged: test.runInitialAssertions()
+        onAvailableChanged: {
+            if (test.stage === "restore-discovery" && applications.available) {
+                test.beginLifecycle();
+            }
+        }
+        onApplicationsChanged: test.checkLifecycle()
+        onPinnedApplicationsChanged: test.checkLifecycle()
+        onPinCommitted: desktopFileId => {
+            if (test.stage === "pinning" && applications.pinIds.length === 8) {
+                if (!test.require(!applications.pin("app7.desktop"), "ninth pin was not rejected")
+                        || !test.require(applications.pinFailure === "limit",
+                                         "pin limit failure was not exposed")) {
+                    return;
+                }
+                test.stage = "moving";
+                test.require(applications.movePin("app6.desktop", 0),
+                             "pin reorder request was rejected");
+            }
+        }
+        onPinReordered: desktopFileId => {
+            if (test.stage !== "moving") {
+                return;
+            }
+            if (!test.require(applications.pinIds[0] === "app6.desktop",
+                              "pin order did not commit after save")) {
+                return;
+            }
+            test.stage = "unpinning";
+            test.require(applications.unpin("app0.desktop"), "unpin request was rejected");
+        }
+        onPinRemoved: desktopFileId => {
+            if (test.stage !== "unpinning") {
+                return;
+            }
+            test.stage = "launching";
+            test.require(applications.recordAcceptedLaunch("app9.desktop"),
+                         "accepted launch did not update MRU");
+        }
+        onRecencyPersisted: {
+            if (test.stage === "unsafe-launch" && applications.recencyIds[0] === "app7.desktop") {
+                console.log("application model isolated-store failure tests passed");
+                Qt.exit(0);
+                return;
+            }
+            if (test.stage !== "launching" || applications.recencyIds[0] !== "app9.desktop") {
+                return;
+            }
+            if (!test.require(equal(applications.recencyIds, ["app9.desktop", "app8.desktop"]),
+                              "accepted launch did not move to MRU front") || !test.require(equal(
+                                                                                                ids(applications.recentApplications),
+                                                                                                ["app9.desktop",
+                                                                                                 "app8.desktop"]),
+                                                                                            "recent rows do not follow MRU order")) {
+                return;
+            }
+            console.log("application model mutation tests passed");
+            Qt.exit(0);
+        }
+    }
+
+    FileView {
+        id: appWriter
+
+        path: Quickshell.env("XDG_DATA_HOME") + "/applications/app0.desktop"
+        atomicWrites: true
+        printErrors: false
+        onSaved: {
+            if (test.stage === "hidden-write") {
+                test.stage = "hidden-wait";
+            } else if (test.stage === "restore-write") {
+                test.stage = "restore-wait";
+            }
+        }
+    }
+
+    FileView {
+        id: renamedWriter
+
+        path: Quickshell.env("XDG_DATA_HOME") + "/applications/renamed.desktop"
+        atomicWrites: true
+        preload: false
+        printErrors: false
+    }
+
+    Timer {
+        interval: 15000
+        running: true
+        onTriggered: {
+            console.error("FAIL: application model tests timed out at " + test.stage);
+            Qt.exit(1);
+        }
+    }
+
+    Component.onCompleted: Qt.callLater(test.runInitialAssertions)
+}

--- a/tests/applications_helper_test.cpp
+++ b/tests/applications_helper_test.cpp
@@ -1,0 +1,311 @@
+#define QT_NO_KEYWORDS
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QSaveFile>
+#include <QSet>
+#include <QTemporaryDir>
+
+#include <cstdio>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace {
+[[noreturn]] void fail(const char *message)
+{
+    std::fprintf(stderr, "FAIL: %s\n", message);
+    std::fflush(stderr);
+    std::exit(1);
+}
+
+void require(bool condition, const char *message)
+{
+    if (!condition) {
+        fail(message);
+    }
+}
+
+void writeFile(const QString &path, const QByteArray &contents, QFile::Permissions permissions = {})
+{
+    QFile file(path);
+    require(file.open(QIODevice::WriteOnly | QIODevice::Truncate), "could not create fixture");
+    require(file.write(contents) == contents.size(), "could not write fixture");
+    file.close();
+    if (permissions != QFile::Permissions {}) {
+        require(file.setPermissions(permissions), "could not set fixture permissions");
+    }
+}
+
+void writeDesktop(const QString &directory, const QString &name, const QByteArray &body)
+{
+    QDir().mkpath(directory);
+    writeFile(directory + u'/' + name, body);
+}
+
+class HelperProcess {
+public:
+    HelperProcess(const QString &path, const QString &pinsPath, const QString &recencyPath,
+                  const QProcessEnvironment &environment)
+    {
+        process.setProcessEnvironment(environment);
+        process.start(path, {pinsPath, recencyPath});
+        require(process.waitForStarted(3000), "helper did not start");
+    }
+
+    ~HelperProcess()
+    {
+        if (process.state() != QProcess::NotRunning) {
+            send(QJsonObject {{QStringLiteral("op"), QStringLiteral("shutdown")}});
+            process.waitForFinished(1000);
+        }
+    }
+
+    QJsonObject next()
+    {
+        buffer.append(process.readAllStandardOutput());
+        while (!buffer.contains('\n')) {
+            if (!process.waitForReadyRead(3000)) {
+                const QByteArray diagnostic = process.readAllStandardError();
+                std::fprintf(stderr, "helper timeout after %d responses; state=%d exit=%d stderr=%s\n",
+                             responseCount, static_cast<int>(process.state()), process.exitCode(),
+                             diagnostic.constData());
+                fail("helper response timed out");
+            }
+            buffer.append(process.readAllStandardOutput());
+        }
+        const qsizetype newline = buffer.indexOf('\n');
+        const QByteArray line = buffer.first(newline);
+        buffer.remove(0, newline + 1);
+        QJsonParseError error {};
+        const QJsonDocument document = QJsonDocument::fromJson(line, &error);
+        require(error.error == QJsonParseError::NoError && document.isObject(),
+                "helper returned invalid JSON");
+        ++responseCount;
+        return document.object();
+    }
+
+    QJsonObject request(const QJsonObject &command)
+    {
+        send(command);
+        return next();
+    }
+
+private:
+    void send(const QJsonObject &command)
+    {
+        QByteArray line = QJsonDocument(command).toJson(QJsonDocument::Compact);
+        line.append('\n');
+        require(process.write(line) == line.size(), "helper command write failed");
+        require(process.waitForBytesWritten(1000), "helper command did not flush");
+    }
+
+    QProcess process;
+    QByteArray buffer;
+    int responseCount = 0;
+};
+
+QSet<QString> ids(const QJsonObject &generation)
+{
+    QSet<QString> result;
+    const QJsonArray entries = generation.value(QStringLiteral("entries")).toArray();
+    for (const QJsonValue &value : entries) {
+        result.insert(value.toObject().value(QStringLiteral("id")).toString());
+    }
+    return result;
+}
+
+QFile::Permissions privatePermissions()
+{
+    return QFile::ReadOwner | QFile::WriteOwner;
+}
+}
+
+int main(int argc, char **argv)
+{
+    QCoreApplication application(argc, argv);
+    require(application.arguments().size() == 2, "helper path argument is required");
+
+    QTemporaryDir temporary;
+    require(temporary.isValid(), "temporary directory is unavailable");
+    const QString root = temporary.path();
+    const QString highApplications = root + QStringLiteral("/data-high/applications");
+    const QString lowApplications = root + QStringLiteral("/data-low/applications");
+    const QString configBase = root + QStringLiteral("/config");
+    const QString stateBase = root + QStringLiteral("/state");
+    require(QDir().mkpath(configBase) && QDir().mkpath(stateBase), "could not create XDG bases");
+
+    writeDesktop(highApplications, QStringLiteral("valid.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=Valid\nExec=/usr/bin/true\n");
+    writeDesktop(highApplications, QStringLiteral("precedence.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=Masked\nNoDisplay=true\nExec=/usr/bin/true\n");
+    writeDesktop(lowApplications, QStringLiteral("precedence.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=Lower\nExec=/usr/bin/true\n");
+    writeDesktop(highApplications, QStringLiteral("gnome-only.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=GNOME\nOnlyShowIn=GNOME;\nExec=/usr/bin/true\n");
+    writeDesktop(highApplications, QStringLiteral("missing-tryexec.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=TryExec\nTryExec=/not/installed\nExec=/usr/bin/true\n");
+    writeDesktop(highApplications, QStringLiteral("invalid-exec.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=Invalid Exec\nExec=/usr/bin/true %Z\n");
+    writeDesktop(highApplications, QStringLiteral("org.example.InvalidDbus.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=Invalid D-Bus fallback\nDBusActivatable=true\nExec=/usr/bin/true %Z\n");
+    writeDesktop(highApplications, QStringLiteral("terminal.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=Terminal\nTerminal=true\nExec=/usr/bin/true\n");
+    writeDesktop(highApplications, QStringLiteral("no-launch.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=No launch\n");
+    writeDesktop(highApplications, QStringLiteral("hidden.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=Hidden\nHidden=true\nExec=/usr/bin/true\n");
+    writeDesktop(highApplications, QStringLiteral("wrong-type.desktop"),
+                 "[Desktop Entry]\nType=Link\nName=Link\nURL=https://example.invalid\n");
+    writeDesktop(highApplications, QStringLiteral("malformed.desktop"),
+                 "not a desktop entry\n");
+    writeDesktop(highApplications, QStringLiteral("org.example.Dbus.desktop"),
+                 "[Desktop Entry]\nType=Application\nName=D-Bus\nDBusActivatable=true\n");
+
+    const QString pinsPath = configBase + QStringLiteral("/nagi-shell/application-pins.json");
+    const QString recencyPath = stateBase + QStringLiteral("/nagi-shell/application-recency.json");
+    require(QDir().mkpath(QFileInfo(pinsPath).absolutePath()), "could not create pins directory");
+    writeFile(pinsPath,
+              "{\n  \"version\": 1,\n  \"desktopFileIds\": [\n    \"valid.desktop\"\n  ]\n}\n",
+              privatePermissions());
+
+    QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+    environment.insert(QStringLiteral("XDG_DATA_HOME"), root + QStringLiteral("/data-high"));
+    environment.insert(QStringLiteral("XDG_DATA_DIRS"), root + QStringLiteral("/data-low"));
+    environment.insert(QStringLiteral("XDG_CURRENT_DESKTOP"), QStringLiteral("KDE"));
+
+    {
+        HelperProcess helper(application.arguments().at(1), pinsPath, recencyPath, environment);
+        const QJsonObject initialized = helper.next();
+        require(initialized.value(QStringLiteral("type")) == QStringLiteral("initialized"),
+                "helper did not initialize");
+        const QJsonObject stores = initialized.value(QStringLiteral("stores")).toObject();
+        require(stores.value(QStringLiteral("pins")).toObject().value(QStringLiteral("category"))
+                    == QStringLiteral("loaded"),
+                "valid pins were not loaded");
+        require(stores.value(QStringLiteral("recency")).toObject().value(QStringLiteral("category"))
+                    == QStringLiteral("missing"),
+                "missing recency was not clean first-run state");
+
+        const QJsonObject generation = helper.request(
+            QJsonObject {{QStringLiteral("op"), QStringLiteral("scan")},
+                         {QStringLiteral("generation"), 1}});
+        require(generation.value(QStringLiteral("complete")).toBool(),
+                "fixture discovery was incomplete");
+        require(ids(generation)
+                    == QSet<QString> {QStringLiteral("valid.desktop"),
+                                      QStringLiteral("org.example.Dbus.desktop")},
+                "ineligible desktop entries were not excluded");
+
+        const QJsonObject ready = helper.request(
+            QJsonObject {{QStringLiteral("op"), QStringLiteral("prepare-write")},
+                         {QStringLiteral("store"), QStringLiteral("recency")},
+                         {QStringLiteral("serial"), 2}});
+        require(ready.value(QStringLiteral("success")).toBool(),
+                "missing recency file was not prepared");
+
+        struct stat status {};
+        const QByteArray nativeRecency = QFile::encodeName(recencyPath);
+        require(::lstat(nativeRecency.constData(), &status) == 0 && S_ISREG(status.st_mode)
+                    && (status.st_mode & 0777) == 0600 && status.st_uid == getuid(),
+                "prepared recency file is not private");
+
+        const QJsonObject emptyVerified = helper.request(
+            QJsonObject {{QStringLiteral("op"), QStringLiteral("verify-write")},
+                         {QStringLiteral("store"), QStringLiteral("recency")},
+                         {QStringLiteral("serial"), 2}});
+        require(emptyVerified.value(QStringLiteral("success")).toBool(),
+                "empty first-write store was not accepted");
+
+        QSaveFile save(recencyPath);
+        require(save.open(QIODevice::WriteOnly), "could not open atomic recency save");
+        const QByteArray recency =
+            "{\n  \"version\": 1,\n  \"desktopFileIds\": [\n    \"valid.desktop\"\n  ]\n}\n";
+        require(save.write(recency) == recency.size() && save.commit(),
+                "atomic recency save failed");
+        const QJsonObject verified = helper.request(
+            QJsonObject {{QStringLiteral("op"), QStringLiteral("verify-write")},
+                         {QStringLiteral("store"), QStringLiteral("recency")},
+                         {QStringLiteral("serial"), 2}});
+        require(verified.value(QStringLiteral("success")).toBool(),
+                "atomic recency save was not verified");
+
+        QSaveFile interrupted(recencyPath);
+        require(interrupted.open(QIODevice::WriteOnly), "could not open interrupted save");
+        interrupted.write("partial");
+        interrupted.cancelWriting();
+        QFile unchanged(recencyPath);
+        require(unchanged.open(QIODevice::ReadOnly) && unchanged.readAll() == recency,
+                "interrupted atomic save changed the committed file");
+    }
+
+    QFile::remove(highApplications + QStringLiteral("/precedence.desktop"));
+    {
+        HelperProcess helper(application.arguments().at(1), pinsPath, recencyPath, environment);
+        helper.next();
+        const QJsonObject generation = helper.request(
+            QJsonObject {{QStringLiteral("op"), QStringLiteral("scan")},
+                         {QStringLiteral("generation"), 2}});
+        require(ids(generation).contains(QStringLiteral("precedence.desktop")),
+                "lower-precedence same-ID entry did not return");
+    }
+
+    const QString unsafeBase = root + QStringLiteral("/unsafe");
+    require(QDir().mkpath(unsafeBase + QStringLiteral("/nagi-shell")),
+            "could not create unsafe fixture directory");
+    const QString unsafePins = unsafeBase + QStringLiteral("/nagi-shell/application-pins.json");
+    const QByteArray nativePins = QFile::encodeName(pinsPath);
+    const QByteArray nativeUnsafe = QFile::encodeName(unsafePins);
+    require(::symlink(nativePins.constData(), nativeUnsafe.constData()) == 0,
+            "could not create symlink fixture");
+    {
+        HelperProcess helper(application.arguments().at(1), unsafePins, recencyPath, environment);
+        const QJsonObject stores = helper.next().value(QStringLiteral("stores")).toObject();
+        const QJsonObject pins = stores.value(QStringLiteral("pins")).toObject();
+        require(!pins.value(QStringLiteral("available")).toBool()
+                    && pins.value(QStringLiteral("category")) == QStringLiteral("symlink"),
+                "symlink store was not refused");
+    }
+
+    const QString oversizedBase = root + QStringLiteral("/oversized");
+    const QString oversizedPins =
+        oversizedBase + QStringLiteral("/nagi-shell/application-pins.json");
+    require(QDir().mkpath(QFileInfo(oversizedPins).absolutePath()),
+            "could not create oversized fixture directory");
+    writeFile(oversizedPins, QByteArray(128 * 1024 + 1, 'x'), privatePermissions());
+    {
+        HelperProcess helper(application.arguments().at(1), oversizedPins, recencyPath, environment);
+        const QJsonObject pins = helper.next()
+                                     .value(QStringLiteral("stores"))
+                                     .toObject()
+                                     .value(QStringLiteral("pins"))
+                                     .toObject();
+        require(pins.value(QStringLiteral("available")).toBool()
+                    && pins.value(QStringLiteral("category")) == QStringLiteral("oversized")
+                    && !pins.contains(QStringLiteral("text")),
+                "oversized store was read or disabled incorrectly");
+    }
+
+    require(QDir(highApplications).removeRecursively(),
+            "could not replace discovery fixture directory");
+    writeFile(highApplications, "not a directory");
+    {
+        HelperProcess helper(application.arguments().at(1), pinsPath, recencyPath, environment);
+        helper.next();
+        const QJsonObject generation = helper.request(
+            QJsonObject {{QStringLiteral("op"), QStringLiteral("scan")},
+                         {QStringLiteral("generation"), 3}});
+        require(!generation.value(QStringLiteral("complete")).toBool()
+                    && generation.value(QStringLiteral("failure")) == QStringLiteral("discovery"),
+                "invalid discovery path became an authoritative empty generation");
+    }
+
+    qInfo("application helper tests passed");
+    return 0;
+}


### PR DESCRIPTION
Use GIO to validate canonical desktop IDs and launch eligibility where
Quickshell 0.3.1 lacks the required metadata. Persist ordered pins and
recency through private atomic XDG stores.

Closes #24