### PR TITLE
feat(ui): prepare Polkit modal UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ AUDIO_LIVE_TEST_DIR := $(BUILD_DIR)/audio-live-test
 AUDIO_LIVE_WRITE_TEST_DIR := $(BUILD_DIR)/audio-live-write-test
 SURFACE_STATE_TEST_DIR := $(BUILD_DIR)/surface-state-test
 UI_PRIMITIVES_TEST_DIR := $(BUILD_DIR)/ui-primitives-test
+POLKIT_UI_TEST_DIR := $(BUILD_DIR)/polkit-ui-test
 DASHBOARD_TEST_DIR := $(BUILD_DIR)/dashboard-test
 IDLE_TEST_DIR := $(BUILD_DIR)/idle-test
 TRAY_TEST_DIR := $(BUILD_DIR)/tray-test
@@ -97,6 +98,7 @@ FEDORA_QUICKSHELL_PACKAGE := quickshell
 
 .PHONY: help requirements prepare check-quickshell check-helper-toolchain check-audio-toolchain check-application-toolchain check-launcher-shortcut-toolchain check-notification-toolchain check-tray-toolchain helper audio-helper connectivity-helper brightness-helper session-helper application-helper launcher-shortcut-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-brightness-dbus test-brightness test-brightness-live-write test-session-dbus test-session test-applications test-launcher test-launcher-shortcut test-notifications test-adapter test-coordinator test-transients test-weather test-media test-audio test-audio-live test-audio-live-write test-connectivity test-connectivity-live-write test-tray test-tray-live test-idle test-surface-state test-ui-primitives check-nondisplay check format format-check lint-advisory launch diagnose instances logs logs-follow stop
 .PHONY: test-dashboard
+.PHONY: test-polkit-ui
 
 help:
 	@printf '%s\n' \
@@ -137,6 +139,7 @@ help:
 		'make test-tray       Test system tray lifecycle and actions' \
 		'make test-tray-live  Exercise a controlled real tray item on KDE' \
 		'make test-ui-primitives  Render theme tokens and primitives in the island surface' \
+		'make test-polkit-ui  Test the dormant Polkit authentication presentation' \
 		'make test-dashboard   Test expanded dashboard composition and actions' \
 		'make test-idle       Test idle island composition and collapse' \
 		'make launch          Run this checkout in the foreground' \
@@ -476,13 +479,20 @@ test-launcher: check-quickshell | $(BUILD_DIR)
 test-surface-state: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(SURFACE_STATE_TEST_DIR)/qml
 	cp tests/surface-state/shell.qml $(SURFACE_STATE_TEST_DIR)/shell.qml
-	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandStateCoordinator.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(SURFACE_STATE_TEST_DIR)/qml/
+	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandStateCoordinator.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(SURFACE_STATE_TEST_DIR)/qml/
 	$(QS) -p $(SURFACE_STATE_TEST_DIR) --no-duplicate
+
+test-polkit-ui: check-quickshell | $(BUILD_DIR)
+	rm -rf $(POLKIT_UI_TEST_DIR)
+	mkdir -p $(POLKIT_UI_TEST_DIR)/qml
+	cp tests/polkit-ui/shell.qml $(POLKIT_UI_TEST_DIR)/shell.qml
+	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/PolkitView.qml $(POLKIT_UI_TEST_DIR)/qml/
+	QT_QPA_PLATFORM='offscreen' $(QS) -p $(POLKIT_UI_TEST_DIR) --no-duplicate
 
 test-ui-primitives: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(UI_PRIMITIVES_TEST_DIR)/qml
 	cp tests/ui/shell.qml $(UI_PRIMITIVES_TEST_DIR)/shell.qml
-	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/IslandStateCoordinator.qml qml/IslandSurface.qml qml/TrayView.qml $(UI_PRIMITIVES_TEST_DIR)/qml/
+	cp qml/Theme.qml qml/IslandPanel.qml qml/IslandText.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/IslandStateCoordinator.qml qml/IslandSurface.qml qml/TrayView.qml $(UI_PRIMITIVES_TEST_DIR)/qml/
 	$(QS) -p $(UI_PRIMITIVES_TEST_DIR) --no-duplicate
 
 test-dashboard: check-quickshell | $(BUILD_DIR)
@@ -562,7 +572,7 @@ lint-advisory:
 
 check: check-nondisplay test-surface-state test-ui-primitives
 
