### PR TITLE
feat(session): add KDE session actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,14 @@ CONNECTIVITY_HELPER := $(BUILD_DIR)/nagi-connectivity
 CONNECTIVITY_MOC := $(BUILD_DIR)/connectivity/main.moc
 CONNECTIVITY_DBUS_TEST := $(BUILD_DIR)/connectivity-dbus-test
 CONNECTIVITY_DBUS_TEST_MOC := $(BUILD_DIR)/connectivity_dbus_test.moc
+SESSION_HELPER := $(BUILD_DIR)/nagi-session
+SESSION_MOC := $(BUILD_DIR)/session/main.moc
+SESSION_DBUS_TEST := $(BUILD_DIR)/session-dbus-test
+SESSION_DBUS_TEST_MOC := $(BUILD_DIR)/session_dbus_test.moc
 APPLICATION_HELPER := $(BUILD_DIR)/nagi-applications
 CONNECTIVITY_TEST_DIR := $(BUILD_DIR)/connectivity-test
 CONNECTIVITY_LIVE_WRITE_TEST_DIR := $(BUILD_DIR)/connectivity-live-write-test
+SESSION_TEST_DIR := $(BUILD_DIR)/session-test
 COORDINATOR_TEST_DIR := $(BUILD_DIR)/coordinator-test
 WEATHER_TEST_DIR := $(BUILD_DIR)/weather-test
 MEDIA_TEST_DIR := $(BUILD_DIR)/media-test
@@ -75,7 +80,7 @@ QUICKSHELL_CHANNEL := stable
 FEDORA_QUICKSHELL_COPR := errornointernet/quickshell
 FEDORA_QUICKSHELL_PACKAGE := quickshell
 
-.PHONY: help requirements prepare check-quickshell check-helper-toolchain check-audio-toolchain check-application-toolchain check-notification-toolchain check-tray-toolchain helper audio-helper connectivity-helper application-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-applications test-notifications test-adapter test-coordinator test-weather test-media test-audio test-audio-live test-audio-live-write test-connectivity test-connectivity-live-write test-tray test-tray-live test-idle test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
+.PHONY: help requirements prepare check-quickshell check-helper-toolchain check-audio-toolchain check-application-toolchain check-notification-toolchain check-tray-toolchain helper audio-helper connectivity-helper session-helper application-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-session-dbus test-session test-applications test-notifications test-adapter test-coordinator test-weather test-media test-audio test-audio-live test-audio-live-write test-connectivity test-connectivity-live-write test-tray test-tray-live test-idle test-surface-state test-ui-primitives check-nondisplay launch diagnose instances logs logs-follow stop format format-check lint-advisory check clean
 
 help:
 	@printf '%s\n' \
@@ -83,6 +88,7 @@ help:
 		'make helper          Build the KWin virtual desktop helper' \
 		'make audio-helper    Build the confirmed PipeWire audio bridge' \
 		'make connectivity-helper  Build the Wi-Fi and Bluetooth bridge' \
+		'make session-helper  Build the KDE session action bridge' \
 		'make application-helper  Build desktop-entry and persistence bridge' \
 		'make notification-plugin  Build the process-scoped notification runtime' \
 		'make test-native     Test KWin tuple normalization' \
@@ -90,6 +96,8 @@ help:
 		'make test-audio-protocol  Test the audio bridge command boundary' \
 		'make test-audio-volume  Test proportional average-volume writes' \
 		'make test-connectivity-dbus  Test D-Bus state, denial, and lifecycle' \
+		'make test-session-dbus  Test KDE session dispatch, denial, and cleanup' \
+		'make test-session   Test session service and interaction state' \
 		'make test-applications  Test desktop discovery and persistence bridge' \
 		'make test-notifications  Test notification lifecycle and bounded history' \
 		'make test-adapter    Test the QML adapter boundary' \
@@ -169,7 +177,14 @@ $(CONNECTIVITY_MOC): src/connectivity/main.cpp | $(BUILD_DIR)
 	mkdir -p $(dir $@)
 	$(MOC) $< -o $@
 
+$(SESSION_MOC): src/session/main.cpp | $(BUILD_DIR)
+	mkdir -p $(dir $@)
+	$(MOC) $< -o $@
+
 $(CONNECTIVITY_DBUS_TEST_MOC): tests/connectivity_dbus_test.cpp | $(BUILD_DIR)
+	$(MOC) $< -o $@
+
+$(SESSION_DBUS_TEST_MOC): tests/session_dbus_test.cpp | $(BUILD_DIR)
 	$(MOC) $< -o $@
 
 $(NOTIFICATION_RUNTIME_MOC): src/notifications/runtime.h | $(NOTIFICATION_BUILD_DIR)
@@ -205,8 +220,14 @@ $(AUDIO_VOLUME_TEST): tests/pipewire_audio_volume_test.cpp src/pipewire-audio/vo
 $(CONNECTIVITY_HELPER): src/connectivity/main.cpp $(CONNECTIVITY_MOC) | $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(QT_CFLAGS) -I$(dir $(CONNECTIVITY_MOC)) src/connectivity/main.cpp -o $@ $(LDFLAGS) $(QT_LIBS)
 
