### PR TITLE
feat(tray): add system tray access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ AUDIO_LIVE_WRITE_TEST_DIR := $(BUILD_DIR)/audio-live-write-test
 SURFACE_STATE_TEST_DIR := $(BUILD_DIR)/surface-state-test
 UI_PRIMITIVES_TEST_DIR := $(BUILD_DIR)/ui-primitives-test
 IDLE_TEST_DIR := $(BUILD_DIR)/idle-test
+TRAY_TEST_DIR := $(BUILD_DIR)/tray-test
+TRAY_LIVE_TEST_DIR := $(BUILD_DIR)/tray-live-test
+TRAY_LIVE_TEST := $(BUILD_DIR)/tray-live-test-runner
 APPLICATION_TEST := $(BUILD_DIR)/applications-helper-test
 APPLICATION_QML_TEST_DIR := $(BUILD_DIR)/applications-test
 NOTIFICATION_BUILD_DIR := $(BUILD_DIR)/notifications
@@ -57,6 +60,8 @@ QT_CFLAGS := $(shell $(PKG_CONFIG) --cflags Qt6Core Qt6DBus)
 QT_LIBS := $(shell $(PKG_CONFIG) --libs Qt6Core Qt6DBus)
 NOTIFICATION_QT_CFLAGS := $(shell $(PKG_CONFIG) --cflags Qt6Core Qt6DBus Qt6Qml)
 NOTIFICATION_QT_LIBS := $(shell $(PKG_CONFIG) --libs Qt6Core Qt6DBus Qt6Qml)
+TRAY_QT_CFLAGS := $(shell $(PKG_CONFIG) --cflags Qt6Core Qt6Gui Qt6Widgets)
+TRAY_QT_LIBS := $(shell $(PKG_CONFIG) --libs Qt6Core Qt6Gui Qt6Widgets)
 PIPEWIRE_CFLAGS := $(shell $(PKG_CONFIG) --cflags libpipewire-0.3)
 PIPEWIRE_LIBS := $(shell $(PKG_CONFIG) --libs libpipewire-0.3)
 GIO_CFLAGS := $(shell $(PKG_CONFIG) --cflags gio-unix-2.0)
@@ -70,7 +75,7 @@ QUICKSHELL_CHANNEL := stable
 FEDORA_QUICKSHELL_COPR := errornointernet/quickshell
 FEDORA_QUICKSHELL_PACKAGE := quickshell
 
-.PHONY: help requirements prepare check-quickshell check-helper-toolchain check-audio-toolchain check-application-toolchain check-notification-toolchain helper audio-helper connectivity-helper application-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-applications test-notifications test-adapter test-coordinator test-weather test-media test-audio test-audio-live test-audio-live-write test-connectivity test-connectivity-live-write test-idle test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
+.PHONY: help requirements prepare check-quickshell check-helper-toolchain check-audio-toolchain check-application-toolchain check-notification-toolchain check-tray-toolchain helper audio-helper connectivity-helper application-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-applications test-notifications test-adapter test-coordinator test-weather test-media test-audio test-audio-live test-audio-live-write test-connectivity test-connectivity-live-write test-tray test-tray-live test-idle test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
 
 help:
 	@printf '%s\n' \
@@ -97,6 +102,8 @@ help:
 		'make test-audio-live-write  Change and restore live default audio state' \
 		'make test-connectivity  Test Wi-Fi and Bluetooth adapter state' \
 		'make test-connectivity-live-write  Change and restore live radios' \
+		'make test-tray       Test system tray lifecycle and actions' \
+		'make test-tray-live  Exercise a controlled real tray item on KDE' \
 		'make test-ui-primitives  Render theme tokens and primitives in the island surface' \
 		'make test-idle       Test idle island composition and collapse' \
 		'make launch          Run this checkout in the foreground' \
@@ -114,13 +121,14 @@ help:
 requirements:
 	@printf 'Quickshell >= %s from the %s release channel\n' '$(QUICKSHELL_MIN_VERSION)' '$(QUICKSHELL_CHANNEL)'
 	@printf 'Fedora 44 source: COPR %s, package %s (never quickshell-git)\n' '$(FEDORA_QUICKSHELL_COPR)' '$(FEDORA_QUICKSHELL_PACKAGE)'
-	@printf 'Install: sudo dnf copr enable %s && sudo dnf install %s pipewire-devel glib2-devel qt6-qtdeclarative-devel\n' '$(FEDORA_QUICKSHELL_COPR)' '$(FEDORA_QUICKSHELL_PACKAGE)'
-	@printf 'Native builds: C++20, Qt 6 Core/DBus/QML, libpipewire 0.3, and GIO Unix development files\n'
+	@printf 'Install: sudo dnf copr enable %s && sudo dnf install %s pipewire-devel glib2-devel qt6-qtbase-devel qt6-qtdeclarative-devel\n' '$(FEDORA_QUICKSHELL_COPR)' '$(FEDORA_QUICKSHELL_PACKAGE)'
+	@printf 'Native builds: C++20, Qt 6 Core/DBus/GUI/Widgets/QML, libpipewire 0.3, and GIO Unix development files\n'
 	@$(MAKE) --no-print-directory check-quickshell
 	@$(MAKE) --no-print-directory check-helper-toolchain
 	@$(MAKE) --no-print-directory check-audio-toolchain
 	@$(MAKE) --no-print-directory check-application-toolchain
 	@$(MAKE) --no-print-directory check-notification-toolchain
+	@$(MAKE) --no-print-directory check-tray-toolchain
 
 prepare:
 	@touch .qmlls.ini
@@ -138,6 +146,9 @@ check-application-toolchain:
 check-notification-toolchain:
 	@$(PKG_CONFIG) --exists Qt6Core Qt6DBus Qt6Qml
 	@test -x '$(MOC)'