-check-nondisplay: check-quickshell format-check audio-helper connectivity-helper brightness-helper session-helper application-helper launcher-shortcut-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-brightness-dbus test-brightness test-session-dbus test-session test-applications test-launcher test-launcher-shortcut test-notifications test-adapter test-coordinator test-transients test-weather test-media test-audio test-connectivity test-tray test-idle test-dashboard
+check-nondisplay: check-quickshell format-check audio-helper connectivity-helper brightness-helper session-helper application-helper launcher-shortcut-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-brightness-dbus test-brightness test-session-dbus test-session test-applications test-launcher test-launcher-shortcut test-notifications test-adapter test-coordinator test-transients test-weather test-media test-audio test-connectivity test-tray test-idle test-dashboard test-polkit-ui
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/qml/IslandSurface.qml
+++ b/qml/IslandSurface.qml
@@ -15,6 +15,7 @@ PanelWindow {
     property var media: null
     property bool reducedMotion: false
     property var sessionService: null
+    property var polkitController: null
     property var notificationService: null
     property var applicationModel: null
     // Each source resolves only its own normalized payload for an exact opaque
@@ -42,12 +43,22 @@ PanelWindow {
     readonly property bool launcher: ownerKind === coordinator.ownerLauncher
     readonly property bool session: ownerKind === coordinator.ownerSession
     readonly property bool history: ownerKind === coordinator.ownerHistory
+    readonly property bool polkitControllerReady: polkitController !== null && polkitController
+                                                  !== undefined && polkitController.available
+                                                  === true
+                                                  && typeof polkitController.selectIdentity
+                                                  === "function"
+                                                  && typeof polkitController.submitResponse
+                                                  === "function" && typeof polkitController.cancel
+                                                  === "function"
+    readonly property bool polkit: ownerKind === coordinator.ownerPolkitModal
+                                   && polkitControllerReady
     readonly property bool transientOwner: ownerKind === coordinator.ownerWorkspace || ownerKind
                                            === coordinator.ownerBrightness || ownerKind
                                            === coordinator.ownerVolume || ownerKind
                                            === coordinator.ownerNotification
     readonly property bool notificationTransient: ownerKind === coordinator.ownerNotification
-    readonly property bool largeContent: expanded || launcher || history || session
+    readonly property bool largeContent: expanded || launcher || history || session || polkit
     readonly property int edgeInset: Theme.spacing.sm
     readonly property int preferredWidth: largeContent ? Theme.size.islandExpandedWidth :
                                                          transientOwner ? (notificationTransient
@@ -81,6 +92,16 @@ PanelWindow {
                                                                                 launcherLoader.item.selectedId
     readonly property bool sessionFocused: sessionLoader.item !== null
                                            && sessionLoader.item.activeFocus
+    readonly property bool polkitLoaded: polkitLoader.item !== null
+    readonly property bool polkitFocused: polkitLoader.item !== null
+                                          && polkitLoader.item.activeFocus
+    readonly property bool polkitResponseFocused: polkitLoader.item !== null
+                                                  && polkitLoader.item.responseFocused
+    readonly property int polkitIdentityCount: polkitLoader.item === null ? 0 :
+                                                                            polkitLoader.item.identityCount
+
+    readonly property bool polkitResponseFieldVisible: polkitLoader.item !== null
+                                                       && polkitLoader.item.responseFieldVisible
     readonly property bool historyFocused: historyLoader.item !== null
                                            && historyLoader.item.historyFocused
     readonly property int historyRowCount: historyLoader.item === null ? 0 :
@@ -144,10 +165,11 @@ PanelWindow {
               !== null && launcherLoader.item.visible;
         const sessionVisible = ownerKind === coordinator.ownerSession && sessionLoader.item
               !== null && sessionLoader.item.visible;
+        const polkitVisible = polkit && polkitLoader.item !== null && polkitLoader.item.visible;
         const transientVisible = transientOwner && transientLoader.item !== null
               && transientLoader.item.visible && transientLoader.item.committed;
         if (!idleVisible && !dashboardVisible && !launcherVisible && !historyVisible &&
-                !sessionVisible && !transientVisible) {
+                !sessionVisible && !polkitVisible && !transientVisible) {
             return;
         }
 
@@ -206,6 +228,9 @@ PanelWindow {
             } else if (surface.focusTarget === surface.coordinator.focusSessionActions
                        && surface.session && sessionLoader.item !== null) {
                 target = sessionLoader.item;
+            } else if (surface.focusTarget === surface.coordinator.focusPolkitModal
+                       && surface.polkit && polkitLoader.item !== null) {
+                target = polkitLoader.item;
             }
             if (target === null) {
                 return;
@@ -322,7 +347,8 @@ PanelWindow {
                                                                                         === coordinator.focusLauncherSearch)
                    || (history && focusTarget === coordinator.focusNotificationHistory) || (session
                                                                                             && focusTarget
-                                                                                            === coordinator.focusSessionActions))
+                                                                                            === coordinator.focusSessionActions)
+                   || (polkit && focusTarget === coordinator.focusPolkitModal))
     implicitHeight: safeLogicalSize(preferredHeight, screen === null ? 0 : screen.height)
     implicitWidth: safeLogicalSize(preferredWidth, screen === null ? 0 : screen.width)
 
@@ -442,6 +468,27 @@ PanelWindow {
                 ownerEpoch: surface.ownerEpoch
                 service: surface.notificationService
                 onCancelled: epoch => surface.coordinator.cancelInteractive(epoch)
+            }
+        }
+
+        onLoaded: {
+            surface.queuePresentationAcknowledgement();
+            surface.queueOwnerFocus();
+        }
+    }
+
+    Loader {
+        id: polkitLoader
+
+        anchors.fill: parent
+        active: surface.polkit
+        visible: active
+
+        sourceComponent: Component {
+            PolkitView {
+                controller: surface.polkitController
+                ownerEpoch: surface.ownerEpoch
+                ownerRevision: surface.ownerRevision
             }
         }
 

--- a/qml/IslandSurfaceHost.qml
+++ b/qml/IslandSurfaceHost.qml
@@ -14,6 +14,7 @@ Scope {
     property var weather: null
     property var media: null
     property var sessionService: null
+    property var polkitController: null
     property var notificationService: null
     property var applicationModel: null
     property var workspaceTransientSource: null
@@ -55,6 +56,16 @@ Scope {
                                                                                   ownership.liveSurface.launcherSelectedId
     readonly property bool sessionFocused: ownership.liveSurface !== null
                                            && ownership.liveSurface.sessionFocused
+    readonly property bool polkitLoaded: ownership.liveSurface !== null
+                                         && ownership.liveSurface.polkitLoaded
+    readonly property bool polkitFocused: ownership.liveSurface !== null
+                                          && ownership.liveSurface.polkitFocused
+    readonly property bool polkitResponseFocused: ownership.liveSurface !== null
+                                                  && ownership.liveSurface.polkitResponseFocused
+    readonly property int polkitIdentityCount: ownership.liveSurface === null ? 0 :
+                                                                                ownership.liveSurface.polkitIdentityCount
+    readonly property bool polkitResponseFieldVisible: ownership.liveSurface !== null
+                                                       && ownership.liveSurface.polkitResponseFieldVisible
     readonly property bool historyFocused: ownership.liveSurface !== null
                                            && ownership.liveSurface.historyFocused
     readonly property int historyRowCount: ownership.liveSurface === null ? 0 :
@@ -208,6 +219,7 @@ Scope {
             weather: host.weather
             media: host.media
             sessionService: host.sessionService
+            polkitController: host.polkitController
             notificationService: host.notificationService
             applicationModel: host.applicationModel
             workspaceTransientSource: host.workspaceTransientSource

--- a/qml/PolkitView.qml
+++ b/qml/PolkitView.qml
@@ -1,0 +1,609 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Widgets
+import QtQuick
+import QtQuick.Layouts
+
+// Presentation-only authentication view. The injected controller is a normalized
+// contract; no Polkit object, cookie, PAM payload, or backend identity enters this
+// component. The response lives only in responseInput and short-lived method
+// locals. Clearing QML/QString references minimizes retention but cannot promise
+// forensic zeroization.
+FocusScope {
+    id: view
+
+    required property var controller
+    required property real ownerEpoch
+    required property real ownerRevision
+
+    readonly property bool controllerAvailable: controller !== null && controller !== undefined
+                                                && controller.available === true
+                                                && typeof controller.selectIdentity === "function"
+                                                && typeof controller.submitResponse === "function"
+                                                && typeof controller.cancel === "function"
+    readonly property bool terminal: controllerAvailable && controller.terminal === true
+    readonly property bool responseRequired: controllerAvailable && controller.responseRequired
+                                             === true
+    readonly property bool responseVisible: controllerAvailable && controller.responseVisible
+                                            === true
+    readonly property bool controllerSubmissionPending: controllerAvailable
+                                                        && controller.submissionPending === true
+    readonly property bool controllerCancellationPending: controllerAvailable
+                                                          && controller.cancellationPending === true
+    readonly property bool operationPending: state.submitDispatched || state.cancelDispatched
+                                             || controllerSubmissionPending
+                                             || controllerCancellationPending
+    readonly property int flowGeneration: boundedGeneration(controllerAvailable
+                                                            ? controller.flowGeneration : 0)
+    readonly property int promptGeneration: boundedGeneration(controllerAvailable
+                                                              ? controller.promptGeneration : 0)
+    readonly property int failureGeneration: boundedGeneration(controllerAvailable
+                                                               ? controller.failureGeneration : 0)
+    readonly property var identities: normalizedIdentities()
+    readonly property int identityCount: identities.length
+    readonly property var selectedIdentity: normalizedSelectedIdentity()
+    readonly property int selectedIdentityIndex: selectedIdentity === null ? -1 : identities.indexOf(
+                                                                                 selectedIdentity)
+    readonly property string requestMessage: boundedText(controllerAvailable ? controller.message :
+                                                                               "", 512, "Authentication is required.")
+    readonly property string actionId: boundedText(controllerAvailable ? controller.actionId : "",
+                                                   256, "")
+    readonly property string inputPrompt: boundedText(controllerAvailable ? controller.inputPrompt :
+                                                                            "", 256, "Authentication response")
+    readonly property string supplementaryMessage: boundedText(controllerAvailable
+                                                               ? controller.supplementaryMessage :
+                                                                 "", 512, "")
+    readonly property bool supplementaryIsError: controllerAvailable
+                                                 && controller.supplementaryIsError === true
+    readonly property string iconName: normalizedIconName(controllerAvailable ? controller.iconName :
+                                                                                "")
+    readonly property bool responseFieldVisible: controllerAvailable && !terminal
+                                                 && responseRequired && selectedIdentity !== null
+    readonly property bool authenticateEnabled: responseFieldVisible && !operationPending
+    readonly property bool cancelEnabled: controllerAvailable && !terminal &&
+                                          !state.cancelDispatched && !controllerCancellationPending
+    readonly property bool responseFocused: responseInput.activeFocus
+    readonly property int responseEchoMode: responseInput.echoMode
+
+    visible: controllerAvailable
+
+    Keys.priority: Keys.BeforeItem
+    Keys.onEscapePressed: event => {
+        if (view.requestCancellation()) {
+            event.accepted = true;
+        }
+    }
+
+    function boundedGeneration(value) {
+        return Number.isInteger(value) && value >= 0 && value <= 2147483647 ? value : 0;
+    }
+
+    function boundedText(value, maximumLength, fallback) {
+        if (typeof value !== "string" || value.length === 0) {
+            return fallback;
+        }
+        return value.slice(0, maximumLength);
+    }
+
+    function controllerMethod(name) {
+        if (!controllerAvailable || typeof controller[name] !== "function") {
+            return null;
+        }
+        return controller[name];
+    }
+
+    function identityIsNormalized(identity) {
+        return identity !== null && typeof identity === "object" && !Array.isArray(identity)
+                && typeof identity.id === "string" && identity.id.length > 0 && identity.id.length <= 128
+                && typeof identity.string === "string" && identity.string.length <= 128
+                && typeof identity.displayName === "string" && identity.displayName.length <= 128
+                && typeof identity.isGroup === "boolean";
+    }
+
+    function normalizedIdentities() {
+        if (!controllerAvailable || !Array.isArray(controller.identities)) {
+            return [];
+        }
+        for (let index = 0; index < controller.identities.length; index += 1) {
+            if (!identityIsNormalized(controller.identities[index])) {
+                return [];
+            }
+        }
+        return controller.identities;
+    }
+
+    function normalizedSelectedIdentity() {
+        if (!controllerAvailable || identities.indexOf(controller.selectedIdentity) < 0) {
+            return null;
+        }
+        return controller.selectedIdentity;
+    }
+
+    function identityLabel(identity) {
+        if (!identityIsNormalized(identity)) {
+            return "Unknown identity";
+        }
+        const base = identity.displayName !== "" ? identity.displayName : identity.string !== ""
+                                                   ? identity.string : identity.id;
+        return identity.isGroup ? base + " (group)" : base;
+    }
+
+    function normalizedIconName(value) {
+        if (typeof value === "string" && value.length > 0 && value.length <= 128 &&
+                /^[A-Za-z0-9._+-]+$/.test(value) && Quickshell.hasThemeIcon(value)) {
+            return value;
+        }
+        return "object-locked-symbolic";
+    }
+
+    function clearResponse() {
+        responseInput.clear();
+        responseInput.deselect();
+    }
+
+    function clearForLifecycle(resetCancellation) {
+        clearResponse();
+        state.submitDispatched = false;
+        if (resetCancellation) {
+            state.cancelDispatched = false;
+        }
+    }
+
+    function queuePromptFocus() {
+        const expectedEpoch = ownerEpoch;
+        const expectedRevision = ownerRevision;
+        const expectedFlow = flowGeneration;
+        const expectedPrompt = promptGeneration;
+        Qt.callLater(function () {
+            if (!view.visible || expectedEpoch !== view.ownerEpoch || expectedRevision
+                    !== view.ownerRevision || expectedFlow !== view.flowGeneration
+                    || expectedPrompt !== view.promptGeneration || !view.responseFieldVisible) {
+                return;
+            }
+            responseInput.forceActiveFocus(Qt.ShortcutFocusReason);
+        });
+    }
+
+    function synchronizeIdentityIndex() {
+        identityList.currentIndex = selectedIdentityIndex >= 0 ? selectedIdentityIndex :
+                                                                 identityCount > 0 ? 0 : -1;
+        if (identityList.currentIndex >= 0) {
+            identityList.positionViewAtIndex(identityList.currentIndex, ListView.Contain);
+        }
+    }
+
+    function focusInitialControl() {
+        synchronizeIdentityIndex();
+        if (identityCount > 1 && identityList.currentItem !== null) {
+            identityList.currentItem.forceActiveFocus(Qt.ShortcutFocusReason);
+            return;
+        }
+        if (responseFieldVisible) {
+            responseInput.forceActiveFocus(Qt.ShortcutFocusReason);
+            return;
+        }
+        if (authenticateEnabled) {
+            authenticateButton.forceActiveFocus(Qt.ShortcutFocusReason);
+            return;
+        }
+        if (cancelEnabled) {
+            cancelButton.forceActiveFocus(Qt.ShortcutFocusReason);
+        }
+    }
+
+    function requestIdentity(identity) {
+        const method = controllerMethod("selectIdentity");
+        if (method === null || operationPending || terminal || identities.indexOf(identity) < 0
+                || identity === selectedIdentity) {
+            return false;
+        }
+        clearResponse();
+        state.submitDispatched = false;
+        method.call(controller, identity);
+        return true;
+    }
+
+    function submitCurrentResponse() {
+        const method = controllerMethod("submitResponse");
+        if (!authenticateEnabled || method === null) {
+            return false;
+        }
+
+        let response = responseInput.text;
+        clearResponse();
+        state.submitDispatched = true;
+        try {
+            method.call(controller, response, promptGeneration);
+        } finally {
+            response = "";
+        }
+        return true;
+    }
+
+    function requestCancellation() {
+        const method = controllerMethod("cancel");
+        if (!cancelEnabled || method === null) {
+            return false;
+        }
+        clearResponse();
+        state.submitDispatched = false;
+        state.cancelDispatched = true;
+        method.call(controller);
+        return true;
+    }
+
+    onControllerChanged: {
+        clearForLifecycle(true);
+        synchronizeIdentityIndex();
+        queuePromptFocus();
+    }
+    onOwnerEpochChanged: clearForLifecycle(true)
+    onOwnerRevisionChanged: {
+        clearForLifecycle(true);
+        queuePromptFocus();
+    }
+    onVisibleChanged: {
+        if (!visible) {
+            clearForLifecycle(true);
+        }
+    }
+
+    Component.onCompleted: {
+        clearForLifecycle(true);
+        synchronizeIdentityIndex();
+        queuePromptFocus();
+    }
+    Component.onDestruction: clearResponse()
+
+    Connections {
+        target: view.controller
+        ignoreUnknownSignals: true
+
+        function onAvailableChanged() {
+            view.clearForLifecycle(true);
+            if (view.controllerAvailable) {
+                view.queuePromptFocus();
+            }
+        }
+        function onCancellationPendingChanged() {
+            if (view.controllerCancellationPending) {
+                view.clearResponse();
+            }
+        }
+        function onFailureGenerationChanged() {
+            view.clearForLifecycle(false);
+        }
+        function onFlowGenerationChanged() {
+            view.clearForLifecycle(true);
+            view.synchronizeIdentityIndex();
+            view.queuePromptFocus();
+        }
+        function onIdentitiesChanged() {
+            view.clearForLifecycle(false);
+            view.synchronizeIdentityIndex();
+        }
+        function onPromptGenerationChanged() {
+            view.clearForLifecycle(false);
+            view.queuePromptFocus();
+        }
+        function onResponseRequiredChanged() {
+            if (!view.responseRequired) {
+                view.clearResponse();
+            } else {
+                view.queuePromptFocus();
+            }
+        }
+        function onSelectedIdentityChanged() {
+            view.clearForLifecycle(false);
+            view.synchronizeIdentityIndex();
+        }
+        function onSubmissionPendingChanged() {
+            if (view.controllerSubmissionPending) {
+                view.clearResponse();
+            }
+        }
+        function onTerminalChanged() {
+            if (view.terminal) {
+                view.clearForLifecycle(true);
+            }
+        }
+    }
+
+    QtObject {
+        id: state
+
+        property bool submitDispatched: false
+        property bool cancelDispatched: false
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: Theme.spacing.xl
+        spacing: Theme.spacing.lg
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacing.lg
+
+            IslandPanel {
+                Layout.preferredWidth: Theme.size.controlHeightLg
+                Layout.preferredHeight: Theme.size.controlHeightLg
+                color: Theme.color.controlFill
+                radius: Theme.radius.md
+
+                IconImage {
+                    anchors.centerIn: parent
+                    implicitSize: Theme.size.iconSizeLg
+                    source: Quickshell.iconPath(view.iconName, "dialog-password")
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: Theme.spacing.xs
+
+                IslandText {
+                    text: "Authentication required"
+                    textFormat: Text.PlainText
+                    size: "title"
+                    font.weight: Theme.type.weightSemibold
+                    Accessible.role: Accessible.Heading
+                    Accessible.name: text
+                }
+
+                IslandText {
+                    Layout.fillWidth: true
+                    text: view.requestMessage
+                    textFormat: Text.PlainText
+                    wrapMode: Text.Wrap
+                    Accessible.role: Accessible.StaticText
+                    Accessible.name: text
+                }
+
+                IslandText {
+                    Layout.fillWidth: true
+                    visible: text !== ""
+                    text: view.actionId
+                    textFormat: Text.PlainText
+                    tone: "muted"
+                    elide: Text.ElideRight
+                    Accessible.role: Accessible.StaticText
+                    Accessible.name: text
+                }
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: view.identityCount > 0
+            spacing: Theme.spacing.sm
+
+            IslandText {
+                text: view.identityCount > 1 ? "Choose an identity" : "Identity"
+                textFormat: Text.PlainText
+                tone: "secondary"
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
+            }
+
+            ListView {
+                id: identityList
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: Theme.size.controlHeightMd + Theme.size.focusRingGap * 2
+                orientation: ListView.Horizontal
+                spacing: Theme.spacing.md
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+                model: view.identities
+                visible: view.identityCount > 1
+                Accessible.role: Accessible.List
+                Accessible.name: "Authentication identities"
+
+                delegate: IslandButton {
+                    id: identityButton
+
+                    required property int index
+                    required property var modelData
+
+                    objectName: "polkitIdentityButton" + index
+                    label: view.identityLabel(modelData)
+                    variant: modelData === view.selectedIdentity ? "accent" : "standard"
+                    enabled: view.controllerAvailable && !view.terminal && !view.operationPending
+                    Accessible.description: modelData === view.selectedIdentity
+                                            ? "Selected authentication identity" :
+                                              "Select this authentication identity"
+                    onClicked: view.requestIdentity(modelData)
+
+                    Keys.onLeftPressed: event => {
+                        const nextIndex = Math.max(0, index - 1);
+                        identityList.currentIndex = nextIndex;
+                        identityList.positionViewAtIndex(nextIndex, ListView.Contain);
+                        if (identityList.currentItem !== null) {
+                            identityList.currentItem.forceActiveFocus(Qt.ShortcutFocusReason);
+                        }
+                        event.accepted = true;
+                    }
+                    Keys.onRightPressed: event => {
+                        const nextIndex = Math.min(view.identityCount - 1, index + 1);
+                        identityList.currentIndex = nextIndex;
+                        identityList.positionViewAtIndex(nextIndex, ListView.Contain);
+                        if (identityList.currentItem !== null) {
+                            identityList.currentItem.forceActiveFocus(Qt.ShortcutFocusReason);
+                        }
+                        event.accepted = true;
+                    }
+                }
+            }
+
+            IslandText {
+                Layout.fillWidth: true
+                visible: view.identityCount === 1
+                text: view.selectedIdentity === null ? "No supported identity selected" :
+                                                       view.identityLabel(view.selectedIdentity)
+                textFormat: Text.PlainText
+                elide: Text.ElideRight
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacing.sm
+
+            IslandText {
+                Layout.fillWidth: true
+                text: view.inputPrompt
+                textFormat: Text.PlainText
+                tone: "secondary"
+                wrapMode: Text.Wrap
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
+            }
+
+            IslandPanel {
+                objectName: "polkitResponseField"
+                Accessible.role: Accessible.EditableText
+                Accessible.name: "Authentication response"
+                Accessible.description: "Enter the response requested for authentication"
+                Accessible.passwordEdit: true
+                Accessible.selectableText: false
+                Accessible.focusable: true
+                Accessible.focused: responseInput.activeFocus
+                Layout.fillWidth: true
+                Layout.preferredHeight: Theme.size.controlHeightLg
+                visible: view.responseFieldVisible
+                opacity: view.operationPending ? Theme.opacity.disabled : 1
+                radius: Theme.radius.md
+                color: Theme.color.controlFill
+                border.width: Theme.size.hairlineWidth
+                border.color: responseInput.activeFocus ? Theme.color.focusRing :
+                                                          Theme.color.surfaceBorder
+
+                TextInput {
+                    id: responseInput
+
+                    objectName: "polkitResponseInput"
+                    anchors.fill: parent
+                    leftPadding: Theme.spacing.md
+                    rightPadding: Theme.spacing.md
+                    color: Theme.color.textPrimary
+                    selectionColor: Theme.color.accent
+                    selectedTextColor: Theme.color.accentForeground
+                    font.pixelSize: Theme.type.body
+                    verticalAlignment: TextInput.AlignVCenter
+                    clip: true
+                    activeFocusOnTab: true
+                    enabled: !view.operationPending
+                    readOnly: view.operationPending
+                    echoMode: view.responseVisible ? TextInput.Normal : TextInput.NoEcho
+                    passwordMaskDelay: 0
+                    maximumLength: 4096
+                    selectByMouse: view.responseVisible
+                    persistentSelection: false
+                    inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText
+                                      | Qt.ImhNoAutoUppercase | (view.responseVisible ? Qt.ImhNone :
+                                                                                        Qt.ImhHiddenText)
+                    Accessible.ignored: true
+
+                    onSelectedTextChanged: {
+                        if (!view.responseVisible && selectedText !== "") {
+                            deselect();
+                        }
+                    }
+
+                    Keys.priority: Keys.BeforeItem
+                    Keys.onPressed: event => {
+                        const control = (event.modifiers & Qt.ControlModifier) !== 0;
+                        const shift = (event.modifiers & Qt.ShiftModifier) !== 0;
+                        const hiddenExposure = !view.responseVisible && ((control && (event.key
+                                                                                      === Qt.Key_C
+                                                                                      || event.key
+                                                                                      === Qt.Key_X
+                                                                                      || event.key
+                                                                                      === Qt.Key_Insert))
+                                                                         || (shift && event.key
+                                                                             === Qt.Key_Delete));
+                        if (hiddenExposure) {
+                            deselect();
+                            event.accepted = true;
+                        }
+                    }
+                    Keys.onReturnPressed: event => {
+                        view.submitCurrentResponse();
+                        event.accepted = true;
+                    }
+                    Keys.onEnterPressed: event => {
+                        view.submitCurrentResponse();
+                        event.accepted = true;
+                    }
+                }
+            }
+
+            IslandText {
+                Layout.fillWidth: true
+                visible: !view.responseFieldVisible && view.controllerAvailable && !view.terminal
+                text: view.identityCount === 0
+                      ? "No supported authentication identity is available." :
+                        "Waiting for an authentication prompt…"
+                textFormat: Text.PlainText
+                tone: "secondary"
+                wrapMode: Text.Wrap
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
+            }
+        }
+
+        Item {
+            Layout.fillHeight: true
+            Layout.minimumHeight: Theme.spacing.sm
+        }
+
+        IslandText {
+            Layout.fillWidth: true
+            visible: text !== ""
+            text: view.controllerCancellationPending || state.cancelDispatched ? "Cancelling…" :
+                                                                                 view.controllerSubmissionPending
+                                                                                 || state.submitDispatched
+                                                                                 ? "Authenticating…" :
+                                                                                   view.supplementaryMessage
+            textFormat: Text.PlainText
+            color: view.supplementaryIsError ? Theme.color.danger : Theme.color.textSecondary
+            wrapMode: Text.Wrap
+            Accessible.role: Accessible.StaticText
+            Accessible.name: text
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacing.md
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            IslandButton {
+                id: cancelButton
+
+                objectName: "polkitCancelButton"
+                label: "Cancel"
+                enabled: view.cancelEnabled
+                Accessible.description: "Cancel this authentication request"
+                onClicked: view.requestCancellation()
+            }
+
+            IslandButton {
+                id: authenticateButton
+
+                objectName: "polkitAuthenticateButton"
+                label: "Authenticate"
+                variant: "accent"
+                enabled: view.authenticateEnabled
+                Accessible.description: "Submit the current authentication response"
+                onClicked: view.submitCurrentResponse()
+            }
+        }
+    }
+}

--- a/tests/polkit-ui/shell.qml
+++ b/tests/polkit-ui/shell.qml
@@ -1,0 +1,375 @@
+import Quickshell
+import QtQuick
+import QtTest
+import "qml"
+
+ShellRoot {
+    id: test
+
+    property int step: 0
+    property int retryAttempts: 0
+    property var responseInput: null
+    property var responseField: null
+    property var firstIdentityButton: null
+    property var secondIdentityButton: null
+    property var cancelButton: null
+    property var authenticateButton: null
+    readonly property int maximumRetryAttempts: 200
+
+    function require(condition, message) {
+        if (!condition) {
+            console.error("FAIL: " + message);
+            Qt.exit(1);
+            throw new Error(message);
+        }
+    }
+
+    function findObject(item, name) {
+        if (item === null || item === undefined) {
+            return null;
+        }
+        if (item.objectName === name) {
+            return item;
+        }
+        const candidates = [];
+        if (item.children !== undefined) {
+            for (let index = 0; index < item.children.length; index += 1) {
+                candidates.push(item.children[index]);
+            }
+        }
+        if (item.contentItem !== undefined && item.contentItem !== null) {
+            candidates.push(item.contentItem);
+        }
+        for (let index = 0; index < candidates.length; index += 1) {
+            const found = findObject(candidates[index], name);
+            if (found !== null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    function awaitState(condition, message) {
+        if (condition) {
+            retryAttempts = 0;
+            return true;
+        }
+        retryAttempts += 1;
+        require(retryAttempts <= maximumRetryAttempts, message);
+        retry.restart();
+        return false;
+    }
+
+    function advance() {
+        step += 1;
+        Qt.callLater(runStep);
+    }
+
+    function traversalContains(start, targets) {
+        let cursor = start;
+        const remaining = targets.slice();
+        for (let hop = 0; hop < 16 && cursor !== null && remaining.length > 0; hop += 1) {
+            cursor = cursor.nextItemInFocusChain(true);
+            const index = remaining.indexOf(cursor);
+            if (index >= 0) {
+                remaining.splice(index, 1);
+            }
+        }
+        return remaining.length === 0;
+    }
+
+    function runStep() {
+        if (step === 0) {
+            responseInput = findObject(polkitView, "polkitResponseInput");
+            responseField = findObject(polkitView, "polkitResponseField");
+            firstIdentityButton = findObject(polkitView, "polkitIdentityButton0");
+            secondIdentityButton = findObject(polkitView, "polkitIdentityButton1");
+            cancelButton = findObject(polkitView, "polkitCancelButton");
+            authenticateButton = findObject(polkitView, "polkitAuthenticateButton");
+            if (!awaitState(responseInput !== null && responseField !== null
+                            && firstIdentityButton !== null && secondIdentityButton !== null
+                            && cancelButton !== null && authenticateButton !== null,
+                            "Polkit controls were not created")) {
+                return;
+            }
+            require(polkitView.requestMessage.length === 512
+                    && polkitView.actionId.length === 256,
+                    "untrusted request strings are bounded");
+            require(polkitView.iconName === "object-locked-symbolic",
+                    "unsafe icon names use the fixed fallback");
+            require(polkitView.identityCount === 2 && polkitView.selectedIdentity === identityA,
+                    "only the normalized identity projection is consumed");
+            require(polkitView.supplementaryMessage.length === 512,
+                    "supplementary feedback is bounded");
+            polkitView.focusInitialControl();
+        } else if (step === 1) {
+            if (!awaitState(firstIdentityButton.activeFocus,
+                            "multiple identities did not receive initial focus")) {
+                return;
+            }
+            responseInput.text = "synthetic-before-identity-change";
+            require(polkitView.requestIdentity(identityB), "live identity change is accepted");
+            require(controller.identityChangeCount === 1 && controller.identityWasExact
+                    && controller.identityInputWasCleared,
+                    "identity dispatch uses the exact object after clearing input");
+            require(responseInput.text === "" && controller.selectedIdentity === identityB,
+                    "identity replacement retains no prior response");
+            controller.promptGeneration += 1;
+        } else if (step === 2) {
+            if (!awaitState(responseInput.activeFocus,
+                            "new hidden prompt did not focus the response field")) {
+                return;
+            }
+            require(responseInput.echoMode === TextInput.NoEcho && !responseInput.selectByMouse,
+                    "hidden prompt uses NoEcho and disables mouse selection");
+            require(responseInput.passwordMaskDelay === 0 && responseInput.maximumLength === 4096,
+                    "hidden prompt has no reveal delay and has the fixed response bound");
+            require((responseInput.inputMethodHints & Qt.ImhHiddenText) !== 0
+                    && (responseInput.inputMethodHints & Qt.ImhSensitiveData) !== 0
+                    && (responseInput.inputMethodHints & Qt.ImhNoPredictiveText) !== 0
+                    && (responseInput.inputMethodHints & Qt.ImhNoAutoUppercase) !== 0,
+                    "hidden prompt disables learning, prediction, and capitalization");
+            require(responseInput.Accessible.ignored && responseField.Accessible.passwordEdit
+                    && !responseField.Accessible.selectableText && responseField.Accessible.focused,
+                    "accessibility protects the focused response value");
+            responseInput.text = "x".repeat(5000);
+            require(responseInput.length === 4096,
+                    "response is bounded to 4096 UTF-16 code units");
+            responseInput.text = "hidden-selection";
+            responseInput.select(0, responseInput.length);
+            require(responseInput.selectedText === "",
+                    "hidden response cannot retain a selection for copy or drag");
+            clipboardSource.text = "clipboard-sentinel";
+            clipboardSource.selectAll();
+            clipboardSource.copy();
+            responseInput.text = "synthetic-secret";
+            responseInput.selectAll();
+            responseInput.copy();
+            clipboardProbe.text = "";
+            clipboardProbe.paste();
+            require(clipboardProbe.text === "clipboard-sentinel",
+                    "hidden response cannot replace clipboard contents");
+            responseInput.text = "  synthetic response  ";
+            require(polkitView.submitCurrentResponse(), "current prompt submits explicitly");
+            require(controller.submitCount === 1 && controller.submitMatched
+                    && controller.submitInputWasCleared,
+                    "exact unnormalized response is submitted after field clear");
+            require(responseInput.text === "" && !responseInput.enabled
+                    && !polkitView.submitCurrentResponse(),
+                    "submission disables editing, stays one-shot, and retains no response");
+            controller.submissionPending = false;
+            controller.failureGeneration += 1;
+            controller.responseVisible = true;
+            controller.responseRequired = true;
+            controller.promptGeneration += 1;
+        } else if (step === 3) {
+            if (!awaitState(responseInput.activeFocus && responseInput.echoMode === TextInput.Normal,
+                            "visible retry prompt did not refocus in Normal mode")) {
+                return;
+            }
+            require(responseInput.selectByMouse,
+                    "visible response permits normal editing without changing submit semantics");
+            require(polkitView.submitCurrentResponse(), "empty response remains a valid explicit submit");
+            require(controller.submitCount === 2 && controller.emptySubmitMatched
+                    && responseInput.text === "",
+                    "empty response is forwarded exactly without normalization");
+            controller.submissionPending = false;
+            controller.responseRequired = true;
+            controller.promptGeneration += 1;
+        } else if (step === 4) {
+            if (!awaitState(responseInput.activeFocus,
+                            "prompt after empty response did not refocus")) {
+                return;
+            }
+            require(traversalContains(firstIdentityButton,
+                                      [responseInput, cancelButton, authenticateButton]),
+                    "focus chain reaches response, Cancel, and Authenticate");
+            responseInput.text = "synthetic-before-cancel";
+            keyDriver.pressEscape();
+            require(controller.cancelCount === 1 && controller.cancelInputWasCleared
+                    && responseInput.text === "",
+                    "Escape clears input before the guarded cancellation dispatch");
+            require(!polkitView.requestCancellation() && !responseInput.enabled
+                    && !cancelButton.enabled && !authenticateButton.enabled,
+                    "repeated cancellation, editing, and actions stay disabled");
+            controller.cancellationPending = true;
+            controller.terminal = true;
+            controller.available = false;
+        } else if (step === 5) {
+            require(!polkitView.visible && responseInput.text === "",
+                    "unavailable terminal controller hides and clears the view");
+            controller.available = true;
+            controller.terminal = false;
+            controller.cancellationPending = false;
+            controller.flowGeneration += 1;
+            controller.promptGeneration += 1;
+            controller.identities = [malformedIdentity];
+            controller.selectedIdentity = malformedIdentity;
+        } else if (step === 6) {
+            require(polkitView.identityCount === 0 && !polkitView.responseFieldVisible
+                    && !polkitView.authenticateEnabled,
+                    "malformed identity projection never exposes a credential field");
+            controller.identities = [identityA];
+            controller.selectedIdentity = identityA;
+            controller.promptGeneration += 1;
+            polkitView.ownerRevision += 1;
+        } else if (step === 7) {
+            if (!awaitState(responseInput.activeFocus,
+                            "current owner revision did not receive prompt focus")) {
+                return;
+            }
+            responseInput.text = "synthetic-before-controller-replacement";
+            polkitView.controller = incompleteController;
+            require(responseInput.text === "" && !polkitView.visible,
+                    "incomplete controller contract clears and hides the credential view");
+            polkitView.controller = null;
+            require(!polkitView.visible, "missing controller keeps the credential view absent");
+            polkitView.controller = controller;
+        } else if (step === 8) {
+            if (!awaitState(responseInput.activeFocus,
+                            "replacement controller did not restore current prompt focus")) {
+                return;
+            }
+            responseInput.text = "synthetic-before-owner-change";
+            polkitView.ownerEpoch += 1;
+            require(responseInput.text === "",
+                    "owner replacement clears local response state");
+            console.log("Polkit presentation tests passed");
+            Qt.exit(0);
+            return;
+        }
+        advance();
+    }
+
+    QtObject {
+        id: identityA
+        readonly property string id: "unix-user:1000"
+        readonly property string string: "unix-user:developer"
+        readonly property string displayName: "Developer"
+        readonly property bool isGroup: false
+    }
+
+    QtObject {
+        id: identityB
+        readonly property string id: "unix-user:0"
+        readonly property string string: "unix-user:root"
+        readonly property string displayName: "Administrator"
+        readonly property bool isGroup: false
+    }
+
+    QtObject {
+        id: malformedIdentity
+        readonly property string id: "missing-fields"
+    }
+
+    QtObject {
+        id: incompleteController
+
+        readonly property bool available: true
+    }
+
+    QtObject {
+        id: controller
+
+        property bool available: true
+        property bool terminal: false
+        property bool responseRequired: true
+        property bool responseVisible: false
+        property bool submissionPending: false
+        property bool cancellationPending: false
+        property int flowGeneration: 1
+        property int promptGeneration: 1
+        property int failureGeneration: 0
+        property string message: "M".repeat(600)
+        property string actionId: "A".repeat(300)
+        property string inputPrompt: "Password"
+        property string supplementaryMessage: "S".repeat(600)
+        property bool supplementaryIsError: true
+        property string iconName: "file:///unsafe/icon"
+        property var identities: [identityA, identityB]
+        property var selectedIdentity: identityA
+
+        property int identityChangeCount: 0
+        property bool identityWasExact: false
+        property bool identityInputWasCleared: false
+        property int submitCount: 0
+        property bool submitMatched: false
+        property bool emptySubmitMatched: false
+        property bool submitInputWasCleared: false
+        property int cancelCount: 0
+        property bool cancelInputWasCleared: false
+
+        function cancel() {
+            cancelCount += 1;
+            cancelInputWasCleared = test.responseInput.text === "";
+            cancellationPending = true;
+        }
+
+        function selectIdentity(identity) {
+            identityChangeCount += 1;
+            identityWasExact = identity === identityB;
+            identityInputWasCleared = test.responseInput.text === "";
+            selectedIdentity = identity;
+        }
+
+        function submitResponse(response, generation) {
+            submitCount += 1;
+            submitInputWasCleared = test.responseInput.text === "";
+            if (submitCount === 1) {
+                submitMatched = response === "  synthetic response  "
+                        && generation === promptGeneration;
+            } else if (submitCount === 2) {
+                emptySubmitMatched = response === "" && generation === promptGeneration;
+            }
+            submissionPending = true;
+            responseRequired = false;
+        }
+    }
+
+    Window {
+        id: window
+
+        visible: true
+        width: Theme.size.islandExpandedWidth
+        height: Theme.size.islandExpandedHeight
+        color: Theme.color.surface
+
+        PolkitView {
+            id: polkitView
+
+            anchors.fill: parent
+            controller: controller
+            ownerEpoch: 1
+            ownerRevision: 1
+        }
+
+        TextInput {
+
+            id: clipboardSource
+            visible: false
+        }
+
+        TextInput {
+            id: clipboardProbe
+            visible: false
+        }
+    }
+
+    TestCase {
+        id: keyDriver
+
+        name: "Polkit keyboard driver"
+        when: false
+
+        function pressEscape() {
+            keyClick(Qt.Key_Escape);
+        }
+    }
+    Timer {
+        id: retry
+        interval: 10
+        onTriggered: test.runStep()
+    }
+
+    Component.onCompleted: Qt.callLater(runStep)
+}

--- a/tests/surface-state/shell.qml
+++ b/tests/surface-state/shell.qml
@@ -16,7 +16,9 @@ ShellRoot {
     property int initialSurfaceGeneration: 0
     property int compactTransientWidth: 0
     property int compactTransientHeight: 0
+    property real modalRevisionBeforeReplacement: 0
     readonly property int maximumRetryAttempts: 500
+    readonly property string polkitVisualState: Quickshell.env("NAGI_POLKIT_VISUAL_STATE") ?? ""
 
     function advance() {
         Qt.callLater(test.runStep);
@@ -42,7 +44,51 @@ ShellRoot {
         }
     }
 
+    function configurePolkitVisualState() {
+        const supported = ["hidden-multiple", "single", "visible", "pending", "failure",
+                           "cancellation"];
+        require(supported.indexOf(polkitVisualState) >= 0,
+                "unknown Polkit visual state: " + polkitVisualState);
+        fakePolkitController.available = true;
+        fakePolkitController.terminal = false;
+        fakePolkitController.responseRequired = true;
+        fakePolkitController.responseVisible = polkitVisualState === "visible";
+        fakePolkitController.submissionPending = polkitVisualState === "pending";
+        fakePolkitController.cancellationPending = polkitVisualState === "cancellation";
+        fakePolkitController.supplementaryMessage = polkitVisualState === "failure"
+                ? "Authentication failed. Check the response and try again." : "";
+        fakePolkitController.supplementaryIsError = polkitVisualState === "failure";
+        fakePolkitController.identities = polkitVisualState === "hidden-multiple"
+                ? [modalIdentity, alternateModalIdentity] : [modalIdentity];
+        fakePolkitController.selectedIdentity = modalIdentity;
+    }
+
+    function runPolkitVisualStep() {
+        if (step === 0) {
+            if (!awaitState(host.surfaceToken !== null && coordinator.presentationVisible,
+                            "visual surface did not acknowledge Idle")) {
+                return;
+            }
+            configurePolkitVisualState();
+            require(coordinator.syncPolkitModal(true, true, 1),
+                    "visual Modal snapshot enters");
+            step = 1;
+            advance();
+            return;
+        }
+        if (!awaitState(coordinator.ownerName === "polkitModal"
+                        && coordinator.presentationVisible && host.polkitLoaded,
+                        "visual Polkit state did not render")) {
+            return;
+        }
+        console.warn("holding Polkit visual state " + polkitVisualState);
+    }
+
     function runStep() {
+        if (polkitVisualState !== "") {
+            runPolkitVisualStep();
+            return;
+        }
         if (step === 0) {
             if (!awaitState(host.surfaceToken !== null && coordinator.presentationVisible,
                             "actual surface did not acknowledge Idle within five seconds")) {
@@ -86,7 +132,12 @@ ShellRoot {
                             && coordinator.presentationVisible && host.surfaceFocusable
                             && host.launcherFocused && host.launcherResultCount === 1
                             && host.loadedDashboardRegionCount === 0,
-                            "launcher did not replace and focus within five seconds")) {
+                            "launcher state: owner=" + coordinator.ownerName + " visible="
+                            + coordinator.presentationVisible + " focusable="
+                            + host.surfaceFocusable + " focused=" + host.launcherFocused
+                            + " results=" + host.launcherResultCount + " regions="
+                            + host.loadedDashboardRegionCount + " target=" + coordinator.focusTarget
+                            + " serial=" + coordinator.focusRequestSerial)) {
                 return;
             }
             require(host.launcherSelectedId === "fixture.desktop"
@@ -268,7 +319,84 @@ ShellRoot {
                     "all six real region components remount across Interactive interruptions");
             require(!coordinator.setHover(host.surfaceGeneration + 1, true),
                     "stale surface intent cannot reopen the dashboard");
-            console.warn("actual island launcher, transient, dashboard, history, and session tests passed");
+            host.reducedMotion = true;
+            require(host.requestDeliberateExpansion(),
+                    "Modal predecessor opens through deliberate surface intent");
+        } else if (step === 20) {
+            if (!awaitState(coordinator.ownerName === "expanded" && coordinator.presentationVisible
+                            && host.dashboardFocused,
+                            "Modal predecessor did not become focused")) {
+                return;
+            }
+            require(coordinator.syncPolkitModal(true, true, 1),
+                    "controlled Modal snapshot enters");
+        } else if (step === 21) {
+            if (!awaitState(coordinator.ownerName === "polkitModal"
+                            && coordinator.presentationVisible && host.surfaceFocusable
+                            && host.polkitLoaded && host.polkitFocused,
+                            "Polkit presentation did not load, acknowledge, and focus")) {
+                return;
+            }
+            require(host.surfacePreferredWidth === Theme.size.islandExpandedWidth
+                    && host.surfacePreferredHeight === Theme.size.islandExpandedHeight
+                    && host.geometryAnimationDuration === 0,
+                    "Polkit Modal uses bounded reduced-motion geometry");
+            require(host.polkitIdentityCount === 2 && host.polkitResponseFieldVisible,
+                    "normalized identities and the live prompt reach the Modal view");
+            require(!coordinator.openLauncher(host.surfaceToken)
+                    && !coordinator.openSession(host.surfaceToken),
+                    "Modal rejects lower-priority Interactive requests");
+            fakePolkitController.promptGeneration += 1;
+        } else if (step === 22) {
+            if (!awaitState(host.polkitResponseFocused,
+                            "new prompt generation did not focus the response field")) {
+                return;
+            }
+            fakePolkitController.available = false;
+        } else if (step === 23) {
+            if (!awaitState(!host.polkitLoaded && !host.polkitResponseFieldVisible,
+                            "unavailable controller did not destroy the credential view")) {
+                return;
+            }
+            fakePolkitController.available = true;
+        } else if (step === 24) {
+            if (!awaitState(host.polkitLoaded && coordinator.presentationVisible
+                            && host.surfaceFocusable,
+                            "restored controller did not recreate the current Modal view")) {
+                return;
+            }
+            modalRevisionBeforeReplacement = coordinator.revision;
+            fakePolkitController.flowGeneration = 2;
+            fakePolkitController.promptGeneration += 1;
+            require(coordinator.syncPolkitModal(true, true, 2),
+                    "serialized flow replacement updates Modal in place");
+            require(!coordinator.presentationVisible,
+                    "flow replacement waits for its matching presentation acknowledgement");
+        } else if (step === 25) {
+            if (!awaitState(coordinator.ownerName === "polkitModal"
+                            && coordinator.presentationVisible && host.polkitLoaded
+                            && host.polkitResponseFocused,
+                            "replacement flow did not acknowledge and refocus")) {
+                return;
+            }
+            require(coordinator.revision === modalRevisionBeforeReplacement + 1,
+                    "flow replacement increments one Modal revision without a second frame");
+            require(coordinator.syncPolkitModal(false, false, 0),
+                    "terminal absent snapshot releases Modal");
+        } else if (step === 26) {
+            if (!awaitState(coordinator.ownerName === "expanded" && coordinator.presentationVisible
+                            && host.dashboardFocused && !host.polkitLoaded,
+                            "Modal completion did not restore its focused predecessor")) {
+                return;
+            }
+            require(host.cancelDashboard(), "restored predecessor remains cancellable");
+        } else if (step === 27) {
+            if (!awaitState(coordinator.ownerName === "idle" && coordinator.presentationVisible
+                            && !host.surfaceFocusable,
+                            "final Modal predecessor cleanup did not restore Idle")) {
+                return;
+            }
+            console.warn("actual island launcher, transient, dashboard, history, session, and Polkit UI tests passed");
             Qt.exit(0);
             return;
         }
@@ -356,6 +484,57 @@ ShellRoot {
                 }
             }
             return -1;
+        }
+    }
+
+    QtObject {
+        id: modalIdentity
+
+        readonly property string id: "unix-user:1000"
+        readonly property string string: "unix-user:developer"
+        readonly property string displayName: "Developer"
+        readonly property bool isGroup: false
+    }
+
+    QtObject {
+        id: alternateModalIdentity
+
+        readonly property string id: "unix-user:0"
+        readonly property string string: "unix-user:root"
+        readonly property string displayName: "Administrator"
+        readonly property bool isGroup: false
+    }
+
+    QtObject {
+        id: fakePolkitController
+
+        property bool available: true
+        property bool terminal: false
+        property bool responseRequired: true
+        property bool responseVisible: false
+        property bool submissionPending: false
+        property bool cancellationPending: false
+        property int flowGeneration: 1
+        property int promptGeneration: 1
+        property int failureGeneration: 0
+        property string message: "Authentication is required to change system settings."
+        property string actionId: "org.example.settings.modify"
+        property string inputPrompt: "Password"
+        property string supplementaryMessage: ""
+        property bool supplementaryIsError: false
+        property string iconName: "object-locked-symbolic"
+        property var identities: [modalIdentity, alternateModalIdentity]
+        property var selectedIdentity: modalIdentity
+
+        function cancel() {
+            cancellationPending = true;
+        }
+        function selectIdentity(identity) {
+            selectedIdentity = identity;
+        }
+        function submitResponse(response, generation) {
+            submissionPending = true;
+            responseRequired = false;
         }
     }
 
@@ -469,6 +648,7 @@ ShellRoot {
         dashboardNotificationsContent: notificationsRegion
         dashboardNavigationContent: navigationRegion
         sessionService: fakeSessionService
+        polkitController: fakePolkitController
         notificationService: fakeNotificationService
         applicationModel: fakeApplicationModel
         workspaceTransientSource: fakeTransientSource


### PR DESCRIPTION
Keep the controller seam dormant until the gated backend ships.
Cover credential cleanup, keyboard access, and Modal restoration.

Closes #34