+$(SESSION_HELPER): src/session/main.cpp $(SESSION_MOC) | $(BUILD_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(QT_CFLAGS) -I$(dir $(SESSION_MOC)) src/session/main.cpp -o $@ $(LDFLAGS) $(QT_LIBS)
+
 $(CONNECTIVITY_DBUS_TEST): tests/connectivity_dbus_test.cpp $(CONNECTIVITY_DBUS_TEST_MOC) | $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(QT_CFLAGS) -I$(BUILD_DIR) tests/connectivity_dbus_test.cpp -o $@ $(LDFLAGS) $(QT_LIBS)
+
+$(SESSION_DBUS_TEST): tests/session_dbus_test.cpp $(SESSION_DBUS_TEST_MOC) | $(BUILD_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(QT_CFLAGS) -I$(BUILD_DIR) tests/session_dbus_test.cpp -o $@ $(LDFLAGS) $(QT_LIBS)
 
 $(APPLICATION_HELPER): $(APPLICATION_HELPER_SOURCE) | $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(QT_CFLAGS) $(GIO_CFLAGS) $(APPLICATION_HELPER_SOURCE) -o $@ $(LDFLAGS) $(QT_LIBS) $(GIO_LIBS)
@@ -232,6 +253,8 @@ helper: check-helper-toolchain $(HELPER)
 audio-helper: check-audio-toolchain $(AUDIO_HELPER)
 
 connectivity-helper: check-helper-toolchain $(CONNECTIVITY_HELPER)
+
+session-helper: check-helper-toolchain $(SESSION_HELPER)
 
 application-helper: check-application-toolchain $(APPLICATION_HELPER)
 
@@ -278,6 +301,16 @@ test-owner-lifecycle: check-helper-toolchain $(HELPER) $(OWNER_TEST)
 test-connectivity-dbus: check-helper-toolchain $(CONNECTIVITY_HELPER) $(CONNECTIVITY_DBUS_TEST)
 	@command -v '$(DBUS_RUN_SESSION)' >/dev/null
 	$(DBUS_RUN_SESSION) -- $(CONNECTIVITY_DBUS_TEST) $(abspath $(CONNECTIVITY_HELPER))
+
+test-session-dbus: check-helper-toolchain $(SESSION_HELPER) $(SESSION_DBUS_TEST)
+	@command -v '$(DBUS_RUN_SESSION)' >/dev/null
+	$(DBUS_RUN_SESSION) -- $(SESSION_DBUS_TEST) $(abspath $(SESSION_HELPER))
+
+test-session: check-quickshell | $(BUILD_DIR)
+	mkdir -p $(SESSION_TEST_DIR)/qml
+	cp tests/session/shell.qml $(SESSION_TEST_DIR)/shell.qml
+	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/SessionBridge.qml qml/SessionService.qml qml/SessionEntry.qml qml/SessionView.qml $(SESSION_TEST_DIR)/qml/
+	$(QS) -p $(SESSION_TEST_DIR) --no-duplicate
 
 test-adapter: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(BUILD_DIR)/adapter-test/qml
@@ -348,13 +381,13 @@ test-tray-live: check-quickshell check-tray-toolchain $(TRAY_LIVE_TEST) | $(BUIL
 test-surface-state: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(SURFACE_STATE_TEST_DIR)/qml
 	cp tests/surface-state/shell.qml $(SURFACE_STATE_TEST_DIR)/shell.qml
-	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandStateCoordinator.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(SURFACE_STATE_TEST_DIR)/qml/
+	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/SessionView.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandStateCoordinator.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(SURFACE_STATE_TEST_DIR)/qml/
 	$(QS) -p $(SURFACE_STATE_TEST_DIR) --no-duplicate
 
 test-ui-primitives: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(UI_PRIMITIVES_TEST_DIR)/qml
 	cp tests/ui/shell.qml $(UI_PRIMITIVES_TEST_DIR)/shell.qml
-	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/IslandProgressBar.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/IslandStateCoordinator.qml qml/IslandSurface.qml qml/TrayView.qml $(UI_PRIMITIVES_TEST_DIR)/qml/
+	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/IslandProgressBar.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/SessionView.qml qml/IslandStateCoordinator.qml qml/IslandSurface.qml qml/TrayView.qml $(UI_PRIMITIVES_TEST_DIR)/qml/
 	$(QS) -p $(UI_PRIMITIVES_TEST_DIR) --no-duplicate
 
 test-idle: check-quickshell | $(BUILD_DIR)
@@ -377,10 +410,10 @@ check-quickshell:
 	fi; \
 	printf 'Quickshell %s satisfies the >= %s requirement.\n' "$$version" '$(QUICKSHELL_MIN_VERSION)'
 
-launch: check-quickshell prepare helper audio-helper connectivity-helper application-helper notification-plugin
+launch: check-quickshell prepare helper audio-helper connectivity-helper session-helper application-helper notification-plugin
 	QML_IMPORT_PATH='$(abspath $(BUILD_DIR)/qml)' $(QS) -p . --no-duplicate
 
-diagnose: check-quickshell prepare helper audio-helper connectivity-helper application-helper notification-plugin
+diagnose: check-quickshell prepare helper audio-helper connectivity-helper session-helper application-helper notification-plugin
 	QML_IMPORT_PATH='$(abspath $(BUILD_DIR)/qml)' $(QS) -p . --no-duplicate -vv --log-times
 
 instances:
@@ -427,6 +460,6 @@ lint-advisory:
 
 check: check-nondisplay test-surface-state test-ui-primitives
 
-check-nondisplay: check-quickshell format-check audio-helper connectivity-helper application-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-applications test-notifications test-adapter test-coordinator test-weather test-media test-audio test-connectivity test-tray test-idle
+check-nondisplay: check-quickshell format-check audio-helper connectivity-helper session-helper application-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-session-dbus test-session test-applications test-notifications test-adapter test-coordinator test-weather test-media test-audio test-connectivity test-tray test-idle
 clean:
 	rm -rf $(BUILD_DIR)

--- a/qml/IslandButton.qml
+++ b/qml/IslandButton.qml
@@ -39,8 +39,8 @@ AbstractButton {
                                                                    Theme.color.accent;
         }
         if (variant === "danger") {
-            return pressed ? Theme.color.dangerPressed : hovered ? Theme.color.dangerHover :
-                                                                   Theme.color.danger;
+            return pressed ? Theme.color.dangerFillPressed : hovered ? Theme.color.dangerFillHover :
+                                                                       Theme.color.dangerFill;
         }
         return pressed ? Theme.color.controlFillPressed : hovered ? Theme.color.controlFillHover :
                                                                     Theme.color.controlFill;
@@ -51,7 +51,7 @@ AbstractButton {
             return Theme.color.accentForeground;
         }
         if (variant === "danger") {
-            return Theme.color.dangerForeground;
+            return Theme.color.danger;
         }
         return Theme.color.textPrimary;
     }

--- a/qml/IslandStateCoordinator.qml
+++ b/qml/IslandStateCoordinator.qml
@@ -22,6 +22,7 @@ Scope {
     readonly property int focusLauncherSearch: 1
     readonly property int focusPolkitModal: 2
     readonly property int focusExpandedDashboard: 3
+    readonly property int focusSessionActions: 4
 
     readonly property int surfaceGeneration: reducer.surfaceGeneration
     readonly property var surfaceToken: reducer.surfaceToken
@@ -223,6 +224,9 @@ Scope {
                             "holdDuration": holdRemaining,
                             "kind": ownerKind,
                             "rank": ownerRank,
+                            "revision": revision,
+                            "taskEpoch": (ownerKind === root.ownerLauncher || ownerKind
+                                          === root.ownerSession) ? ownerEpoch : 0,
                             "sourceToken": ownerSourceToken,
                             "surfaceGeneration": surfaceGeneration
                         });
@@ -275,20 +279,27 @@ Scope {
         }
 
         function enterOwner(kind, sourceToken, record, now) {
-            nextOwnerEpoch += 1;
+            const restoredTaskEpoch = record === null ? 0 : record.taskEpoch;
+            if ((kind === root.ownerLauncher || kind === root.ownerSession) && typeof restoredTaskEpoch
+                    === "number" && restoredTaskEpoch > 0) {
+                ownerEpoch = restoredTaskEpoch;
+                revision = Math.max(1, record.revision + 1);
+            } else {
+                nextOwnerEpoch += 1;
+                ownerEpoch = nextOwnerEpoch;
+                revision = 1;
+            }
             ownerKind = kind;
             ownerRank = rankFor(kind);
-            ownerEpoch = nextOwnerEpoch;
-            revision = 1;
             ownerSourceToken = sourceToken;
             ownerAdmission = record === null ? 0 : record.admission;
             ownerFreshUntil = record === null ? -1 : record.freshUntil;
             ownerHoldDuration = record === null ? holdFor(kind) : record.holdDuration;
             ownerHoldUntil = -1;
             presentationVisible = false;
-            focusPending = kind === root.ownerLauncher || kind === root.ownerPolkitModal || (kind
-                                                                                             === root.ownerExpanded
-                                                                                             && explicitExpandedIntent);
+            focusPending = kind === root.ownerLauncher || kind === root.ownerSession || kind
+                    === root.ownerPolkitModal || (kind === root.ownerExpanded
+                                                  && explicitExpandedIntent);
             focusTarget = focusFor(kind);
         }
 
@@ -338,20 +349,31 @@ Scope {
                 restoreNext(now);
             }
         }
-
         function finishInteractive(epoch) {
             const now = currentTime();
             expireDue(now);
 
-            if ((ownerKind !== root.ownerLauncher && ownerKind !== root.ownerSession) || ownerEpoch
-                    !== epoch) {
+            if ((ownerKind === root.ownerLauncher || ownerKind === root.ownerSession) && ownerEpoch
+                    === epoch) {
+                restoreNext(now);
                 schedule(now);
-                return false;
+                return true;
             }
 
-            restoreNext(now);
+            for (let index = restoration.length - 1; index >= 0; index -= 1) {
+                const frame = restoration[index];
+                if ((frame.kind === root.ownerLauncher || frame.kind === root.ownerSession)
+                        && frame.taskEpoch === epoch) {
+                    const frames = restoration.slice();
+                    frames.splice(index, 1);
+                    restoration = frames;
+                    schedule(now);
+                    return true;
+                }
+            }
+
             schedule(now);
-            return true;
+            return false;
         }
 
         function focusFor(kind) {
@@ -363,6 +385,9 @@ Scope {
             }
             if (kind === root.ownerExpanded && explicitExpandedIntent) {
                 return root.focusExpandedDashboard;
+            }
+            if (kind === root.ownerSession) {
+                return root.focusSessionActions;
             }
             return root.focusNone;
         }

--- a/qml/IslandSurface.qml
+++ b/qml/IslandSurface.qml
@@ -14,6 +14,7 @@ PanelWindow {
     property var weather: null
     property var media: null
     property bool reducedMotion: false
+    property var sessionService: null
 
     // Downstream dashboard features provide real visual components through
     // these slots. Null content is removed instead of replaced by inert UI.
@@ -30,20 +31,26 @@ PanelWindow {
     readonly property int focusTarget: coordinator.focusTarget
     readonly property real focusRequestSerial: coordinator.focusRequestSerial
     readonly property bool expanded: ownerKind === coordinator.ownerExpanded
+    readonly property bool session: ownerKind === coordinator.ownerSession
+    readonly property bool largeContent: expanded || session
     readonly property int edgeInset: Theme.spacing.sm
-    readonly property int preferredWidth: expanded ? Theme.size.islandExpandedWidth : Math.max(
-                                                         Theme.size.islandIdleWidth,
-                                                         idleContentWidth)
-    readonly property int preferredHeight: expanded ? Theme.size.islandExpandedHeight :
-                                                      Theme.size.islandIdleHeight
+    readonly property int preferredWidth: largeContent ? Theme.size.islandExpandedWidth : Math.max(
+                                                             Theme.size.islandIdleWidth,
+                                                             idleContentWidth)
+    readonly property int preferredHeight: largeContent ? Theme.size.islandExpandedHeight :
+                                                          Theme.size.islandIdleHeight
     readonly property int idleContentWidth: idleContent.visible ? idleContent.implicitWidth :
                                                                   Theme.size.islandIdleWidth
     readonly property int geometryAnimationDuration: reducedMotion ? 0 : Theme.motion.durationSlow
     readonly property bool dashboardFocused: expandedContent.activeFocus
     readonly property int loadedDashboardRegionCount: expandedContent.loadedRegionCount
+    readonly property bool sessionFocused: sessionLoader.item !== null
+                                           && sessionLoader.item.activeFocus
 
     property real focusedOwnerEpoch: 0
     property real appliedFocusRequestSerial: 0
+    property int sessionRequestId: 0
+    property real sessionRequestOwnerEpoch: 0
 
     function acknowledgePresentation(generation, epoch, contentRevision) {
         if (generation <= 0 || hostSurfaceGeneration !== generation || ownerEpoch !== epoch
@@ -53,7 +60,9 @@ PanelWindow {
 
         const idleVisible = ownerKind === coordinator.ownerIdle && idleContent.visible;
         const dashboardVisible = ownerKind === coordinator.ownerExpanded && expandedContent.visible;
-        if (!idleVisible && !dashboardVisible) {
+        const sessionVisible = ownerKind === coordinator.ownerSession && sessionLoader.item
+              !== null && sessionLoader.item.visible;
+        if (!idleVisible && !dashboardVisible && !sessionVisible) {
             return;
         }
 
@@ -73,20 +82,39 @@ PanelWindow {
         return explicitAccepted && hoverAccepted;
     }
 
-    function queueDashboardFocus() {
+    function trackSessionRequest(requestId, epoch) {
+        if (!session || epoch !== ownerEpoch || requestId <= 0 || sessionRequestId !== 0) {
+            return;
+        }
+        sessionRequestId = requestId;
+        sessionRequestOwnerEpoch = epoch;
+    }
+
+    function queueOwnerFocus() {
         const generation = hostSurfaceGeneration;
         const epoch = ownerEpoch;
         const serial = focusRequestSerial;
         Qt.callLater(function () {
             if (generation !== surface.hostSurfaceGeneration || epoch !== surface.ownerEpoch
-                    || serial !== surface.focusRequestSerial || surface.focusTarget
-                    !== surface.coordinator.focusExpandedDashboard || !surface.expanded) {
+                    || serial !== surface.focusRequestSerial) {
+                return;
+            }
+
+            let target = null;
+            if (surface.focusTarget === surface.coordinator.focusExpandedDashboard
+                    && surface.expanded) {
+                target = expandedContent;
+            } else if (surface.focusTarget === surface.coordinator.focusSessionActions
+                       && surface.session && sessionLoader.item !== null) {
+                target = sessionLoader.item;
+            }
+            if (target === null) {
                 return;
             }
 
             surface.focusedOwnerEpoch = epoch;
             surface.appliedFocusRequestSerial = serial;
-            expandedContent.focusInitialControl();
+            target.focusInitialControl();
         });
     }
 
@@ -127,7 +155,13 @@ PanelWindow {
         target: surface.coordinator
 
         function onFocusRequestSerialChanged() {
-            surface.queueDashboardFocus();
+            surface.queueOwnerFocus();
+        }
+
+        function onPresentationVisibleChanged() {
+            if (surface.coordinator.presentationVisible) {
+                Qt.callLater(surface.queueOwnerFocus);
+            }
         }
 
         function onOwnerEpochChanged() {
@@ -140,13 +174,31 @@ PanelWindow {
         }
     }
 
+    Connections {
+        target: surface.sessionService
+        ignoreUnknownSignals: true
+
+        function onOperationFinished(requestId, action, outcome) {
+            if (requestId !== surface.sessionRequestId) {
+                return;
+            }
+            const epoch = surface.sessionRequestOwnerEpoch;
+            surface.sessionRequestId = 0;
+            surface.sessionRequestOwnerEpoch = 0;
+            if (outcome === "accepted") {
+                surface.coordinator.completeInteractive(epoch);
+            }
+        }
+    }
+
     // Leave screen unassigned at creation so Qt selects the startup primary/default output.
     anchors.top: true
     color: "transparent"
     exclusiveZone: 0
-    focusable: expanded && focusedOwnerEpoch === ownerEpoch && focusTarget
-               === coordinator.focusExpandedDashboard && appliedFocusRequestSerial
-               === focusRequestSerial
+    focusable: focusedOwnerEpoch === ownerEpoch && appliedFocusRequestSerial === focusRequestSerial
+               && ((expanded && focusTarget === coordinator.focusExpandedDashboard) || (session
+                                                                                        && focusTarget
+                                                                                        === coordinator.focusSessionActions))
     implicitHeight: safeLogicalSize(preferredHeight, screen === null ? 0 : screen.height)
     implicitWidth: safeLogicalSize(preferredWidth, screen === null ? 0 : screen.width)
 
@@ -170,7 +222,7 @@ PanelWindow {
         id: islandPanel
 
         anchors.fill: parent
-        radius: surface.expanded ? Theme.radius.xl : Theme.radius.pill
+        radius: surface.largeContent ? Theme.radius.xl : Theme.radius.pill
 
         Behavior on radius {
             NumberAnimation {
@@ -204,6 +256,29 @@ PanelWindow {
         notificationsContent: surface.dashboardNotificationsContent
         navigationContent: surface.dashboardNavigationContent
         onCloseRequested: surface.cancelDashboard()
+    }
+
+    Loader {
+        id: sessionLoader
+
+        anchors.fill: parent
+        active: surface.session && surface.sessionService !== null
+        visible: active
+
+        sourceComponent: Component {
+            SessionView {
+                ownerEpoch: surface.ownerEpoch
+                service: surface.sessionService
+                onActionDispatched: (requestId, epoch) => surface.trackSessionRequest(requestId,
+                                                                                      epoch)
+                onCancelled: epoch => surface.coordinator.cancelInteractive(epoch)
+            }
+        }
+
+        onLoaded: {
+            surface.queuePresentationAcknowledgement();
+            surface.queueOwnerFocus();
+        }
     }
 
     HoverHandler {

--- a/qml/IslandSurfaceHost.qml
+++ b/qml/IslandSurfaceHost.qml
@@ -13,6 +13,7 @@ Scope {
     property var clock: null
     property var weather: null
     property var media: null
+    property var sessionService: null
     property bool reducedMotion: false
     property Component dashboardMediaContent: null
     property Component dashboardClockContent: null
@@ -40,6 +41,8 @@ Scope {
                                              && ownership.liveSurface.dashboardFocused
     readonly property int loadedDashboardRegionCount: ownership.liveSurface === null ? 0 :
                                                                                        ownership.liveSurface.loadedDashboardRegionCount
+    readonly property bool sessionFocused: ownership.liveSurface !== null
+                                           && ownership.liveSurface.sessionFocused
     readonly property int geometryAnimationDuration: ownership.liveSurface === null ? 0 :
                                                                                       ownership.liveSurface.geometryAnimationDuration
 
@@ -178,6 +181,7 @@ Scope {
             clock: host.clock
             weather: host.weather
             media: host.media
+            sessionService: host.sessionService
             reducedMotion: host.reducedMotion
             dashboardMediaContent: host.dashboardMediaContent
             dashboardClockContent: host.dashboardClockContent

--- a/qml/SessionBridge.qml
+++ b/qml/SessionBridge.qml
@@ -1,0 +1,180 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+// Bounded JSON-lines wrapper for the Nagi-owned KDE session helper. Raw D-Bus
+// service names, object paths, methods, and errors remain inside the helper.
+Scope {
+    id: root
+
+    required property string helperPath
+    property bool enabled: true
+
+    readonly property bool ready: state.ready
+    readonly property int activeTimerCount: restartTimer.running ? 1 : 0
+    readonly property int maximumLineLength: 4096
+    readonly property int maximumDiagnostics: 4
+
+    signal resultReceived(var result)
+    signal fatalFailure
+
+    function requestAction(requestId, action) {
+        return send({
+                        "op": "action",
+                        "requestId": requestId,
+                        "action": action
+                    });
+    }
+
+    function send(command) {
+        if (!state.ready || !helper.running) {
+            return false;
+        }
+        const line = JSON.stringify(command);
+        if (line.length === 0 || line.length > root.maximumLineLength) {
+            return false;
+        }
+        helper.write(line + "\n");
+        return true;
+    }
+
+    function acceptLine(line) {
+        if (typeof line !== "string" || line.length === 0 || line.length > root.maximumLineLength) {
+            warnBounded("invalid helper line length");
+            return;
+        }
+
+        let message;
+        try {
+            message = JSON.parse(line);
+        } catch (error) {
+            warnBounded("malformed helper line");
+            return;
+        }
+        if (message === null || typeof message !== "object" || Array.isArray(message)
+                || typeof message.type !== "string") {
+            warnBounded("invalid helper message");
+            return;
+        }
+        if (message.type === "ready") {
+            state.ready = true;
+            state.restartAttempts = 0;
+            return;
+        }
+        if (message.type !== "result" || !validResult(message)) {
+            warnBounded("invalid helper result");
+            return;
+        }
+        root.resultReceived({
+                                "requestId": message.requestId,
+                                "action": message.action,
+                                "outcome": message.outcome
+                            });
+    }
+
+    function validAction(action) {
+        return action === "lock" || action === "suspend" || action === "logout" || action
+                === "reboot" || action === "powerOff";
+    }
+
+    function validOutcome(outcome) {
+        return outcome === "accepted" || outcome === "busy" || outcome === "denied" || outcome
+                === "unavailable" || outcome === "timeout" || outcome === "backend";
+    }
+
+    function validResult(message) {
+        return Number.isInteger(message.requestId) && message.requestId > 0 && message.requestId
+                <= 2147483647 && validAction(message.action) && validOutcome(message.outcome);
+    }
+
+    function warnBounded(message) {
+        if (state.diagnosticCount >= root.maximumDiagnostics) {
+            return;
+        }
+        state.diagnosticCount += 1;
+        console.warn("Session bridge: " + message);
+    }
+
+    function forwardDiagnostic(message) {
+        if (state.diagnosticCount >= root.maximumDiagnostics) {
+            return;
+        }
+        state.diagnosticCount += 1;
+        const bounded = typeof message === "string" ? message.slice(0, 256) :
+                                                      "invalid helper diagnostic";
+        console.warn("Session helper: " + bounded);
+    }
+
+    function failBridge() {
+        state.ready = false;
+        root.fatalFailure();
+    }
+
+    onEnabledChanged: {
+        if (enabled) {
+            state.restartAttempts = 0;
+            state.restartAllowed = true;
+        } else {
+            restartTimer.stop();
+            state.restartAllowed = false;
+            state.ready = false;
+        }
+    }
+
+    QtObject {
+        id: state
+
+        property bool ready: false
+        property bool restartAllowed: true
+        property bool destroying: false
+        property int restartAttempts: 0
+        property int diagnosticCount: 0
+    }
+
+    Timer {
+        id: restartTimer
+
+        interval: 250 * Math.pow(2, Math.max(0, state.restartAttempts - 1))
+        onTriggered: state.restartAllowed = true
+    }
+
+    Process {
+        id: helper
+
+        command: [root.helperPath]
+        stdinEnabled: true
+        running: root.enabled && root.helperPath !== "" && state.restartAllowed
+
+        stdout: SplitParser {
+            onRead: data => root.acceptLine(data)
+        }
+
+        stderr: SplitParser {
+            onRead: data => root.forwardDiagnostic(data)
+        }
+
+        onStarted: state.ready = false
+        onExited: function (exitCode, exitStatus) {
+            root.failBridge();
+            if (!state.destroying && root.enabled && state.restartAttempts < 3) {
+                state.restartAttempts += 1;
+                state.restartAllowed = false;
+                restartTimer.restart();
+            } else {
+                state.restartAllowed = false;
+            }
+        }
+    }
+
+    Component.onDestruction: {
+        state.destroying = true;
+        restartTimer.stop();
+        if (helper.running && state.ready) {
+            helper.write("{\"op\":\"shutdown\"}\n");
+        }
+        helper.running = false;
+        state.ready = false;
+    }
+}

--- a/qml/SessionEntry.qml
+++ b/qml/SessionEntry.qml
@@ -1,0 +1,11 @@
+import QtQuick
+
+IslandButton {
+    id: entry
+
+    signal openRequested
+
+    label: "Session"
+    Accessible.description: "Open lock, suspend, logout, reboot, and power-off actions"
+    onClicked: openRequested()
+}

--- a/qml/SessionService.qml
+++ b/qml/SessionService.qml
@@ -1,0 +1,134 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import QtQuick
+
+// Stable session-operation boundary for presentation. It exposes only bounded
+// action and outcome enums; D-Bus details remain private to SessionBridge.
+Scope {
+    id: root
+
+    required property string helperPath
+
+    // Verification seam. Production owns one native SessionBridge.
+    property var bridge: null
+
+    readonly property bool backendReady: engine.currentBridge !== null && engine.currentBridge.ready
+    readonly property bool pending: engine.pendingRequestId !== 0
+    readonly property string pendingAction: engine.pendingAction
+    readonly property string failure: engine.failure
+    readonly property int activeTimerCount: root.bridge === null ? nativeBridge.activeTimerCount : 0
+
+    signal operationFinished(int requestId, string action, string outcome)
+
+    function clearFailure() {
+        engine.failure = "none";
+    }
+
+    function requestAction(action) {
+        return engine.requestAction(action);
+    }
+
+    onBridgeChanged: engine.reset()
+    Component.onDestruction: engine.cleanup()
+
+    SessionBridge {
+        id: nativeBridge
+
+        helperPath: root.helperPath
+        enabled: root.bridge === null
+    }
+
+    Connections {
+        target: engine.currentBridge
+        ignoreUnknownSignals: true
+
+        function onFatalFailure() {
+            engine.failPending("backend");
+        }
+
+        function onResultReceived(result) {
+            engine.acceptResult(result);
+        }
+    }
+
+    QtObject {
+        id: engine
+
+        property var currentBridge: root.bridge === null ? nativeBridge : root.bridge
+        property int nextRequestId: 1
+        property int pendingRequestId: 0
+        property string pendingAction: "none"
+        property string failure: "none"
+
+        function acceptResult(result) {
+            if (result === null || typeof result !== "object" || Array.isArray(result)
+                    || result.requestId !== pendingRequestId || result.action !== pendingAction ||
+                    !validOutcome(result.outcome)) {
+                return;
+            }
+
+            const requestId = pendingRequestId;
+            const action = pendingAction;
+            pendingRequestId = 0;
+            pendingAction = "none";
+            failure = result.outcome === "accepted" ? "none" : result.outcome;
+            root.operationFinished(requestId, action, result.outcome);
+        }
+
+        function allocateRequestId() {
+            const requestId = nextRequestId;
+            nextRequestId = nextRequestId >= 2147483647 ? 1 : nextRequestId + 1;
+            return requestId;
+        }
+
+        function cleanup() {
+            currentBridge = null;
+            reset();
+        }
+
+        function failPending(outcome) {
+            if (pendingRequestId === 0) {
+                failure = outcome;
+                return;
+            }
+            acceptResult({
+                             "requestId": pendingRequestId,
+                             "action": pendingAction,
+                             "outcome": outcome
+                         });
+        }
+
+        function requestAction(action) {
+            if (currentBridge === null || !currentBridge.ready || pendingRequestId !== 0 || !validAction(
+                        action)) {
+                return 0;
+            }
+
+            const requestId = allocateRequestId();
+            if (!currentBridge.requestAction(requestId, action)) {
+                return 0;
+            }
+            pendingRequestId = requestId;
+            pendingAction = action;
+            failure = "none";
+            return requestId;
+        }
+
+        function reset() {
+            pendingRequestId = 0;
+            pendingAction = "none";
+            failure = "none";
+        }
+
+        function validAction(action) {
+            return action === "lock" || action === "suspend" || action === "logout" || action
+                    === "reboot" || action === "powerOff";
+        }
+
+        function validOutcome(outcome) {
+            return outcome === "accepted" || outcome === "busy" || outcome === "denied" || outcome
+                    === "unavailable" || outcome === "timeout" || outcome === "backend";
+        }
+    }
+}

--- a/qml/SessionView.qml
+++ b/qml/SessionView.qml
@@ -1,0 +1,200 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+
+FocusScope {
+    id: view
+
+    required property var service
+    required property real ownerEpoch
+
+    readonly property bool actionPending: service !== null && service.pending
+
+    signal actionDispatched(int requestId, real ownerEpoch)
+    signal cancelled(real ownerEpoch)
+
+    function failureText(failure) {
+        if (failure === "busy") {
+            return "Another session action is still pending.";
+        }
+        if (failure === "denied") {
+            return "Permission denied. Check the KDE session policy and try again.";
+        }
+        if (failure === "unavailable") {
+            return "This action is unavailable in the current KDE session.";
+        }
+        if (failure === "timeout") {
+            return "The KDE session service did not respond. Try again.";
+        }
+        if (failure === "backend") {
+            return "The session action failed. Try again or use KDE's session controls.";
+        }
+        return "";
+    }
+
+    function focusInitialControl() {
+        lockButton.forceActiveFocus(Qt.ShortcutFocusReason);
+    }
+
+    function pendingLabel(action) {
+        if (action === "lock") {
+            return "Locking…";
+        }
+        if (action === "suspend") {
+            return "Suspending…";
+        }
+        if (action === "logout") {
+            return "Opening logout confirmation…";
+        }
+        if (action === "reboot") {
+            return "Opening restart confirmation…";
+        }
+        if (action === "powerOff") {
+            return "Opening power-off confirmation…";
+        }
+        return "Working…";
+    }
+
+    function requestAction(action) {
+        if (service === null || actionPending) {
+            return false;
+        }
+        service.clearFailure();
+        const requestId = service.requestAction(action);
+        if (requestId === 0) {
+            return false;
+        }
+        actionDispatched(requestId, ownerEpoch);
+        return true;
+    }
+
+    Keys.priority: Keys.BeforeItem
+    Keys.onEscapePressed: event => {
+        if (!view.actionPending) {
+            view.cancelled(view.ownerEpoch);
+            event.accepted = true;
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: Theme.spacing.xl
+        spacing: Theme.spacing.lg
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacing.md
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: Theme.spacing.xs
+
+                IslandText {
+                    text: "Session"
+                    size: "title"
+                    font.weight: Theme.type.weightSemibold
+                }
+
+                IslandText {
+                    text: "Choose a session action. KDE confirms logout, restart, and power off."
+                    tone: "secondary"
+                    wrapMode: Text.Wrap
+                    Layout.fillWidth: true
+                }
+            }
+
+            IslandButton {
+                id: cancelButton
+
+                label: "Cancel"
+                enabled: !view.actionPending
+                Accessible.description: "Return without performing a session action"
+                onClicked: view.cancelled(view.ownerEpoch)
+            }
+        }
+
+        GridLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            columns: 2
+            columnSpacing: Theme.spacing.md
+            rowSpacing: Theme.spacing.md
+
+            IslandButton {
+                id: lockButton
+
+                label: "Lock"
+                enabled: view.service !== null && view.service.backendReady && !view.actionPending
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Accessible.description: "Lock this KDE session"
+                onClicked: view.requestAction("lock")
+            }
+
+            IslandButton {
+                label: "Suspend"
+                enabled: view.service !== null && view.service.backendReady && !view.actionPending
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Accessible.description: "Suspend this computer"
+                onClicked: view.requestAction("suspend")
+            }
+
+            IslandButton {
+                label: "Log out"
+                variant: "danger"
+                enabled: view.service !== null && view.service.backendReady && !view.actionPending
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Accessible.description: "Open KDE confirmation to end the current session"
+                onClicked: view.requestAction("logout")
+            }
+
+            IslandButton {
+                label: "Restart"
+                variant: "danger"
+                enabled: view.service !== null && view.service.backendReady && !view.actionPending
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Accessible.description: "Open KDE confirmation to restart this computer"
+                onClicked: view.requestAction("reboot")
+            }
+
+            IslandButton {
+                label: "Power off"
+                variant: "danger"
+                enabled: view.service !== null && view.service.backendReady && !view.actionPending
+                Layout.columnSpan: 2
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Accessible.description: "Open KDE confirmation to power off this computer"
+                onClicked: view.requestAction("powerOff")
+            }
+        }
+
+        IslandText {
+            readonly property string failureMessage: view.service === null ? "" : view.failureText(
+                                                                                 view.service.failure)
+
+            text: view.actionPending ? view.pendingLabel(view.service.pendingAction) :
+                                       failureMessage
+            visible: text !== ""
+            color: view.actionPending ? Theme.color.textSecondary : Theme.color.danger
+            wrapMode: Text.Wrap
+            Layout.fillWidth: true
+            Accessible.role: Accessible.StaticText
+            Accessible.name: text
+        }
+
+        IslandText {
+            text: "Session controls are unavailable. Restart Nagi Shell and try again."
+            visible: view.service === null || !view.service.backendReady
+            tone: "secondary"
+            wrapMode: Text.Wrap
+            Layout.fillWidth: true
+            Accessible.role: Accessible.StaticText
+            Accessible.name: text
+        }
+    }
+}

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -14,7 +14,7 @@ import QtQuick
 //   textSecondary >= 10.2:1  AAA body text
 //   textMuted     >=  5.8:1  AA body text
 //   accentForeground = 7.4:1  against the accent fill
-//   dangerForeground = 6.6:1  against the danger fill
+//   danger       >=  4.9:1  against every destructive control fill
 //   focusRing     >=  8.8:1  non-text UI minimum is 3:1
 //   accent        >=  7.19:1 control boundary against the surface
 //   progressFill  =   5.9:1  against the progress track
@@ -40,9 +40,9 @@ Singleton {
         readonly property color accentPressed: "#6390EE"
         readonly property color accentForeground: "#0B1220"
         readonly property color danger: "#F26D7E"
-        readonly property color dangerHover: "#F58594"
-        readonly property color dangerPressed: "#E4576B"
-        readonly property color dangerForeground: "#1F0A0E"
+        readonly property color dangerFill: "#21171B"
+        readonly property color dangerFillHover: "#321B22"
+        readonly property color dangerFillPressed: "#43202A"
         readonly property color success: "#7BD88F"
         readonly property color warning: "#E8C268"
         readonly property color focusRing: "#8FB5FF"

--- a/shell.qml
+++ b/shell.qml
@@ -34,6 +34,11 @@ ShellRoot {
         helperPath: Quickshell.shellPath("build/nagi-connectivity")
     }
 
+    SessionService {
+        id: session
+        helperPath: Quickshell.shellPath("build/nagi-session")
+    }
+
     ApplicationModel {
         id: applications
 
@@ -56,17 +61,28 @@ ShellRoot {
         }
     }
 
+    Component {
+        id: sessionDashboardEntry
+
+        SessionEntry {
+            onOpenRequested: islandState.openSession(islandHost.surfaceToken)
+        }
+    }
+
     ReducedMotion {
         id: motion
     }
 
     IslandSurfaceHost {
+        id: islandHost
         coordinator: islandState
         virtualDesktops: virtualDesktops
         clock: clock
         weather: weather
         media: media
+        sessionService: session
         reducedMotion: motion.active
         dashboardQuickControlsContent: tray.available ? trayDashboardContent : null
+        dashboardNavigationContent: sessionDashboardEntry
     }
 }

--- a/src/session/main.cpp
+++ b/src/session/main.cpp
@@ -1,0 +1,293 @@
+#include <QCoreApplication>
+#include <QDBusConnection>
+#include <QDBusError>
+#include <QDBusMessage>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSocketNotifier>
+#include <QTimer>
+
+#include <array>
+#include <cerrno>
+#include <cstdio>
+#include <limits>
+#include <optional>
+#include <unistd.h>
+
+namespace {
+
+constexpr int DbusTimeoutMs = 5000;
+constexpr int RequestTimeoutMs = 5500;
+constexpr qsizetype MaximumCommandBytes = 4096;
+constexpr int MaximumDiagnostics = 4;
+
+struct Operation {
+    const char *service;
+    const char *path;
+    const char *interface;
+    const char *method;
+};
+
+std::optional<Operation> operationFor(const QString &action)
+{
+    if (action == QStringLiteral("lock")) {
+        return Operation{
+            "org.freedesktop.ScreenSaver",
+            "/ScreenSaver",
+            "org.freedesktop.ScreenSaver",
+            "Lock",
+        };
+    }
+    if (action == QStringLiteral("suspend")) {
+        return Operation{
+            "org.kde.Solid.PowerManagement",
+            "/org/kde/Solid/PowerManagement/Actions/SuspendSession",
+            "org.kde.Solid.PowerManagement.Actions.SuspendSession",
+            "suspendToRam",
+        };
+    }
+    if (action == QStringLiteral("logout")) {
+        return Operation{
+            "org.kde.LogoutPrompt",
+            "/LogoutPrompt",
+            "org.kde.LogoutPrompt",
+            "promptLogout",
+        };
+    }
+    if (action == QStringLiteral("reboot")) {
+        return Operation{
+            "org.kde.LogoutPrompt",
+            "/LogoutPrompt",
+            "org.kde.LogoutPrompt",
+            "promptReboot",
+        };
+    }
+    if (action == QStringLiteral("powerOff")) {
+        return Operation{
+            "org.kde.LogoutPrompt",
+            "/LogoutPrompt",
+            "org.kde.LogoutPrompt",
+            "promptShutDown",
+        };
+    }
+    return std::nullopt;
+}
+
+QString normalizeFailure(const QDBusError &error)
+{
+    const QString name = error.name().toLower();
+    if (name.contains(QStringLiteral("accessdenied"))
+        || name.contains(QStringLiteral("notauthorized"))
+        || name.contains(QStringLiteral("permissiondenied"))
+        || name.contains(QStringLiteral("authentication"))) {
+        return QStringLiteral("denied");
+    }
+    if (error.type() == QDBusError::NoReply || error.type() == QDBusError::Timeout
+        || name.contains(QStringLiteral("timeout"))) {
+        return QStringLiteral("timeout");
+    }
+    if (error.type() == QDBusError::ServiceUnknown
+        || error.type() == QDBusError::UnknownObject
+        || error.type() == QDBusError::UnknownInterface
+        || error.type() == QDBusError::UnknownMethod
+        || name.contains(QStringLiteral("serviceunknown"))
+        || name.contains(QStringLiteral("namehasnoowner"))) {
+        return QStringLiteral("unavailable");
+    }
+    return QStringLiteral("backend");
+}
+
+class SessionBridge final : public QObject {
+    Q_OBJECT
+
+public:
+    explicit SessionBridge(QObject *parent = nullptr)
+        : QObject(parent)
+        , bus(QDBusConnection::sessionBus())
+    {
+        requestTimer.setSingleShot(true);
+        requestTimer.setInterval(RequestTimeoutMs);
+        connect(&requestTimer, &QTimer::timeout, this, [this] {
+            if (pendingRequestId == 0) {
+                return;
+            }
+            const int requestId = pendingRequestId;
+            const QString action = pendingAction;
+            clearPending();
+            publishResult(requestId, action, QStringLiteral("timeout"));
+        });
+
+        stdinNotifier = new QSocketNotifier(STDIN_FILENO, QSocketNotifier::Read, this);
+        connect(stdinNotifier, &QSocketNotifier::activated, this, [this] { readCommands(); });
+        QTimer::singleShot(0, this, [this] {
+            publishMessage(QJsonObject{{QStringLiteral("type"), QStringLiteral("ready")}});
+        });
+    }
+
+private:
+    void requestAction(int requestId, const QString &action)
+    {
+        const std::optional<Operation> operation = operationFor(action);
+        if (!operation.has_value()) {
+            return;
+        }
+        if (pendingRequestId != 0) {
+            publishResult(requestId, action, QStringLiteral("busy"));
+            return;
+        }
+
+        pendingRequestId = requestId;
+        pendingAction = action;
+        requestTimer.start();
+
+        const Operation &target = operation.value();
+        const QDBusMessage request = QDBusMessage::createMethodCall(
+            QString::fromLatin1(target.service),
+            QString::fromLatin1(target.path),
+            QString::fromLatin1(target.interface),
+            QString::fromLatin1(target.method));
+        auto *watcher = new QDBusPendingCallWatcher(bus.asyncCall(request, DbusTimeoutMs), this);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher, requestId, action] {
+            const QDBusPendingReply<> reply = *watcher;
+            watcher->deleteLater();
+            if (pendingRequestId != requestId || pendingAction != action) {
+                return;
+            }
+            const QString outcome = reply.isError() ? normalizeFailure(reply.error())
+                                                    : QStringLiteral("accepted");
+            clearPending();
+            publishResult(requestId, action, outcome);
+        });
+    }
+
+    void clearPending()
+    {
+        requestTimer.stop();
+        pendingRequestId = 0;
+        pendingAction.clear();
+    }
+
+    void handleCommand(const QJsonObject &command)
+    {
+        const QString operation = command.value(QStringLiteral("op")).toString();
+        if (operation == QStringLiteral("shutdown")) {
+            QCoreApplication::quit();
+            return;
+        }
+
+        const QJsonValue requestValue = command.value(QStringLiteral("requestId"));
+        const QString action = command.value(QStringLiteral("action")).toString();
+        if (operation != QStringLiteral("action") || !requestValue.isDouble()
+            || requestValue.toDouble() < 1
+            || requestValue.toDouble() > std::numeric_limits<int>::max()
+            || requestValue.toInt() != requestValue.toDouble() || !operationFor(action).has_value()) {
+            diagnose(QStringLiteral("invalid command schema"));
+            return;
+        }
+        requestAction(requestValue.toInt(), action);
+    }
+
+    void readCommands()
+    {
+        std::array<char, MaximumCommandBytes> bytes{};
+        const ssize_t count = ::read(STDIN_FILENO, bytes.data(), bytes.size());
+        if (count == 0) {
+            QCoreApplication::quit();
+            return;
+        }
+        if (count < 0) {
+            if (errno != EAGAIN && errno != EINTR) {
+                diagnose(QStringLiteral("stdin read failed"));
+                QCoreApplication::exit(2);
+            }
+            return;
+        }
+
+        commandBuffer.append(bytes.data(), count);
+        if (commandBuffer.size() > MaximumCommandBytes * 2) {
+            diagnose(QStringLiteral("command buffer exceeded limit"));
+            commandBuffer.clear();
+        }
+        while (true) {
+            const qsizetype newline = commandBuffer.indexOf('\n');
+            if (newline < 0) {
+                return;
+            }
+            QByteArray line = commandBuffer.left(newline);
+            commandBuffer.remove(0, newline + 1);
+            if (line.endsWith('\r')) {
+                line.chop(1);
+            }
+            if (line.isEmpty() || line.size() > MaximumCommandBytes) {
+                diagnose(QStringLiteral("invalid command length"));
+                continue;
+            }
+            QJsonParseError error;
+            const QJsonDocument document = QJsonDocument::fromJson(line, &error);
+            if (error.error != QJsonParseError::NoError || !document.isObject()) {
+                diagnose(QStringLiteral("malformed command"));
+                continue;
+            }
+            handleCommand(document.object());
+        }
+    }
+
+    void publishResult(int requestId, const QString &action, const QString &outcome)
+    {
+        publishMessage(QJsonObject{
+            {QStringLiteral("type"), QStringLiteral("result")},
+            {QStringLiteral("requestId"), requestId},
+            {QStringLiteral("action"), action},
+            {QStringLiteral("outcome"), outcome},
+        });
+    }
+
+    void publishMessage(const QJsonObject &message)
+    {
+        const QByteArray bytes = QJsonDocument(message).toJson(QJsonDocument::Compact);
+        std::fwrite(bytes.constData(), 1, static_cast<size_t>(bytes.size()), stdout);
+        std::fputc('\n', stdout);
+        std::fflush(stdout);
+    }
+
+    void diagnose(const QString &message)
+    {
+        if (diagnosticCount >= MaximumDiagnostics || message == lastDiagnostic) {
+            return;
+        }
+        lastDiagnostic = message;
+        diagnosticCount += 1;
+        const QByteArray bounded = message.left(256).toUtf8();
+        std::fprintf(stderr, "nagi-shell session helper: %s\n", bounded.constData());
+        std::fflush(stderr);
+    }
+
+    QDBusConnection bus;
+    QSocketNotifier *stdinNotifier = nullptr;
+    QTimer requestTimer;
+    QByteArray commandBuffer;
+    int pendingRequestId = 0;
+    QString pendingAction;
+    int diagnosticCount = 0;
+    QString lastDiagnostic;
+};
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    QCoreApplication application(argc, argv);
+    application.setApplicationName(QStringLiteral("nagi-session"));
+
+    if (!QDBusConnection::sessionBus().isConnected()) {
+        std::fprintf(stderr, "nagi-shell session helper: session bus unavailable\n");
+        return 2;
+    }
+
+    SessionBridge bridge;
+    return application.exec();
+}
+
+#include "main.moc"

--- a/tests/coordinator/shell.qml
+++ b/tests/coordinator/shell.qml
@@ -26,8 +26,7 @@ ShellRoot {
         require(request(), owner + " freshness request enters");
         require(coordinator.ownerName === owner, owner + " owns before freshness boundary");
         nowMs += freshness - 1;
-        require(coordinator.setHover(generation, false), owner
-                + " pre-boundary dispatch succeeds");
+        require(coordinator.setHover(generation, false), owner + " pre-boundary dispatch succeeds");
         require(coordinator.ownerName === owner, owner + " remains fresh before boundary");
         nowMs += 1;
         require(coordinator.setHover(generation, false), owner
@@ -93,12 +92,10 @@ ShellRoot {
 
     function verifyExpandedIntents() {
         attachFreshSurface();
-        require(!coordinator.setHover(generation + 1, true),
-                "stale hover generation is rejected");
+        require(!coordinator.setHover(generation + 1, true), "stale hover generation is rejected");
         require(coordinator.setHover(generation, true), "current hover expands the baseline");
-        require(coordinator.ownerName === "expanded"
-                && coordinator.focusTarget === coordinator.focusNone,
-                "hover expansion never requests keyboard focus");
+        require(coordinator.ownerName === "expanded" && coordinator.focusTarget
+                === coordinator.focusNone, "hover expansion never requests keyboard focus");
         const hoverFocusSerial = coordinator.focusRequestSerial;
         require(coordinator.acknowledgeVisible(generation, coordinator.ownerEpoch,
                                                coordinator.revision),
@@ -108,9 +105,9 @@ ShellRoot {
 
         require(coordinator.setExplicitExpanded(generation, true),
                 "deliberate intent joins the expanded baseline");
-        require(coordinator.ownerName === "expanded"
-                && coordinator.focusTarget === coordinator.focusExpandedDashboard
-                && coordinator.focusRequestSerial === hoverFocusSerial + 1,
+        require(coordinator.ownerName === "expanded" && coordinator.focusTarget
+                === coordinator.focusExpandedDashboard && coordinator.focusRequestSerial
+                === hoverFocusSerial + 1,
                 "visible deliberate expansion receives dashboard focus intent");
         require(coordinator.setExplicitExpanded(generation, false),
                 "deliberate intent can clear independently");
@@ -123,8 +120,8 @@ ShellRoot {
         const deliberateFocusSerial = coordinator.focusRequestSerial;
         require(coordinator.setExplicitExpanded(generation, true),
                 "keyboard expansion enters from Idle");
-        require(coordinator.focusRequestSerial === deliberateFocusSerial
-                && coordinator.focusTarget === coordinator.focusExpandedDashboard,
+        require(coordinator.focusRequestSerial === deliberateFocusSerial && coordinator.focusTarget
+                === coordinator.focusExpandedDashboard,
                 "focus waits for the deliberate dashboard presentation");
         require(coordinator.acknowledgeVisible(generation, coordinator.ownerEpoch,
                                                coordinator.revision),
@@ -165,16 +162,21 @@ ShellRoot {
         require(coordinator.openLauncher(token), "local launcher intent is accepted");
         require(coordinator.ownerName === "launcher", "launcher preempts expanded");
         require(coordinator.openSession(token), "session intent is accepted");
+        const suspendedSessionEpoch = coordinator.ownerEpoch;
         require(coordinator.ownerName === "session", "session preempts launcher");
         require(coordinator.syncPolkitModal(true, true, 1), "Polkit snapshot is accepted");
         require(coordinator.ownerName === "polkitModal", "Modal preempts session");
         require(coordinator.restorationDepth <= coordinator.maximumRestorationDepth,
                 "restoration chain remains bounded");
-
+        require(coordinator.completeInteractive(suspendedSessionEpoch),
+                "matching completion invalidates a Modal-suspended session");
+        require(coordinator.ownerName === "polkitModal",
+                "suspended completion cannot close the current Modal");
+        require(!coordinator.completeInteractive(suspendedSessionEpoch),
+                "repeated suspended completion is stale");
         require(coordinator.syncPolkitModal(false, false, 0), "Polkit cleanup is accepted");
-        require(coordinator.ownerName === "session", "Modal restores the highest predecessor");
-        require(coordinator.completeInteractive(coordinator.ownerEpoch), "session completes");
-        require(coordinator.ownerName === "launcher", "session restores launcher");
+        require(coordinator.ownerName === "launcher",
+                "Modal cleanup skips the completed session and restores its predecessor");
         require(coordinator.cancelInteractive(coordinator.ownerEpoch), "launcher cancels");
         require(coordinator.ownerName === "expanded", "launcher restores expanded");
 
@@ -198,6 +200,28 @@ ShellRoot {
         require(coordinator.cancelInteractive(launcherEpoch), "Escape cancels current launcher");
         require(coordinator.ownerName === "expanded", "Escape restores the predecessor");
 
+        require(coordinator.openSession(token), "visible dashboard session intent opens");
+        const sessionEpoch = coordinator.ownerEpoch;
+        require(coordinator.acknowledgeVisible(generation, sessionEpoch, coordinator.revision),
+                "matching session presentation is acknowledged");
+        require(coordinator.focusTarget === coordinator.focusSessionActions,
+                "visible session interaction requests action-grid focus");
+        const sessionRevisionBeforeModal = coordinator.revision;
+        require(coordinator.syncPolkitModal(true, true, 2),
+                "Modal can suspend the active session task");
+        require(coordinator.syncPolkitModal(false, false, 0),
+                "Modal cleanup restores an unfinished session task");
+        require(coordinator.ownerName === "session" && coordinator.ownerEpoch === sessionEpoch
+                && coordinator.revision > sessionRevisionBeforeModal,
+                "restoration preserves the session task epoch with a fresh presentation revision");
+        require(coordinator.acknowledgeVisible(generation, sessionEpoch, coordinator.revision),
+                "restored session presentation is acknowledged");
+        require(!coordinator.cancelInteractive(sessionEpoch - 1),
+                "stale session cancellation is rejected");
+        require(coordinator.cancelInteractive(sessionEpoch),
+                "current session cancellation is accepted");
+        require(coordinator.ownerName === "expanded",
+                "session cancellation atomically restores its predecessor");
         require(coordinator.openLauncher(null), "shortcut launcher intent opens");
         require(coordinator.ownerName === "launcher",
                 "global and local origins share launcher behavior");
@@ -306,8 +330,7 @@ ShellRoot {
                                                coordinator.revision),
                 "notification hold starts after visibility");
         nowMs += 500;
-        require(coordinator.setHover(generation, true),
-                "Expanded preempts visible notification");
+        require(coordinator.setHover(generation, true), "Expanded preempts visible notification");
         require(coordinator.ownerName === "expanded", "Expanded owns during preemption");
         require(coordinator.setHover(generation, false), "Expanded releases notification");
         require(coordinator.ownerName === "notification", "fresh predecessor is restored");
@@ -320,8 +343,7 @@ ShellRoot {
         require(coordinator.ownerName === "notification",
                 "restored notification keeps only its remaining hold");
         nowMs += 1;
-        require(coordinator.setHover(generation, false),
-                "remaining hold boundary is processed");
+        require(coordinator.setHover(generation, false), "remaining hold boundary is processed");
         require(coordinator.ownerName === "idle",
                 "remaining hold does not restart from full duration");
 

--- a/tests/session/shell.qml
+++ b/tests/session/shell.qml
@@ -1,0 +1,130 @@
+import Quickshell
+import QtQuick
+import "qml"
+
+ShellRoot {
+    id: test
+
+    property int entryRequests: 0
+    property real cancelledEpoch: 0
+    property int dispatchedRequestId: 0
+    property real dispatchedEpoch: 0
+
+    function require(condition, message) {
+        if (!condition) {
+            console.error("FAIL: " + message);
+            Qt.exit(1);
+            throw new Error(message);
+        }
+    }
+
+    QtObject {
+        id: fakeBridge
+
+        property bool ready: true
+        property var commands: []
+
+        signal resultReceived(var result)
+        signal fatalFailure
+
+        function requestAction(requestId, action) {
+            const next = commands.slice();
+            next.push({
+                          "requestId": requestId,
+                          "action": action
+                      });
+            commands = next;
+            return true;
+        }
+    }
+
+    SessionService {
+        id: service
+
+        helperPath: ""
+        bridge: fakeBridge
+        onOperationFinished: function (requestId, action, outcome) {
+            require(requestId > 0 && action !== "" && outcome !== "",
+                    "service emits bounded operation results");
+        }
+    }
+
+    SessionEntry {
+        id: entry
+
+        onOpenRequested: test.entryRequests += 1
+    }
+
+    SessionView {
+        id: view
+
+        ownerEpoch: 41
+        service: service
+        onActionDispatched: function (requestId, epoch) {
+            test.dispatchedRequestId = requestId;
+            test.dispatchedEpoch = epoch;
+        }
+        onCancelled: epoch => test.cancelledEpoch = epoch
+    }
+
+    function run() {
+        require(service.backendReady && !service.pending && service.failure === "none",
+                "ready bridge produces an idle normalized service");
+        require(entry.label === "Session", "dashboard exposes one concise Session entry");
+        entry.openRequested();
+        require(entryRequests === 1, "Session entry emits one explicit open request");
+
+        require(!view.requestAction("invalid"), "unknown session actions are rejected");
+        require(view.requestAction("lock"), "explicit lock activation is dispatched");
+        const lockRequest = service.pending ? fakeBridge.commands[0].requestId : 0;
+        require(lockRequest > 0 && fakeBridge.commands.length === 1 && dispatchedRequestId
+                === lockRequest && dispatchedEpoch === 41,
+                "view binds one request identity to the current session owner");
+        require(!view.requestAction("suspend") && fakeBridge.commands.length === 1,
+                "repeated activation is blocked while an operation is pending");
+
+        fakeBridge.resultReceived({
+                                      "requestId": lockRequest,
+                                      "action": "lock",
+                                      "outcome": "denied"
+                                  });
+        require(!service.pending && service.failure === "denied",
+                "denial keeps the session task visible with a normalized failure");
+        require(view.failureText(service.failure).indexOf("Permission denied") === 0,
+                "denial copy is actionable and contains no backend payload");
+
+        require(view.requestAction("logout"), "logout confirmation request is dispatched");
+        const logoutRequest = fakeBridge.commands[1].requestId;
+        fakeBridge.resultReceived({
+                                      "requestId": lockRequest,
+                                      "action": "lock",
+                                      "outcome": "accepted"
+                                  });
+        require(service.pending, "stale backend completion cannot finish a newer request");
+        fakeBridge.resultReceived({
+                                      "requestId": logoutRequest,
+                                      "action": "logout",
+                                      "outcome": "accepted"
+                                  });
+        require(!service.pending && service.failure === "none" && dispatchedRequestId
+                === logoutRequest && dispatchedEpoch === 41,
+                "accepted platform handoff retains the matching owner identity for the surface");
+        require(view.requestAction("reboot"), "a later destructive action can start cleanly");
+        fakeBridge.fatalFailure();
+        require(!service.pending && service.failure === "backend",
+                "helper loss cleans up pending state without completing the owner");
+        require(view.failureText(service.failure).indexOf("session action failed") > 0,
+                "backend failure offers an actionable fallback");
+
+        view.cancelled(view.ownerEpoch);
+        require(cancelledEpoch === 41 && fakeBridge.commands.length === 3,
+                "cancellation carries the owner epoch and dispatches no side effect");
+        require(service.activeTimerCount === 0,
+                "injected service leaves no production timers active");
+
+        console.warn("session service and view tests passed");
+        Qt.exit(0);
+    }
+
+    Component.onCompleted: Qt.callLater(run)
+}

--- a/tests/session_dbus_test.cpp
+++ b/tests/session_dbus_test.cpp
@@ -1,0 +1,330 @@
+#include <QCoreApplication>
+#include <QDBusConnection>
+#include <QDBusError>
+#include <QDBusMessage>
+#include <QDBusVirtualObject>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMap>
+#include <QProcess>
+#include <QTimer>
+
+#include <cstdlib>
+#include <cstdio>
+#include <utility>
+
+namespace {
+
+constexpr auto ScreenSaverService = "org.freedesktop.ScreenSaver";
+constexpr auto PowerService = "org.kde.Solid.PowerManagement";
+constexpr auto LogoutService = "org.kde.LogoutPrompt";
+
+class FakeSessionServices final : public QDBusVirtualObject {
+public:
+    enum class Mode {
+        Success,
+        Denied,
+        Backend,
+        Timeout,
+    };
+
+    explicit FakeSessionServices(QObject *parent = nullptr)
+        : QDBusVirtualObject(parent)
+    {
+    }
+
+    QString introspect(const QString &) const override
+    {
+        return {};
+    }
+
+    bool handleMessage(const QDBusMessage &message, const QDBusConnection &connection) override
+    {
+        const QString member = message.member();
+        if (member != QStringLiteral("Lock") && member != QStringLiteral("suspendToRam")
+            && member != QStringLiteral("promptLogout")
+            && member != QStringLiteral("promptReboot")
+            && member != QStringLiteral("promptShutDown")) {
+            return false;
+        }
+
+        calls[member] += 1;
+        if (mode == Mode::Denied) {
+            connection.send(message.createErrorReply(
+                QStringLiteral("org.freedesktop.DBus.Error.AccessDenied"),
+                QStringLiteral("test denial payload must remain private")));
+            return true;
+        }
+        if (mode == Mode::Backend) {
+            connection.send(message.createErrorReply(
+                QStringLiteral("org.kde.Session.Error.Failed"),
+                QStringLiteral("test backend payload must remain private")));
+            return true;
+        }
+        if (mode == Mode::Timeout) {
+            connection.send(message.createErrorReply(
+                QStringLiteral("org.freedesktop.DBus.Error.NoReply"),
+                QStringLiteral("test timeout payload must remain private")));
+            return true;
+        }
+
+        connection.send(message.createReply());
+        return true;
+    }
+
+    int callCount(const QString &member) const
+    {
+        return calls.value(member);
+    }
+
+
+    Mode mode = Mode::Success;
+
+private:
+    QMap<QString, int> calls;
+};
+
+class SessionDbusTest final : public QObject {
+    Q_OBJECT
+
+public:
+    SessionDbusTest(QString helperPath, QObject *parent = nullptr)
+        : QObject(parent)
+        , helperPath(std::move(helperPath))
+        , bus(QDBusConnection::sessionBus())
+        , services(this)
+    {
+    }
+
+    void start()
+    {
+        if (!bus.isConnected()
+            || !bus.registerVirtualObject(QStringLiteral("/"), &services, QDBusConnection::SubPath)
+            || !bus.registerService(QString::fromLatin1(ScreenSaverService))
+            || !bus.registerService(QString::fromLatin1(PowerService))
+            || !bus.registerService(QString::fromLatin1(LogoutService))) {
+            fail("could not register fake session services");
+            return;
+        }
+
+        connect(&helper, &QProcess::readyReadStandardOutput, this, &SessionDbusTest::readOutput);
+        connect(&helper, &QProcess::readyReadStandardError, this, [this] {
+            helperDiagnostics.append(helper.readAllStandardError());
+        });
+        connect(&helper, &QProcess::errorOccurred, this, [this](QProcess::ProcessError) {
+            fail("session helper process failed");
+        });
+        connect(&helper, &QProcess::finished, this, [this](int exitCode, QProcess::ExitStatus status) {
+            if (stage != Stage::Cleanup || exitCode != 0 || status != QProcess::NormalExit) {
+                fail("session helper exited unexpectedly");
+                return;
+            }
+            timeout.stop();
+            qInfo("session D-Bus tests passed");
+            QCoreApplication::exit(0);
+        });
+
+        timeout.setSingleShot(true);
+        timeout.setInterval(10000);
+        connect(&timeout, &QTimer::timeout, this, [this] { fail("session D-Bus test timed out"); });
+        timeout.start();
+        helper.start(helperPath);
+    }
+
+private:
+    enum class Stage {
+        Initial,
+        Lock,
+        Suspend,
+        Logout,
+        Reboot,
+        PowerOff,
+        Denied,
+        Backend,
+        Timeout,
+        Busy,
+        HeldAccepted,
+        Unavailable,
+        Cleanup,
+    };
+
+    void readOutput()
+    {
+        output.append(helper.readAllStandardOutput());
+        while (true) {
+            const qsizetype newline = output.indexOf('\n');
+            if (newline < 0) {
+                return;
+            }
+            const QByteArray line = output.left(newline);
+            output.remove(0, newline + 1);
+            const QJsonObject message = QJsonDocument::fromJson(line).object();
+            processMessage(message);
+        }
+    }
+
+    void processMessage(const QJsonObject &message)
+    {
+        if (stage == Stage::Initial) {
+            require(message.value(QStringLiteral("type")) == QStringLiteral("ready"),
+                    "helper publishes readiness first");
+            stage = Stage::Lock;
+            sendAction(1, "lock");
+            return;
+        }
+        require(message.value(QStringLiteral("type")) == QStringLiteral("result"),
+                "helper publishes only bounded result messages after readiness");
+
+        const int requestId = message.value(QStringLiteral("requestId")).toInt();
+        const QString action = message.value(QStringLiteral("action")).toString();
+        const QString outcome = message.value(QStringLiteral("outcome")).toString();
+        if (stage == Stage::Lock) {
+            expect(requestId, action, outcome, 1, "lock", "accepted");
+            require(services.callCount(QStringLiteral("Lock")) == 1,
+                    "lock invokes the screen saver exactly once");
+            stage = Stage::Suspend;
+            sendAction(2, "suspend");
+        } else if (stage == Stage::Suspend) {
+            expect(requestId, action, outcome, 2, "suspend", "accepted");
+            require(services.callCount(QStringLiteral("suspendToRam")) == 1,
+                    "suspend invokes PowerDevil exactly once");
+            stage = Stage::Logout;
+            sendAction(3, "logout");
+        } else if (stage == Stage::Logout) {
+            expect(requestId, action, outcome, 3, "logout", "accepted");
+            stage = Stage::Reboot;
+            sendAction(4, "reboot");
+        } else if (stage == Stage::Reboot) {
+            expect(requestId, action, outcome, 4, "reboot", "accepted");
+            stage = Stage::PowerOff;
+            sendAction(5, "powerOff");
+        } else if (stage == Stage::PowerOff) {
+            expect(requestId, action, outcome, 5, "powerOff", "accepted");
+            require(services.callCount(QStringLiteral("promptLogout")) == 1
+                        && services.callCount(QStringLiteral("promptReboot")) == 1
+                        && services.callCount(QStringLiteral("promptShutDown")) == 1,
+                    "destructive actions use their matching KDE confirmation prompts");
+            services.mode = FakeSessionServices::Mode::Denied;
+            stage = Stage::Denied;
+            sendAction(6, "lock");
+        } else if (stage == Stage::Denied) {
+            expect(requestId, action, outcome, 6, "lock", "denied");
+            require(!QString::fromUtf8(output).contains(QStringLiteral("test denial")),
+                    "D-Bus denial payload is not exposed");
+            services.mode = FakeSessionServices::Mode::Backend;
+            stage = Stage::Backend;
+            sendAction(7, "suspend");
+        } else if (stage == Stage::Backend) {
+            expect(requestId, action, outcome, 7, "suspend", "backend");
+            services.mode = FakeSessionServices::Mode::Timeout;
+            stage = Stage::Timeout;
+            sendAction(8, "suspend");
+        } else if (stage == Stage::Timeout) {
+            expect(requestId, action, outcome, 8, "suspend", "timeout");
+            services.mode = FakeSessionServices::Mode::Success;
+            stage = Stage::Busy;
+            sendAction(9, "logout");
+            sendAction(10, "reboot");
+        } else if (stage == Stage::Busy) {
+            expect(requestId, action, outcome, 10, "reboot", "busy");
+            require(services.callCount(QStringLiteral("promptReboot")) == 1,
+                    "a repeated activation never reaches D-Bus while another action is pending");
+            stage = Stage::HeldAccepted;
+        } else if (stage == Stage::HeldAccepted) {
+            expect(requestId, action, outcome, 9, "logout", "accepted");
+            services.mode = FakeSessionServices::Mode::Success;
+            require(bus.unregisterService(QString::fromLatin1(ScreenSaverService)),
+                    "screen saver fixture unregisters");
+            stage = Stage::Unavailable;
+            sendAction(11, "lock");
+        } else if (stage == Stage::Unavailable) {
+            expect(requestId, action, outcome, 11, "lock", "unavailable");
+            require(!QString::fromUtf8(helperDiagnostics).contains(QStringLiteral("payload")),
+                    "helper diagnostics reveal no backend payload");
+            stage = Stage::Cleanup;
+            sendShutdown();
+        }
+    }
+
+    void expect(int actualRequestId,
+                const QString &actualAction,
+                const QString &actualOutcome,
+                int requestId,
+                const char *action,
+                const char *outcome)
+    {
+        if (actualRequestId != requestId || actualAction != QString::fromLatin1(action)
+                || actualOutcome != QString::fromLatin1(outcome)) {
+            const QByteArray actualActionBytes = actualAction.toUtf8();
+            const QByteArray actualOutcomeBytes = actualOutcome.toUtf8();
+            std::fprintf(stderr,
+                         "expected result %d/%s/%s, received %d/%s/%s\n",
+                         requestId,
+                         action,
+                         outcome,
+                         actualRequestId,
+                         actualActionBytes.constData(),
+                         actualOutcomeBytes.constData());
+            fail("result preserves request identity and normalized outcome");
+        }
+    }
+
+    void sendAction(int requestId, const char *action)
+    {
+        const QJsonObject command{
+            {QStringLiteral("op"), QStringLiteral("action")},
+            {QStringLiteral("requestId"), requestId},
+            {QStringLiteral("action"), QString::fromLatin1(action)},
+        };
+        helper.write(QJsonDocument(command).toJson(QJsonDocument::Compact) + '\n');
+    }
+
+    void sendShutdown()
+    {
+        helper.write("{\"op\":\"shutdown\"}\n");
+        helper.closeWriteChannel();
+    }
+
+    void require(bool condition, const char *message)
+    {
+        if (!condition) {
+            fail(message);
+        }
+    }
+
+    [[noreturn]] void fail(const char *message)
+    {
+        std::fprintf(stderr, "session D-Bus test failed: %s\n", message);
+        std::fflush(stderr);
+        if (helper.state() != QProcess::NotRunning) {
+            helper.kill();
+            helper.waitForFinished();
+        }
+        std::exit(1);
+    }
+
+    QString helperPath;
+    QDBusConnection bus;
+    FakeSessionServices services;
+    QProcess helper;
+    QTimer timeout;
+    QByteArray output;
+    QByteArray helperDiagnostics;
+    Stage stage = Stage::Initial;
+};
+
+} // namespace
+int main(int argc, char **argv)
+{
+    QCoreApplication application(argc, argv);
+    if (argc != 2) {
+        qCritical("usage: session-dbus-test <helper>");
+        return 2;
+    }
+
+    SessionDbusTest test(QString::fromLocal8Bit(argv[1]));
+    QTimer::singleShot(0, &test, [&test] { test.start(); });
+    return application.exec();
+}
+
+#include "session_dbus_test.moc"

--- a/tests/surface-state/shell.qml
+++ b/tests/surface-state/shell.qml
@@ -10,6 +10,7 @@ ShellRoot {
     property int mountedRegionCount: 0
     property int hoverExpandedEpoch: 0
     property int focusSerialBeforeRestore: 0
+    property real sessionEpoch: 0
     property var initialSurfaceToken: null
     property int initialSurfaceGeneration: 0
     readonly property int maximumRetryAttempts: 500
@@ -51,19 +52,17 @@ ShellRoot {
             require(coordinator.setHover(host.surfaceGeneration, true),
                     "pointer hover intent expands locally");
         } else if (step === 1) {
-            if (!awaitState(coordinator.ownerName === "expanded"
-                            && coordinator.presentationVisible
+            if (!awaitState(coordinator.ownerName === "expanded" && coordinator.presentationVisible
                             && host.loadedDashboardRegionCount === 6,
                             "hover dashboard did not become visible within five seconds")) {
                 return;
             }
             require(coordinator.focusTarget === coordinator.focusNone && !host.surfaceFocusable,
                     "hover expansion never steals keyboard focus");
-            require(host.surfaceToken === initialSurfaceToken
-                    && host.surfaceGeneration === initialSurfaceGeneration,
-                    "expansion preserves the one live surface");
-            require(host.surfaceWidth <= Theme.size.islandExpandedWidth
-                    && host.surfaceHeight <= Theme.size.islandExpandedHeight,
+            require(host.surfaceToken === initialSurfaceToken && host.surfaceGeneration
+                    === initialSurfaceGeneration, "expansion preserves the one live surface");
+            require(host.surfaceWidth <= Theme.size.islandExpandedWidth && host.surfaceHeight
+                    <= Theme.size.islandExpandedHeight,
                     "expanded geometry stays within its logical bounds");
             hoverExpandedEpoch = coordinator.ownerEpoch;
             require(coordinator.setExplicitExpanded(host.surfaceGeneration, true),
@@ -80,9 +79,8 @@ ShellRoot {
             require(coordinator.openLauncher(host.surfaceToken),
                     "higher-priority interaction interrupts Expanded");
         } else if (step === 3) {
-            if (!awaitState(coordinator.ownerName === "launcher"
-                            && !coordinator.presentationVisible
-                            && !host.surfaceFocusable
+            if (!awaitState(coordinator.ownerName === "launcher" &&
+                            !coordinator.presentationVisible && !host.surfaceFocusable
                             && host.loadedDashboardRegionCount === 0,
                             "interruption did not hide obsolete dashboard content")) {
                 return;
@@ -93,9 +91,9 @@ ShellRoot {
             require(coordinator.cancelInteractive(coordinator.ownerEpoch),
                     "interrupted interaction cancels through the coordinator");
         } else if (step === 4) {
-            if (!awaitState(coordinator.ownerName === "expanded"
-                            && coordinator.presentationVisible && host.surfaceFocusable
-                            && host.dashboardFocused && host.loadedDashboardRegionCount === 6,
+            if (!awaitState(coordinator.ownerName === "expanded" && coordinator.presentationVisible
+                            && host.surfaceFocusable && host.dashboardFocused
+                            && host.loadedDashboardRegionCount === 6,
                             "dashboard did not restore visibly with focus")) {
                 return;
             }
@@ -103,8 +101,8 @@ ShellRoot {
                     "restored deliberate dashboard receives one fresh focus request");
             require(host.cancelDashboard(), "keyboard cancellation closes the dashboard");
         } else if (step === 5) {
-            if (!awaitState(coordinator.ownerName === "idle" && coordinator.presentationVisible
-                            && !host.surfaceFocusable,
+            if (!awaitState(coordinator.ownerName === "idle" && coordinator.presentationVisible &&
+                            !host.surfaceFocusable,
                             "dashboard cancellation did not restore Idle")) {
                 return;
             }
@@ -114,10 +112,10 @@ ShellRoot {
             require(host.requestDeliberateExpansion(),
                     "host exposes deliberate keyboard expansion");
         } else if (step === 6) {
-            if (!awaitState(coordinator.ownerName === "expanded"
-                            && coordinator.presentationVisible && host.surfaceFocusable
-                            && host.surfacePreferredWidth > Theme.size.islandIdleWidth
-                            && host.surfacePreferredHeight > Theme.size.islandIdleHeight,
+            if (!awaitState(coordinator.ownerName === "expanded" && coordinator.presentationVisible
+                            && host.surfaceFocusable && host.surfacePreferredWidth
+                            > Theme.size.islandIdleWidth && host.surfacePreferredHeight
+                            > Theme.size.islandIdleHeight,
                             "reduced-motion dashboard did not become usable")) {
                 return;
             }
@@ -129,11 +127,51 @@ ShellRoot {
                             "reduced-motion collapse did not restore Idle")) {
                 return;
             }
-            require(mountedRegionCount >= 12,
-                    "all six real region components remount after interruption");
+            require(host.requestDeliberateExpansion(),
+                    "session entry can originate from a deliberate dashboard");
+        } else if (step === 8) {
+            if (!awaitState(coordinator.ownerName === "expanded" && coordinator.presentationVisible,
+                            "dashboard did not reopen for session entry")) {
+                return;
+            }
+            require(coordinator.openSession(host.surfaceToken),
+                    "visible dashboard session entry is admitted");
+            sessionEpoch = coordinator.ownerEpoch;
+        } else if (step === 9) {
+            if (!awaitState(coordinator.ownerName === "session" && coordinator.presentationVisible
+                            && host.surfaceFocusable && host.sessionFocused,
+                            "session focus state: owner=" + coordinator.ownerName + " visible="
+                            + coordinator.presentationVisible + " focusable="
+                            + host.surfaceFocusable + " focused=" + host.sessionFocused
+                            + " target=" + coordinator.focusTarget + " serial="
+                            + coordinator.focusRequestSerial)) {
+                return;
+            }
+            require(coordinator.focusTarget === coordinator.focusSessionActions,
+                    "session presentation receives the action-grid focus target");
+            require(host.surfaceToken === initialSurfaceToken,
+                    "session interaction preserves the one live surface");
+            require(!coordinator.cancelInteractive(sessionEpoch - 1),
+                    "stale session cancellation cannot close the current owner");
+            require(coordinator.cancelInteractive(sessionEpoch),
+                    "session cancellation accepts the current owner epoch");
+        } else if (step === 10) {
+            if (!awaitState(coordinator.ownerName === "expanded" && coordinator.presentationVisible
+                            && host.dashboardFocused,
+                            "session cancellation did not restore the deliberate dashboard")) {
+                return;
+            }
+            require(host.cancelDashboard(), "restored dashboard remains cancellable");
+        } else if (step === 11) {
+            if (!awaitState(coordinator.ownerName === "idle" && coordinator.presentationVisible,
+                            "final dashboard cancellation did not restore Idle")) {
+                return;
+            }
+            require(mountedRegionCount >= 18,
+                    "all six real region components remount across both interruptions");
             require(!coordinator.setHover(host.surfaceGeneration + 1, true),
                     "stale surface intent cannot reopen the dashboard");
-            console.warn("actual island dashboard surface tests passed");
+            console.warn("actual island dashboard and session surface tests passed");
             Qt.exit(0);
             return;
         }
@@ -178,6 +216,22 @@ ShellRoot {
         TestRegion {}
     }
 
+    QtObject {
+        id: fakeSessionService
+
+        readonly property bool backendReady: true
+        readonly property bool pending: false
+        readonly property string pendingAction: "none"
+        readonly property string failure: "none"
+
+        signal operationFinished(int requestId, string action, string outcome)
+
+        function clearFailure() {
+        }
+        function requestAction(action) {
+            return 0;
+        }
+    }
     IslandStateCoordinator {
         id: coordinator
     }
@@ -192,6 +246,7 @@ ShellRoot {
         dashboardAudioContent: audioRegion
         dashboardNotificationsContent: notificationsRegion
         dashboardNavigationContent: navigationRegion
+        sessionService: fakeSessionService
     }
 
     Timer {


### PR DESCRIPTION
Route lock, suspend, logout, reboot, and power-off operations through
bounded KDE D-Bus integrations. Preserve session task identity across
Polkit interruptions and reject repeated or stale activation.

Closes #30