+
+check-tray-toolchain:
+	@$(PKG_CONFIG) --exists Qt6Core Qt6Gui Qt6Widgets
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
@@ -212,6 +223,9 @@ $(NOTIFICATION_TEST): tests/notification_runtime_test.cpp $(NOTIFICATION_TEST_MO
 
 $(NOTIFICATION_DBUS_TEST): tests/notifications_dbus_test.cpp $(NOTIFICATION_DBUS_TEST_MOC) | $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(QT_CFLAGS) -I$(NOTIFICATION_BUILD_DIR) tests/notifications_dbus_test.cpp -o $@ $(LDFLAGS) $(QT_LIBS)
+
+$(TRAY_LIVE_TEST): tests/tray_live_test.cpp | $(BUILD_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(TRAY_QT_CFLAGS) tests/tray_live_test.cpp -o $@ $(LDFLAGS) $(TRAY_QT_LIBS)
 
 helper: check-helper-toolchain $(HELPER)
 
@@ -319,6 +333,18 @@ test-connectivity-live-write: check-quickshell connectivity-helper | $(BUILD_DIR
 	cp qml/ConnectivityAdapter.qml qml/ConnectivityBridge.qml $(CONNECTIVITY_LIVE_WRITE_TEST_DIR)/qml/
 	NAGI_CONNECTIVITY_HELPER='$(abspath $(CONNECTIVITY_HELPER))' $(QS) -p $(CONNECTIVITY_LIVE_WRITE_TEST_DIR) --no-duplicate
 
+test-tray: check-quickshell | $(BUILD_DIR)
+	mkdir -p $(TRAY_TEST_DIR)/qml
+	cp tests/tray/shell.qml $(TRAY_TEST_DIR)/shell.qml
+	cp qml/TrayAdapter.qml $(TRAY_TEST_DIR)/qml/
+	$(QS) -p $(TRAY_TEST_DIR) --no-duplicate
+
+test-tray-live: check-quickshell check-tray-toolchain $(TRAY_LIVE_TEST) | $(BUILD_DIR)
+	mkdir -p $(TRAY_LIVE_TEST_DIR)/qml
+	cp tests/tray/live.qml $(TRAY_LIVE_TEST_DIR)/shell.qml
+	cp qml/TrayAdapter.qml $(TRAY_LIVE_TEST_DIR)/qml/
+	$(TRAY_LIVE_TEST) '$(QS)' '$(abspath $(TRAY_LIVE_TEST_DIR))'
+
 test-surface-state: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(SURFACE_STATE_TEST_DIR)/qml
 	cp tests/surface-state/shell.qml $(SURFACE_STATE_TEST_DIR)/shell.qml
@@ -328,7 +354,7 @@ test-surface-state: check-quickshell | $(BUILD_DIR)
 test-ui-primitives: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(UI_PRIMITIVES_TEST_DIR)/qml
 	cp tests/ui/shell.qml $(UI_PRIMITIVES_TEST_DIR)/shell.qml
-	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/IslandProgressBar.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/IslandStateCoordinator.qml qml/IslandSurface.qml $(UI_PRIMITIVES_TEST_DIR)/qml/
+	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/IslandProgressBar.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/IslandStateCoordinator.qml qml/IslandSurface.qml qml/TrayView.qml $(UI_PRIMITIVES_TEST_DIR)/qml/
 	$(QS) -p $(UI_PRIMITIVES_TEST_DIR) --no-duplicate
 
 test-idle: check-quickshell | $(BUILD_DIR)
@@ -401,6 +427,6 @@ lint-advisory:
 
 check: check-nondisplay test-surface-state test-ui-primitives
 
-check-nondisplay: check-quickshell format-check audio-helper connectivity-helper application-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-applications test-notifications test-adapter test-coordinator test-weather test-media test-audio test-connectivity test-idle
+check-nondisplay: check-quickshell format-check audio-helper connectivity-helper application-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-applications test-notifications test-adapter test-coordinator test-weather test-media test-audio test-connectivity test-tray test-idle
 clean:
 	rm -rf $(BUILD_DIR)

--- a/qml/TrayAdapter.qml
+++ b/qml/TrayAdapter.qml
@@ -1,0 +1,327 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Services.SystemTray
+import QtQuick
+
+// Stable SystemTray boundary for presentation. Views receive immutable,
+// bounded snapshots and opaque generation tokens; backend item objects and
+// platform menu handles stay private to this adapter.
+Scope {
+    id: root
+
+    // Verification seam. Production observes SystemTray.items directly.
+    property var itemsModel: null
+
+    readonly property int maximumTextCharacters: 256
+    readonly property int maximumIdentityCharacters: 128
+    readonly property int maximumIconSourceCharacters: 4096
+
+    readonly property var items: engine.snapshots
+    readonly property int itemCount: items.length
+    readonly property bool available: itemCount > 0
+    readonly property int trackedItemCount: engine.records.length
+
+    function activate(token) {
+        return engine.dispatch(token, "activate", null, 0, 0);
+    }
+
+    function secondaryActivate(token) {
+        return engine.dispatch(token, "secondary", null, 0, 0);
+    }
+
+    function openMenu(token, parentWindow, relativeX, relativeY) {
+        return engine.dispatch(token, "menu", parentWindow, relativeX, relativeY);
+    }
+
+    // Flushes coalesced lifecycle/property updates for deterministic tests.
+    function processPendingChanges() {
+        engine.flushScheduled();
+    }
+
+    Component.onCompleted: engine.rebuild()
+    Component.onDestruction: engine.hardReset()
+    onItemsModelChanged: engine.scheduleRebuild()
+
+    Connections {
+        target: engine.currentModel
+        ignoreUnknownSignals: true
+
+        function onValuesChanged() {
+            engine.scheduleRebuild();
+        }
+    }
+
+    Component {
+        id: itemWatcher
+
+        Connections {
+            ignoreUnknownSignals: true
+
+            function onIdChanged() {
+                engine.scheduleRebuild();
+            }
+
+            function onTitleChanged() {
+                engine.scheduleRebuild();
+            }
+
+            function onIconChanged() {
+                engine.scheduleRebuild();
+            }
+
+            function onStatusChanged() {
+                engine.scheduleRebuild();
+            }
+
+            function onCategoryChanged() {
+                engine.scheduleRebuild();
+            }
+
+            function onTooltipTitleChanged() {
+                engine.scheduleRebuild();
+            }
+
+            function onTooltipDescriptionChanged() {
+                engine.scheduleRebuild();
+            }
+
+            function onHasMenuChanged() {
+                engine.scheduleRebuild();
+            }
+
+            function onOnlyMenuChanged() {
+                engine.scheduleRebuild();
+            }
+        }
+    }
+
+    QtObject {
+        id: engine
+
+        property var records: []
+        property var snapshots: []
+        property int nextToken: 1
+        property bool scheduled: false
+        readonly property var currentModel: root.itemsModel === null ? SystemTray.items :
+                                                                       root.itemsModel
+
+        function safeRead(object, name, fallback) {
+            if (object === null || object === undefined) {
+                return fallback;
+            }
+
+            try {
+                const value = object[name];
+                return value === undefined ? fallback : value;
+            } catch (error) {
+                return fallback;
+            }
+        }
+
+        function normalizeText(value, limit) {
+            if (typeof value !== "string") {
+                return "";
+            }
+
+            const cleaned = value.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ").replace(/\s+/g,
+                                                                                        " ").trim();
+            return cleaned.length > limit ? cleaned.slice(0, limit) : cleaned;
+        }
+
+        function normalizeIconSource(value) {
+            if (typeof value !== "string" || value.length === 0 || value.length > root.maximumIconSourceCharacters
+                    || /[\u0000-\u001f\u007f-\u009f]/.test(value)) {
+                return "";
+            }
+            return value;
+        }
+
+        function statusName(value) {
+            if (value === Status.NeedsAttention) {
+                return "needsAttention";
+            }
+            if (value === Status.Active) {
+                return "active";
+            }
+            return "passive";
+        }
+
+        function allocateToken() {
+            const token = nextToken;
+            nextToken = nextToken >= 2147483647 ? 1 : nextToken + 1;
+            return token;
+        }
+
+        function findRecord(item) {
+            for (let index = 0; index < records.length; ++index) {
+                if (records[index].item === item) {
+                    return records[index];
+                }
+            }
+            return null;
+        }
+
+        function findToken(token) {
+            if (!Number.isInteger(token) || token <= 0) {
+                return null;
+            }
+            for (let index = 0; index < records.length; ++index) {
+                if (records[index].token === token) {
+                    return records[index];
+                }
+            }
+            return null;
+        }
+
+        function adopt(item) {
+            const record = {
+                "item": item,
+                "token": allocateToken(),
+                "watcher": null
+            };
+            record.watcher = itemWatcher.createObject(root, {
+                                                          "target": item
+                                                      });
+            return record;
+        }
+
+        function disposeRecord(record) {
+            if (record.watcher !== null) {
+                try {
+                    record.watcher.destroy();
+                } catch (error) {
+                    // The watcher may already have died with its backend item.
+                }
+                record.watcher = null;
+            }
+            record.item = null;
+        }
+
+        function snapshot(record) {
+            const item = record.item;
+            let label = normalizeText(safeRead(item, "tooltipTitle", ""),
+                                      root.maximumTextCharacters);
+            if (label === "") {
+                label = normalizeText(safeRead(item, "title", ""), root.maximumTextCharacters);
+            }
+            if (label === "") {
+                label = normalizeText(safeRead(item, "id", ""), root.maximumIdentityCharacters);
+            }
+            if (label === "") {
+                label = "Tray item";
+            }
+
+            const description = normalizeText(safeRead(item, "tooltipDescription", ""),
+                                              root.maximumTextCharacters);
+            return {
+                "token": record.token,
+                "label": label,
+                "tooltip": description === "" ? label : label + "\n" + description,
+                "iconSource": normalizeIconSource(safeRead(item, "icon", "")),
+                "status": statusName(safeRead(item, "status", Status.Passive)),
+                "hasMenu": safeRead(item, "hasMenu", false) === true,
+                "onlyMenu": safeRead(item, "onlyMenu", false) === true
+            };
+        }
+
+        function modelValues() {
+            const values = safeRead(currentModel, "values", null);
+            if (values === null || typeof values !== "object" || typeof values.length
+                    !== "number") {
+
+                return [];
+            }
+            return values;
+        }
+
+        function scheduleRebuild() {
+            if (scheduled) {
+                return;
+            }
+            scheduled = true;
+            Qt.callLater(engine.rebuild);
+        }
+
+        function flushScheduled() {
+            if (scheduled) {
+                rebuild();
+            }
+        }
+
+        function rebuild() {
+            scheduled = false;
+            const values = modelValues();
+            const nextRecords = [];
+
+            for (let valueIndex = 0; valueIndex < values.length; ++valueIndex) {
+                const item = values[valueIndex];
+                if (item === null || item === undefined) {
+                    continue;
+                }
+                const existing = findRecord(item);
+                nextRecords.push(existing === null ? adopt(item) : existing);
+            }
+
+            for (let recordIndex = 0; recordIndex < records.length; ++recordIndex) {
+                if (nextRecords.indexOf(records[recordIndex]) === -1) {
+                    disposeRecord(records[recordIndex]);
+                }
+            }
+
+            records = nextRecords;
+            const nextSnapshots = [];
+            for (let index = 0; index < records.length; ++index) {
+                nextSnapshots.push(snapshot(records[index]));
+            }
+            snapshots = nextSnapshots;
+        }
+
+        function menuCoordinate(value) {
+            return Math.max(-2147483648, Math.min(2147483647, Math.round(value)));
+        }
+
+        function dispatch(token, action, parentWindow, relativeX, relativeY) {
+            const record = findToken(token);
+            if (record === null || record.item === null) {
+                return "rejected";
+            }
+
+            try {
+                if (action === "activate") {
+                    if (safeRead(record.item, "onlyMenu", false) === true) {
+                        return "rejected";
+                    }
+                    record.item.activate();
+                } else if (action === "secondary") {
+                    record.item.secondaryActivate();
+                } else if (action === "menu") {
+                    if (parentWindow === null || parentWindow === undefined || safeRead(record.item,
+                                                                                        "hasMenu",
+                                                                                        false)
+                            !== true || typeof relativeX !== "number" || !Number.isFinite(
+                                relativeX) || typeof relativeY !== "number" || !Number.isFinite(
+                                relativeY)) {
+                        return "rejected";
+                    }
+                    record.item.display(parentWindow, menuCoordinate(relativeX), menuCoordinate(
+                                            relativeY));
+                } else {
+                    return "rejected";
+                }
+            } catch (error) {
+                return "rejected";
+            }
+            return "dispatched";
+        }
+
+        function hardReset() {
+            scheduled = false;
+            for (let index = 0; index < records.length; ++index) {
+                disposeRecord(records[index]);
+            }
+            records = [];
+            snapshots = [];
+        }
+    }
+}

--- a/qml/TrayView.qml
+++ b/qml/TrayView.qml
@@ -1,0 +1,202 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell.Widgets
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
+
+// Presentation-only tray row. It renders normalized snapshots and delegates
+// every platform action back to TrayAdapter.
+FocusScope {
+    id: root
+
+    required property var adapter
+
+    readonly property int itemCount: adapter === null ? 0 : adapter.items.length
+    readonly property bool empty: itemCount === 0
+    readonly property int controlExtent: Theme.size.controlHeightMd
+    readonly property var currentItem: trayList.currentItem
+
+    implicitHeight: empty ? 0 : column.implicitHeight
+    visible: !empty
+
+    function menuPosition(button) {
+        return button.mapToItem(null, button.width / 2, button.height);
+    }
+
+    function openMenu(token, button) {
+        if (adapter === null || button === null || button.Window.window === null) {
+            return "rejected";
+        }
+        const position = menuPosition(button);
+        return adapter.openMenu(token, button.Window.window, position.x, position.y);
+    }
+
+    function primaryAction(item, button) {
+        if (adapter === null || item === null) {
+            return "rejected";
+        }
+        return item.onlyMenu ? openMenu(item.token, button) : adapter.activate(item.token);
+    }
+
+    function secondaryAction(item) {
+        if (adapter === null || item === null) {
+            return "rejected";
+        }
+        return adapter.secondaryActivate(item.token);
+    }
+
+    function moveFocus(index, offset) {
+        if (itemCount <= 0) {
+            return;
+        }
+        const targetIndex = (index + offset + itemCount) % itemCount;
+        trayList.currentIndex = targetIndex;
+        const target = trayList.itemAtIndex(targetIndex);
+        if (target !== null) {
+            target.forceActiveFocus(Qt.TabFocusReason);
+        }
+    }
+
+    ColumnLayout {
+        id: column
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        spacing: Theme.spacing.sm
+
+        IslandText {
+            text: "System tray"
+            tone: "secondary"
+            size: "caption"
+            font.weight: Font.Medium
+        }
+
+        ListView {
+            id: trayList
+
+            objectName: "trayItemList"
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.controlExtent
+            orientation: ListView.Horizontal
+            spacing: Theme.spacing.sm
+            clip: true
+            boundsBehavior: Flickable.StopAtBounds
+            keyNavigationEnabled: false
+            model: root.adapter === null ? [] : root.adapter.items
+
+            delegate: AbstractButton {
+                id: button
+
+                required property int index
+                required property var modelData
+                objectName: "trayItemButton"
+                width: root.controlExtent
+                height: root.controlExtent
+                focusPolicy: Qt.StrongFocus
+                hoverEnabled: true
+                Accessible.role: Accessible.Button
+                Accessible.name: modelData.label
+                Accessible.description: modelData.hasMenu
+                                        ? "System tray item; context menu available" :
+                                          "System tray item"
+
+                onClicked: root.primaryAction(modelData, button)
+
+                Keys.priority: Keys.BeforeItem
+                Keys.onLeftPressed: event => {
+                    root.moveFocus(index, -1);
+                    event.accepted = true;
+                }
+                Keys.onRightPressed: event => {
+                    root.moveFocus(index, 1);
+                    event.accepted = true;
+                }
+                Keys.onPressed: event => {
+                    if (modelData.hasMenu && (event.key === Qt.Key_Menu || (event.key
+                                                                            === Qt.Key_F10 && (
+                                                                                event.modifiers
+                                                                                & Qt.ShiftModifier)))) {
+                        root.openMenu(modelData.token, button);
+                        event.accepted = true;
+                    }
+                }
+                Keys.onTabPressed: {
+                    const next = button.nextItemInFocusChain(true);
+                    if (next !== null) {
+                        next.forceActiveFocus(Qt.TabFocusReason);
+                    }
+                }
+                Keys.onBacktabPressed: {
+                    const previous = button.nextItemInFocusChain(false);
+                    if (previous !== null) {
+                        previous.forceActiveFocus(Qt.BacktabFocusReason);
+                    }
+                }
+
+                background: IslandPanel {
+                    color: button.pressed ? Theme.color.controlFillPressed : button.hovered
+                                            ? Theme.color.controlFillHover : Theme.color.controlFill
+                    border.color: button.modelData.status === "needsAttention" ? Theme.color.accent :
+                                                                                 button.hovered
+                                                                                 ? Theme.color.surfaceBorderHover :
+                                                                                   Theme.color.surfaceBorder
+                }
+
+                contentItem: Item {
+                    IslandText {
+                        anchors.centerIn: parent
+                        visible: trayIcon.status !== Image.Ready
+                        text: button.modelData.label.slice(0, 1).toUpperCase()
+                        tone: "secondary"
+                        font.weight: Font.DemiBold
+                    }
+
+                    Image {
+                        id: trayIcon
+
+                        anchors.centerIn: parent
+                        width: Theme.size.iconSizeMd
+                        height: Theme.size.iconSizeMd
+                        asynchronous: true
+                        fillMode: Image.PreserveAspectFit
+                        source: button.modelData.iconSource
+                        sourceSize.width: Theme.size.iconSizeMd
+                        sourceSize.height: Theme.size.iconSizeMd
+                    }
+
+                    Rectangle {
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        anchors.margins: Theme.spacing.xs
+                        width: 5
+                        height: 5
+                        radius: width / 2
+                        color: Theme.color.accent
+                        visible: button.modelData.status === "needsAttention"
+                    }
+                }
+
+                IslandFocusRing {
+                    visible: button.visualFocus
+                }
+
+                ToolTip.delay: 500
+                ToolTip.visible: button.hovered
+                ToolTip.text: modelData.tooltip
+
+                TapHandler {
+                    acceptedButtons: Qt.RightButton
+                    enabled: button.modelData.hasMenu
+                    onTapped: root.openMenu(button.modelData.token, button)
+                }
+
+                TapHandler {
+                    acceptedButtons: Qt.MiddleButton
+                    onTapped: root.secondaryAction(button.modelData)
+                }
+            }
+        }
+    }
+}

--- a/shell.qml
+++ b/shell.qml
@@ -1,4 +1,6 @@
+//@ pragma UseQApplication
 import Quickshell
+import QtQuick
 import "qml"
 
 ShellRoot {
@@ -42,6 +44,18 @@ ShellRoot {
         id: notifications
     }
 
+    TrayAdapter {
+        id: tray
+    }
+
+    Component {
+        id: trayDashboardContent
+
+        TrayView {
+            adapter: tray
+        }
+    }
+
     ReducedMotion {
         id: motion
     }
@@ -53,5 +67,6 @@ ShellRoot {
         weather: weather
         media: media
         reducedMotion: motion.active
+        dashboardQuickControlsContent: tray.available ? trayDashboardContent : null
     }
 }

--- a/tests/tray/live.qml
+++ b/tests/tray/live.qml
@@ -1,0 +1,116 @@
+//@ pragma UseQApplication
+import Quickshell
+import QtQuick
+import "qml"
+
+ShellRoot {
+    id: test
+
+    property int stage: 0
+    property int attempts: 0
+    property int controlledToken: 0
+    property string initialIcon: ""
+
+    function require(condition, message) {
+        if (!condition) {
+            console.error("FAIL: " + message);
+            Qt.exit(1);
+            throw new Error(message);
+        }
+    }
+
+    function findLabel(label) {
+        for (let index = 0; index < tray.items.length; ++index) {
+            if (tray.items[index].label === label) {
+                return tray.items[index];
+            }
+        }
+        return null;
+    }
+
+    function findToken(token) {
+        for (let index = 0; index < tray.items.length; ++index) {
+            if (tray.items[index].token === token) {
+                return tray.items[index];
+            }
+        }
+        return null;
+    }
+
+    function advance() {
+        attempts += 1;
+        require(attempts < 240, "controlled tray lifecycle did not settle");
+
+        if (stage === 0) {
+            const initial = findLabel("Nagi tray initial");
+            if (initial === null) {
+                return;
+            }
+            require(initial.iconSource !== "" && initial.hasMenu && !initial.onlyMenu,
+                    "real item exposes icon identity and supported behavior");
+            controlledToken = initial.token;
+            initialIcon = initial.iconSource;
+            require(tray.activate(controlledToken) === "dispatched",
+                    "real primary activation dispatches");
+            console.warn("tray live: primary activation dispatched");
+            stage = 1;
+            return;
+        }
+
+        if (stage === 1) {
+            const activated = findLabel("Nagi tray activated");
+            if (activated === null) {
+                return;
+            }
+            require(activated.token === controlledToken && activated.iconSource !== initialIcon,
+                    "real tooltip and icon updates preserve lifecycle identity");
+            require(tray.openMenu(controlledToken, window, 32, 32) === "dispatched",
+                    "real platform menu dispatches against the live window");
+            console.warn("tray live: platform menu dispatched");
+            stage = 2;
+            return;
+        }
+
+        if (stage === 2) {
+            const invoked = findLabel("Nagi tray menu invoked");
+            if (invoked === null) {
+                return;
+            }
+            require(invoked.token === controlledToken,
+                    "real menu action updates the same connected item");
+            require(tray.activate(controlledToken) === "dispatched",
+                    "controlled failure/exit activation dispatches");
+            console.warn("tray live: menu action observed; requesting exit");
+            stage = 3;
+            return;
+        }
+
+        if (findToken(controlledToken) === null) {
+            require(tray.trackedItemCount === tray.itemCount,
+                    "exiting item releases its adapter record without blocking peers");
+            console.warn("tray live: start, update, activation, menu, and exit passed");
+            Qt.exit(0);
+        }
+    }
+
+    TrayAdapter {
+        id: tray
+    }
+
+    PanelWindow {
+        id: window
+
+        anchors.top: true
+        color: "transparent"
+        implicitWidth: 64
+        implicitHeight: 64
+        exclusiveZone: 0
+    }
+
+    Timer {
+        interval: 50
+        repeat: true
+        running: true
+        onTriggered: test.advance()
+    }
+}

--- a/tests/tray/shell.qml
+++ b/tests/tray/shell.qml
@@ -1,0 +1,212 @@
+import Quickshell
+import Quickshell.Services.SystemTray
+import QtQuick
+import "qml"
+
+ShellRoot {
+    id: test
+
+    property var calls: []
+
+    function require(condition, message) {
+        if (!condition) {
+            console.error("FAIL: " + message);
+            Qt.exit(1);
+            throw new Error(message);
+        }
+    }
+
+    function recordCall(item, action, argument) {
+        calls.push({
+                       "name": item.title,
+                       "action": action,
+                       "argument": argument
+                   });
+    }
+
+    function makeItem(overrides) {
+        return itemFactory.createObject(test, overrides);
+    }
+
+    function setItems(items) {
+        trayModel.values = items.slice();
+        tray.processPendingChanges();
+    }
+
+    function itemByLabel(label) {
+        for (let index = 0; index < tray.items.length; ++index) {
+            if (tray.items[index].label === label) {
+                return tray.items[index];
+            }
+        }
+        return null;
+    }
+
+    Component {
+        id: itemFactory
+
+        QtObject {
+            property string title: ""
+            property string icon: ""
+            property string tooltipTitle: ""
+            property string tooltipDescription: ""
+            property int status: Status.Passive
+            property int category: Category.ApplicationStatus
+            property bool hasMenu: false
+            property bool onlyMenu: false
+            property bool failActivation: false
+            property bool failSecondary: false
+            property bool failMenu: false
+
+            function activate() {
+                if (failActivation) {
+                    throw new Error("controlled activation failure");
+                }
+                test.recordCall(this, "activate", null);
+            }
+
+            function secondaryActivate() {
+                if (failSecondary) {
+                    throw new Error("controlled secondary failure");
+                }
+                test.recordCall(this, "secondary", null);
+            }
+
+            function display(parentWindow, x, y) {
+                if (failMenu) {
+                    throw new Error("controlled menu failure");
+                }
+                test.recordCall(this, "menu", {
+                                    "parent": parentWindow,
+                                    "x": x,
+                                    "y": y
+                                });
+            }
+        }
+    }
+
+    QtObject {
+        id: trayModel
+
+        property var values: []
+    }
+
+    TrayAdapter {
+        id: tray
+
+        itemsModel: trayModel
+    }
+
+    function runLifecycleStage() {
+        console.warn("tray: lifecycle and normalization stage");
+        require(!tray.available && tray.itemCount === 0 && tray.trackedItemCount === 0,
+                "an empty backend collapses tray presentation");
+
+        const alpha = makeItem({
+                                   "title": " Alpha\u0007  Item ",
+                                   "icon": "image://icon/alpha",
+                                   "tooltipDescription": " First\n service ",
+                                   "status": Status.Active,
+                                   "hasMenu": true
+                               });
+        const beta = makeItem({
+                                  "title": "Beta",
+                                  "icon": "image://icon/beta",
+                                  "status": Status.Passive
+                              });
+        setItems([alpha, beta]);
+        require(tray.available && tray.itemCount === 2 && tray.trackedItemCount === 2,
+                "ready items appear as one live record each");
+
+        const alphaSnapshot = itemByLabel("Alpha Item");
+        require(alphaSnapshot !== null && alphaSnapshot.tooltip === "Alpha Item\nFirst service",
+                "external text is normalized and bounded");
+        require(alphaSnapshot.iconSource === "image://icon/alpha" && alphaSnapshot.status
+                === "active" && alphaSnapshot.hasMenu,
+                "icon identity, status, and menu support are normalized");
+        const alphaToken = alphaSnapshot.token;
+
+        alpha.tooltipTitle = "Attention";
+        alpha.tooltipDescription = "Updated";
+        alpha.icon = "image://icon/alpha-updated";
+        alpha.status = Status.NeedsAttention;
+        alpha.onlyMenu = true;
+        tray.processPendingChanges();
+        const updated = itemByLabel("Attention");
+        require(updated !== null && updated.token === alphaToken,
+                "property updates retain the connected generation token");
+        require(updated.tooltip === "Attention\nUpdated" && updated.iconSource
+                === "image://icon/alpha-updated" && updated.status === "needsAttention"
+                && updated.onlyMenu,
+                "live tooltip, icon, status, and behavior changes publish together");
+
+        setItems([beta]);
+        require(tray.itemCount === 1 && tray.trackedItemCount === 1 && itemByLabel("Attention")
+                === null, "departed applications disappear and release their record");
+        setItems([alpha, beta]);
+        require(itemByLabel("Attention").token !== alphaToken,
+                "a returning backend object receives a fresh lifecycle token");
+
+        runActionStage(alpha, beta);
+    }
+
+    function runActionStage(alpha, beta) {
+        console.warn("tray: activation and menu stage");
+        calls = [];
+        const alphaSnapshot = itemByLabel("Attention");
+        const betaSnapshot = itemByLabel("Beta");
+
+        require(tray.activate(alphaSnapshot.token) === "rejected",
+                "menu-only items reject unsupported primary activation");
+        require(tray.openMenu(alphaSnapshot.token, test, -99999999999, 99999999999) === "dispatched",
+                "supported native menus dispatch through the adapter");
+        require(calls.length === 1 && calls[0].action === "menu" && calls[0].argument.x ===
+                -2147483648 && calls[0].argument.y === 2147483647,
+                "menu dispatch keeps the real parent and clamps qint32 coordinates");
+
+        require(tray.activate(betaSnapshot.token) === "dispatched" && tray.secondaryActivate(
+                    betaSnapshot.token) === "dispatched",
+                "primary and secondary activation reach the real item methods");
+        require(calls.length === 3 && calls[1].action === "activate" && calls[2].action
+                === "secondary", "activation order is preserved");
+        require(tray.openMenu(betaSnapshot.token, test, 0, 0) === "rejected",
+                "items without menus never enter the platform menu path");
+        require(tray.activate(-1) === "rejected" && tray.openMenu(betaSnapshot.token, null, 0, 0)
+                === "rejected", "stale tokens and missing parent windows reject locally");
+
+        runFailureStage(alpha, beta);
+    }
+
+    function runFailureStage(alpha, beta) {
+        console.warn("tray: isolated failure stage");
+        const failing = makeItem({
+                                     "title": "Failing",
+                                     "icon": "x".repeat(tray.maximumIconSourceCharacters + 1),
+                                     "status": Status.Active,
+                                     "hasMenu": true,
+                                     "failActivation": true,
+                                     "failSecondary": true,
+                                     "failMenu": true
+                                 });
+        setItems([alpha, failing, beta]);
+        const snapshot = itemByLabel("Failing");
+        require(snapshot !== null && snapshot.iconSource === "" && tray.itemCount === 3,
+                "one malformed icon falls back without hiding healthy items");
+        require(tray.activate(snapshot.token) === "rejected" && tray.secondaryActivate(
+                    snapshot.token) === "rejected" && tray.openMenu(snapshot.token, test, 0, 0)
+                === "rejected", "one throwing item cannot escape or block the adapter");
+        require(tray.activate(itemByLabel("Beta").token) === "dispatched",
+                "healthy items remain actionable after a peer failure");
+
+        setItems([]);
+        require(!tray.available && tray.itemCount === 0 && tray.trackedItemCount === 0,
+                "backend exit clears every live snapshot and watcher");
+        alpha.destroy();
+        beta.destroy();
+        failing.destroy();
+        console.warn("tray adapter tests passed");
+        Qt.exit(0);
+    }
+
+    Component.onCompleted: Qt.callLater(test.runLifecycleStage)
+}

--- a/tests/tray_live_test.cpp
+++ b/tests/tray_live_test.cpp
@@ -1,0 +1,158 @@
+#include <QAction>
+#include <QApplication>
+#include <QColor>
+#include <QIcon>
+#include <QMenu>
+#include <QPainter>
+#include <QProcess>
+#include <QSystemTrayIcon>
+#include <QTimer>
+
+#include <iostream>
+
+namespace {
+
+QIcon icon(const QColor &color)
+{
+    QPixmap pixmap(32, 32);
+    pixmap.fill(Qt::transparent);
+    QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(color);
+    painter.drawEllipse(3, 3, 26, 26);
+    return QIcon(pixmap);
+}
+
+int runItem(QApplication &application)
+{
+    QApplication::setApplicationName(QStringLiteral("Nagi Tray Integration Test"));
+    QApplication::setQuitOnLastWindowClosed(false);
+    if (!QSystemTrayIcon::isSystemTrayAvailable()) {
+        std::cerr << "system tray unavailable\n";
+        return 3;
+    }
+
+    bool activated = false;
+    bool menuExposed = false;
+
+    QMenu menu;
+    QAction action(QStringLiteral("Invoke controlled tray action"), &menu);
+    menu.addAction(&action);
+
+    QSystemTrayIcon tray(icon(QColor(QStringLiteral("#7aa2f7"))));
+    tray.setToolTip(QStringLiteral("Nagi tray initial"));
+    tray.setContextMenu(&menu);
+
+    QObject::connect(&tray, &QSystemTrayIcon::activated, &application,
+                     [&](QSystemTrayIcon::ActivationReason reason) {
+        if (reason != QSystemTrayIcon::Trigger) {
+            return;
+        }
+        if (!activated) {
+            activated = true;
+            tray.setIcon(icon(QColor(QStringLiteral("#f26d7e"))));
+            tray.setToolTip(QStringLiteral("Nagi tray activated"));
+            std::cerr << "primary activation observed\n";
+            return;
+        }
+        std::cerr << "tray helper exiting\n";
+        QTimer::singleShot(0, &application, &QCoreApplication::quit);
+    });
+
+    QObject::connect(&menu, &QMenu::aboutToShow, &application, [&] {
+        if (menuExposed) {
+            return;
+        }
+        menuExposed = true;
+        std::cerr << "menu exposed\n";
+        QTimer::singleShot(100, &action, &QAction::trigger);
+    });
+    QObject::connect(&action, &QAction::triggered, &application, [&] {
+        tray.setToolTip(QStringLiteral("Nagi tray menu invoked"));
+        std::cerr << "menu action invoked\n";
+    });
+
+    tray.show();
+    std::cerr << "tray helper registered\n";
+    return application.exec();
+}
+
+int runController(QApplication &application, const QString &qs, const QString &configDirectory)
+{
+    QProcess item;
+    item.setProgram(application.applicationFilePath());
+    item.setArguments({QStringLiteral("--item")});
+    item.setProcessChannelMode(QProcess::ForwardedChannels);
+
+    QProcess shell;
+    shell.setProgram(qs);
+    shell.setArguments({QStringLiteral("-p"), configDirectory, QStringLiteral("--no-duplicate")});
+    shell.setProcessChannelMode(QProcess::ForwardedChannels);
+
+    int result = 1;
+    QObject::connect(&item, &QProcess::started, &application, [&] { shell.start(); });
+    QObject::connect(&item, &QProcess::errorOccurred, &application,
+                     [&](QProcess::ProcessError error) {
+        if (error == QProcess::FailedToStart) {
+            std::cerr << "tray helper failed to start\n";
+            application.quit();
+        }
+    });
+    QObject::connect(&shell, &QProcess::errorOccurred, &application,
+                     [&](QProcess::ProcessError error) {
+        if (error == QProcess::FailedToStart) {
+            std::cerr << "tray QML probe failed to start\n";
+            item.kill();
+            application.quit();
+        }
+    });
+    QObject::connect(&shell, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), &application,
+                     [&](int exitCode, QProcess::ExitStatus status) {
+        result = status == QProcess::NormalExit && exitCode == 0 ? 0 : 1;
+        if (result != 0) {
+            std::cerr << "tray QML probe failed: exit=" << exitCode << '\n';
+        }
+        if (item.state() != QProcess::NotRunning) {
+            item.kill();
+        }
+        application.quit();
+    });
+
+    QTimer timeout;
+    timeout.setSingleShot(true);
+    timeout.setInterval(15000);
+    QObject::connect(&timeout, &QTimer::timeout, &application, [&] {
+        std::cerr << "live tray test timed out\n";
+        if (shell.state() != QProcess::NotRunning) {
+            shell.kill();
+        }
+        if (item.state() != QProcess::NotRunning) {
+            item.kill();
+        }
+        application.quit();
+    });
+
+    item.start();
+    timeout.start();
+    const int eventLoopResult = application.exec();
+    shell.waitForFinished(1000);
+    item.waitForFinished(1000);
+    return eventLoopResult == 0 ? result : eventLoopResult;
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    QApplication application(argc, argv);
+    if (argc == 2 && QString::fromLocal8Bit(argv[1]) == QStringLiteral("--item")) {
+        return runItem(application);
+    }
+    if (argc != 3) {
+        std::cerr << "usage: tray-live-test <qs> <config-dir>\n";
+        return 2;
+    }
+    return runController(application, QString::fromLocal8Bit(argv[1]),
+                         QString::fromLocal8Bit(argv[2]));
+}

--- a/tests/ui/shell.qml
+++ b/tests/ui/shell.qml
@@ -71,6 +71,26 @@ ShellRoot {
         require(indeterminateProgress.indeterminate, "indeterminate progress reports its mode");
         require(iconButton.implicitWidth === iconButton.implicitHeight,
                 "icon button stays circular");
+
+        require(trayView.itemCount === 2 && trayView.implicitHeight > 0,
+                "tray renders live items as one contextual control row");
+        trayView.moveFocus(0, 0);
+        require(trayView.currentItem !== null && trayView.currentItem.activeFocus
+                && trayView.currentItem.objectName === "trayItemButton",
+                "tray items accept keyboard focus");
+        trayView.currentItem.clicked();
+        require(trayActions.length === 1 && trayActions[0].action === "activate"
+                && trayActions[0].token === 1, "primary control activation reaches the adapter");
+        trayView.moveFocus(0, 1);
+        require(trayView.currentItem.modelData.label === "Menu item",
+                "arrow navigation reaches the next labeled tray item");
+        trayView.currentItem.clicked();
+        require(trayActions.length === 2 && trayActions[1].action === "menu"
+                && trayActions[1].token === 2 && trayActions[1].parent !== null,
+                "menu-only controls open the platform menu against their live window");
+        require(trayView.secondaryAction(trayAdapter.items[0]) === "dispatched"
+                && trayActions[2].action === "secondary",
+                "secondary pointer behavior stays available through the normalized adapter");
         console.log("island ui primitive tests passed");
 
         if (Quickshell.env("NAGI_UI_HOLD") === "1") {
@@ -83,6 +103,60 @@ ShellRoot {
     }
 
     Component.onCompleted: Qt.callLater(test.runChecks)
+
+    property var trayActions: []
+
+    QtObject {
+        id: trayAdapter
+
+        readonly property var items: [
+            {
+                "token": 1,
+                "label": "Active item",
+                "tooltip": "Active item",
+                "iconSource": "",
+                "status": "active",
+                "hasMenu": false,
+                "onlyMenu": false
+            },
+            {
+                "token": 2,
+                "label": "Menu item",
+                "tooltip": "Menu item\nContext action",
+                "iconSource": "",
+                "status": "needsAttention",
+                "hasMenu": true,
+                "onlyMenu": true
+            }
+        ]
+
+        function activate(token) {
+            test.trayActions.push({
+                                      "action": "activate",
+                                      "token": token
+                                  });
+            return "dispatched";
+        }
+
+        function secondaryActivate(token) {
+            test.trayActions.push({
+                                      "action": "secondary",
+                                      "token": token
+                                  });
+            return "dispatched";
+        }
+
+        function openMenu(token, parentWindow, x, y) {
+            test.trayActions.push({
+                                      "action": "menu",
+                                      "token": token,
+                                      "parent": parentWindow,
+                                      "x": x,
+                                      "y": y
+                                  });
+            return "dispatched";
+        }
+    }
 
     IslandStateCoordinator {
         id: coordinator
@@ -179,6 +253,13 @@ ShellRoot {
                     size: "lg"
                     source: "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><path d='M3 13 L13 13 L8 4 Z' fill='%237AA2F7'/></svg>"
                 }
+            }
+
+            TrayView {
+                id: trayView
+
+                width: 240
+                adapter: trayAdapter
             }
 
             IslandProgressBar {


### PR DESCRIPTION
Expose live tray items through normalized dashboard controls.
Preserve native activation and menus without creating a persistent tray.

Closes #25