### PR TITLE
test(platform): verify configurable-shell platform contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,14 @@ FEDORA_QUICKSHELL_PACKAGE := quickshell
 .PHONY: check-wallpaper-toolchain wallpaper-helper test-wallpaper test-wallpaper-dbus test-wallpaper-live
 .PHONY: test-typography
 .PHONY: test-global-shortcut-live
+.PHONY: test-multi-surface
+.PHONY: test-ipc-activation
+.PHONY: test-appearance-watcher
+.PHONY: test-settings-writer
+.PHONY: test-networkmanager-contract
+.PHONY: test-bluez-contract
+.PHONY: test-gaming-power-contract
+.PHONY: test-wallpaper-write-contract
 
 help:
 	@printf '%s\n' \
@@ -640,6 +648,43 @@ test-typography: check-quickshell | $(BUILD_DIR)
 	cp '$(TYPOGRAPHY_SOURCE_SANS_FONT)' $(TYPOGRAPHY_TEST_DIR)/fonts/SourceSans3-Regular.ttf
 	NAGI_TYPOGRAPHY_HOLD='$(NAGI_TYPOGRAPHY_HOLD)' $(QS) -p $(TYPOGRAPHY_TEST_DIR) --no-duplicate
 
+# Issue #70 gate: one PanelWindow per connected screen, independent
+# assignment, destruction/recreation, and scale behavior in virtual KWin.
+test-multi-surface: check-quickshell
+	@$(KWIN_VIRTUAL_RUNNER) --outputs 3 --scale 1 -- env NAGI_PROBE_OUTPUTS=3 \
+		bash $(CURDIR)/tests/multi-surface/run-probe.sh
+	@$(KWIN_VIRTUAL_RUNNER) --outputs 2 --scale 1.5 -- env NAGI_PROBE_OUTPUTS=2 \
+		bash $(CURDIR)/tests/multi-surface/run-probe.sh
+
+# Issue #70 gate: same-process singleton activation via IpcHandler/`qs ipc`.
+test-ipc-activation: check-quickshell
+	@$(KWIN_VIRTUAL_RUNNER) --outputs 1 --scale 1 -- \
+		bash $(CURDIR)/tests/ipc-activation/run-probe.sh
+
+# Issue #70 gate: event-first KDE appearance observation from a synthetic
+# kdeglobals (light/dark, accent, reduced motion, malformed, deletion).
+test-appearance-watcher: check-quickshell
+	@bash $(CURDIR)/tests/appearance-watcher/run-probe.sh
+
+# Issue #70 gate: settings writer/watch semantics - private atomic
+# replacement, migration backup, own-write stability, last-good, symlinks.
+test-settings-writer: check-quickshell
+	@bash $(CURDIR)/tests/settings-writer/run-probe.sh
+
+# Issue #70 gates: private D-Bus fixture probes for downstream integration
+# contracts (NetworkManager, BlueZ, gaming performance, Plasma wallpaper).
+test-networkmanager-contract:
+	@bash $(CURDIR)/tests/networkmanager-contract/run-probe.sh
+
+test-bluez-contract:
+	@bash $(CURDIR)/tests/bluez-contract/run-probe.sh
+
+test-gaming-power-contract: check-helper-toolchain
+	@bash $(CURDIR)/tests/gaming-power-contract/run-probe.sh
+
+test-wallpaper-write-contract:
+	@bash $(CURDIR)/tests/wallpaper-write-contract/run-probe.sh
+
 check-quickshell:
 	@set -eu; \
 	version="$$($(QS) --version | sed -n 's/^Quickshell \([0-9][0-9.]*\).*/\1/p')"; \
@@ -702,7 +747,7 @@ lint-advisory:
 		exit 0; \
 	}
 
-check: check-nondisplay test-surface-state test-ui-primitives
+check: check-nondisplay test-surface-state test-ui-primitives test-multi-surface test-ipc-activation test-appearance-watcher test-settings-writer test-networkmanager-contract test-bluez-contract test-gaming-power-contract test-wallpaper-write-contract
 
 check-nondisplay: check-quickshell format-check audio-helper connectivity-helper brightness-helper session-helper application-helper global-shortcut-helper wallpaper-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-brightness-dbus test-brightness test-session-dbus test-session test-applications test-launcher test-global-shortcut test-notifications test-adapter test-coordinator test-transients test-weather test-media test-audio test-connectivity test-tray test-theme-config test-onboarding test-icons test-subview-frame test-wallpaper-dbus test-wallpaper test-idle test-dashboard test-polkit-ui
 

--- a/tests/appearance-watcher/run-probe.sh
+++ b/tests/appearance-watcher/run-probe.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Issue #70 gate 4 wrapper: drives a synthetic kdeglobals through light,
+# dark, accent removal, reduced motion, malformed values, and deletion using
+# atomic renames, asserting event-first re-derivation for every transition.
+set -uo pipefail
+
+root="$(mktemp -d "${TMPDIR:-/tmp}/nagi-appearance.XXXXXX")"
+config="$root/config"
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+log="$(mktemp "${TMPDIR:-/tmp}/nagi-appearance-log.XXXXXX")"
+deadline=$((SECONDS + 60))
+status=0
+pid=""
+
+mkdir -p "$config"
+cat >"$config/kdeglobals" <<'EOF'
+[General]
+ColorScheme=BreezeLight
+AccentColor=#3daee9
+[KDE]
+AnimationDurationFactor=1.00
+EOF
+
+write_variant() {
+    printf '%s' "$1" >"$config/kdeglobals.new"
+    mv -f "$config/kdeglobals.new" "$config/kdeglobals"
+}
+
+fail() {
+    echo "appearance-watcher: $1" >&2
+    status=1
+}
+
+await_line() {
+    local needle=$1
+    while ((SECONDS < deadline)); do
+        if grep -qF "$needle" "$log" 2>/dev/null; then
+            return 0
+        fi
+        if [[ -n "$pid" ]] && ! kill -0 "$pid" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+    grep 'APPEARANCE ' "$log" >&2 || true
+    fail "timed out waiting for: $needle"
+    return 1
+}
+
+QT_QPA_PLATFORM='offscreen' XDG_CONFIG_HOME="$config" HOME="$root/home" \
+    mkdir -p "$root/home"
+QT_QPA_PLATFORM='offscreen' XDG_CONFIG_HOME="$config" HOME="$root/home" \
+    qs -p "$dir" >"$log" 2>&1 &
+pid=$!
+
+await_line 'APPEARANCE scheme=BreezeLight accent=#3DAEE9 motion=1' \
+    || true
+
+if ((status == 0)); then
+    write_variant '[General]
+ColorScheme=BreezeDark
+[KDE]
+AnimationDurationFactor=0
+'
+    await_line 'APPEARANCE scheme=BreezeDark accent=null motion=0'
+fi
+
+if ((status == 0)); then
+    write_variant '[General]
+ColorScheme=BreezeDark
+AccentColor=not-a-color
+[KDE]
+AnimationDurationFactor=0.5
+'
+    await_line 'APPEARANCE scheme=BreezeDark accent=invalid motion=0.5'
+fi
+
+if ((status == 0)); then
+    rm -f "$config/kdeglobals"
+    await_line 'APPEARANCE scheme=null accent=null motion=null'
+fi
+
+events=$(grep -c 'APPEARANCE ' "$log" || true)
+if ((status == 0)) && ((events < 4)); then
+    fail "expected at least 4 observed transitions, saw ${events}"
+fi
+
+if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null
+fi
+wait "$pid" 2>/dev/null
+
+if ((status != 0)); then
+    tail -n 60 "$log" >&2
+else
+    grep -E 'PROBE |APPEARANCE ' "$log"
+    echo "appearance-watcher: event-first kdeglobals observation verified (${events} transitions)"
+fi
+
+rm -f "$log"
+rm -rf "$root"
+exit "$status"

--- a/tests/appearance-watcher/shell.qml
+++ b/tests/appearance-watcher/shell.qml
@@ -1,0 +1,118 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+// Issue #70 gate 4: event-first KDE appearance observation probe. Watches a
+// synthetic kdeglobals through Quickshell FileView and re-derives color
+// scheme, accent, and animation factor after every change event, including
+// atomic-rename replacement and deletion.
+ShellRoot {
+    id: root
+
+    readonly property string configHome: {
+        const xdgHome = Quickshell.env("XDG_CONFIG_HOME") ?? "";
+        return xdgHome !== "" ? xdgHome : (Quickshell.env("HOME") ?? "") + "/.config";
+    }
+    readonly property string kdeGlobalsPath: configHome + "/kdeglobals"
+
+    property int changeEvents: 0
+    property var debounce: null
+
+    function canonicalAccent(value) {
+        if (/^#[0-9a-fA-F]{6}$/.test(value)) {
+            return value.toUpperCase();
+        }
+        const rgb = value.split(",");
+        if (rgb.length === 3 || rgb.length === 4) {
+            let ok = true;
+            let hex = "#";
+            for (let index = 0; index < 3; index += 1) {
+                const channel = Number(rgb[index].trim());
+                if (!Number.isInteger(channel) || channel < 0 || channel > 255) {
+                    ok = false;
+                    break;
+                }
+                hex += channel.toString(16).padStart(2, "0").toUpperCase();
+            }
+            if (ok) {
+                return hex;
+            }
+        }
+        return "invalid";
+    }
+
+    function emit(scheme, accent, motion) {
+        console.warn("APPEARANCE scheme=" + scheme + " accent=" + accent + " motion=" + motion);
+    }
+
+    function publish() {
+        const content = watcher.loaded ? watcher.text() : "";
+        if (content === "" && !watcher.loaded) {
+            root.emit("null", "null", "null");
+            return;
+        }
+        let section = "";
+        let scheme = "null";
+        let accent = "null";
+        let motion = "null";
+        const lines = content.split(/\r?\n/);
+        for (let index = 0; index < lines.length; index += 1) {
+            const line = lines[index].trim();
+            if (line === "" || line.startsWith("#")) {
+                continue;
+            }
+            if (line.startsWith("[") && line.endsWith("]")) {
+                section = line.slice(1, -1);
+                continue;
+            }
+            const split = line.indexOf("=");
+            if (split <= 0) {
+                continue;
+            }
+            const key = line.slice(0, split).trim();
+            const value = line.slice(split + 1).trim();
+            if (section === "General" && key === "ColorScheme") {
+                scheme = value;
+            } else if (section === "General" && key === "AccentColor") {
+                accent = root.canonicalAccent(value);
+            } else if (section === "KDE" && key === "AnimationDurationFactor") {
+                const number = Number(value);
+                motion = Number.isFinite(number) && number >= 0 ? String(number) : "invalid";
+            }
+        }
+        root.emit(scheme, accent, motion);
+    }
+
+    Timer {
+        id: settle
+
+        interval: 80
+        onTriggered: root.publish()
+    }
+
+    FileView {
+        id: watcher
+
+        path: root.kdeGlobalsPath
+        watchChanges: true
+        preload: true
+        printErrors: false
+
+        onFileChanged: {
+            root.changeEvents += 1;
+            reload();
+        }
+        onLoaded: settle.restart()
+        onLoadFailed: function (error) {
+            if (error === FileViewError.FileNotFound) {
+                settle.restart();
+            } else {
+                console.warn("APPEARANCE error=" + error);
+            }
+        }
+    }
+
+    Component.onCompleted: console.warn("PROBE READY path=" + root.kdeGlobalsPath)
+}

--- a/tests/bluez-contract/client_probe.py
+++ b/tests/bluez-contract/client_probe.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+import asyncio
+import os
+import sys
+
+from dbus_next import Message, MessageType, Variant
+from dbus_next.aio import MessageBus
+
+BLUEZ = "org.bluez"
+ADAPTER_PATH = "/org/bluez/hci0"
+DEVICE_PATH = "/org/bluez/hci0/dev_01_02_03_04_05_06"
+OBJECT_MANAGER = "org.freedesktop.DBus.ObjectManager"
+PROPERTIES = "org.freedesktop.DBus.Properties"
+ADAPTER = "org.bluez.Adapter1"
+DEVICE = "org.bluez.Device1"
+AGENT_MANAGER = "org.bluez.AgentManager1"
+MOCK = "org.bluez.Mock1"
+
+
+class ProbeFailure(RuntimeError):
+    pass
+
+
+def require(condition, detail):
+    if not condition:
+        raise ProbeFailure(detail)
+
+
+def require_ok(reply, operation):
+    if reply.message_type == MessageType.ERROR:
+        raise ProbeFailure(f"{operation}: {reply.error_name}: {reply.body}")
+    return reply
+
+
+def require_error(reply, expected, operation):
+    require(reply.message_type == MessageType.ERROR, f"{operation}: expected {expected}, got success")
+    require(reply.error_name == expected, f"{operation}: expected {expected}, got {reply.error_name}")
+
+
+async def wait_event(event, detail):
+    try:
+        await asyncio.wait_for(event.wait(), 2.0)
+    except TimeoutError as error:
+        raise ProbeFailure(detail) from error
+
+
+async def call(bus, path, interface, member, signature="", body=None, destination=BLUEZ):
+    return await bus.call(
+        Message(
+            destination=destination,
+            path=path,
+            interface=interface,
+            member=member,
+            signature=signature,
+            body=body or [],
+        )
+    )
+
+
+async def add_match(bus, rule):
+    require_ok(
+        await call(
+            bus,
+            "/org/freedesktop/DBus",
+            "org.freedesktop.DBus",
+            "AddMatch",
+            "s",
+            [rule],
+            "org.freedesktop.DBus",
+        ),
+        "AddMatch",
+    )
+
+
+class Agent:
+    def __init__(self, name):
+        self.name = name
+        self.confirmations = 0
+        self.pin_requests = 0
+        self.authorizations = 0
+        self.cancels = 0
+        self.releases = 0
+        self.pin_event = asyncio.Event()
+
+    @property
+    def pairing_prompts(self):
+        return self.confirmations + self.pin_requests
+
+    def handle(self, message):
+        if message.message_type != MessageType.METHOD_CALL or message.interface != "org.bluez.Agent1":
+            return False
+        if message.member == "RequestConfirmation":
+            self.confirmations += 1
+            return Message.new_method_return(message)
+        if message.member == "RequestPinCode":
+            self.pin_requests += 1
+            self.pin_event.set()
+            return True
+        if message.member == "AuthorizeService":
+            self.authorizations += 1
+            return Message.new_method_return(message)
+        if message.member == "Cancel":
+            self.cancels += 1
+            return Message.new_method_return(message)
+        if message.member == "Release":
+            self.releases += 1
+            return Message.new_method_return(message)
+        return Message.new_error(message, "org.bluez.Error.Rejected", f"{self.name} rejected unknown request")
+
+
+class Observer:
+    def __init__(self):
+        self.rows = set()
+        self.added = asyncio.Event()
+        self.removed_count = 0
+        self.removed = asyncio.Event()
+        self.owner_lost = asyncio.Event()
+        self.property_events = []
+
+    def handle(self, message):
+        if message.message_type != MessageType.SIGNAL:
+            return False
+        if message.interface == OBJECT_MANAGER and message.member == "InterfacesAdded":
+            path, interfaces = message.body
+            if DEVICE in interfaces:
+                self.rows.add(path)
+                self.added.set()
+            return False
+        if message.interface == OBJECT_MANAGER and message.member == "InterfacesRemoved":
+            path, interfaces = message.body
+            if DEVICE in interfaces:
+                self.rows.discard(path)
+                self.removed_count += 1
+                self.removed.set()
+            return False
+        if message.interface == PROPERTIES and message.member == "PropertiesChanged":
+            self.property_events.append(message.body)
+            return False
+        if message.interface == "org.freedesktop.DBus" and message.member == "NameOwnerChanged":
+            name, old_owner, new_owner = message.body
+            if name == BLUEZ and old_owner and not new_owner:
+                self.owner_lost.set()
+            return False
+        return False
+
+
+async def get_property(bus, name):
+    reply = require_ok(
+        await call(bus, DEVICE_PATH, PROPERTIES, "Get", "ss", [DEVICE, name]),
+        f"read Device1.{name}",
+    )
+    return reply.body[0].value
+
+
+async def set_trusted(bus, value):
+    require_ok(
+        await call(
+            bus,
+            DEVICE_PATH,
+            PROPERTIES,
+            "Set",
+            "ssv",
+            [DEVICE, "Trusted", Variant("b", value)],
+        ),
+        "write Device1.Trusted",
+    )
+
+
+async def discover(bus, observer):
+    observer.added.clear()
+    require_ok(
+        await call(
+            bus,
+            ADAPTER_PATH,
+            ADAPTER,
+            "SetDiscoveryFilter",
+            "a{sv}",
+            [{"Transport": Variant("s", "auto"), "UUIDs": Variant("as", [])}],
+        ),
+        "SetDiscoveryFilter",
+    )
+    require_ok(await call(bus, ADAPTER_PATH, ADAPTER, "StartDiscovery"), "StartDiscovery")
+    await wait_event(observer.added, "InterfacesAdded was not observed")
+    require(DEVICE_PATH in observer.rows, "client row was not created from InterfacesAdded")
+    require_ok(await call(bus, ADAPTER_PATH, ADAPTER, "StopDiscovery"), "StopDiscovery")
+
+
+async def main():
+    address = os.environ.get("DBUS_SESSION_BUS_ADDRESS")
+    if not address:
+        print("FAIL: private session bus address missing", file=sys.stderr)
+        return 2
+
+    bus_a = await MessageBus(bus_address=address).connect()
+    bus_b = await MessageBus(bus_address=address).connect()
+    require(bus_a.unique_name != bus_b.unique_name, "agents do not have distinct unique bus names")
+
+    agent_a = Agent("A")
+    agent_b = Agent("B")
+    observer = Observer()
+    bus_a.add_message_handler(agent_a.handle)
+    bus_a.add_message_handler(observer.handle)
+    bus_b.add_message_handler(agent_b.handle)
+    await add_match(bus_a, "type='signal',sender='org.bluez'")
+    await add_match(bus_a, "type='signal',sender='org.freedesktop.DBus',member='NameOwnerChanged'")
+
+    snapshot = require_ok(
+        await call(bus_a, "/", OBJECT_MANAGER, "GetManagedObjects"),
+        "GetManagedObjects",
+    ).body[0]
+    require(DEVICE_PATH not in snapshot, "device existed before discovery event")
+    require(not observer.rows, "client created a device row from something other than InterfacesAdded")
+
+    path_b = "/org/example/AgentB"
+    path_a = "/org/example/AgentA"
+    require_ok(
+        await call(bus_b, "/org/bluez", AGENT_MANAGER, "RegisterAgent", "os", [path_b, "DisplayYesNo"]),
+        "RegisterAgent(B)",
+    )
+    require_ok(
+        await call(bus_b, "/org/bluez", AGENT_MANAGER, "RequestDefaultAgent", "o", [path_b]),
+        "RequestDefaultAgent(B)",
+    )
+    require_ok(
+        await call(bus_a, "/org/bluez", AGENT_MANAGER, "RegisterAgent", "os", [path_a, "KeyboardDisplay"]),
+        "RegisterAgent(A)",
+    )
+
+    await discover(bus_a, observer)
+    print("PASS 1 discovery filter/lifecycle and event-first InterfacesAdded")
+
+    require(await get_property(bus_a, "Paired") is False, "initial Paired was not false")
+    require(await get_property(bus_a, "Connected") is False, "initial Connected was not false")
+    require(await get_property(bus_a, "Trusted") is False, "initial Trusted was not false")
+
+    require_ok(
+        await call(bus_a, "/org/bluez", MOCK, "SimulateIncomingConnection"),
+        "untrusted incoming connection",
+    )
+    require(agent_b.authorizations == 1, "untrusted incoming connection did not use default agent B")
+    require(agent_a.authorizations == 0, "registered agent A stole default service authorization")
+    require(await get_property(bus_a, "Connected") is True, "accepted incoming connection did not connect")
+    require_ok(await call(bus_a, DEVICE_PATH, DEVICE, "Disconnect"), "Disconnect incoming")
+
+    await set_trusted(bus_a, True)
+    require(await get_property(bus_a, "Trusted") is True, "Trusted write was not observable")
+    require_ok(
+        await call(bus_a, "/org/bluez", MOCK, "SimulateIncomingConnection"),
+        "trusted incoming connection",
+    )
+    require(agent_b.authorizations == 1, "trusted incoming connection incorrectly prompted default agent")
+    require(await get_property(bus_a, "Connected") is True, "trusted incoming connection was not auto-accepted")
+    require_ok(await call(bus_a, DEVICE_PATH, DEVICE, "Disconnect"), "Disconnect trusted incoming")
+    print("PASS 2 Paired/Connected/Trusted properties and trusted auto-accept")
+
+    connect_task = asyncio.create_task(call(bus_a, DEVICE_PATH, DEVICE, "Connect"))
+    await asyncio.sleep(0.01)
+    require_error(
+        await call(bus_a, DEVICE_PATH, DEVICE, "Connect"),
+        "org.bluez.Error.InProgress",
+        "concurrent Connect",
+    )
+    require_ok(await connect_task, "first Connect")
+    require(await get_property(bus_a, "Connected") is True, "Connect did not set Connected")
+    require_error(
+        await call(bus_a, DEVICE_PATH, DEVICE, "Connect"),
+        "org.bluez.Error.AlreadyConnected",
+        "connected Connect",
+    )
+    require_ok(await call(bus_a, DEVICE_PATH, DEVICE, "Disconnect"), "Disconnect")
+    require(await get_property(bus_a, "Connected") is False, "Disconnect did not clear Connected")
+    print("PASS 4 Connect/Disconnect transitions and InProgress/AlreadyConnected errors")
+
+    await set_trusted(bus_a, False)
+    require_ok(await call(bus_a, DEVICE_PATH, DEVICE, "Pair"), "Pair")
+    require(agent_a.confirmations == 1, "calling connection A did not receive RequestConfirmation")
+    require(agent_b.pairing_prompts == 0, "default agent B received A's scoped pairing prompt")
+    require(await get_property(bus_a, "Paired") is True, "Pair did not set Paired")
+    print("PASS 3 Pair routed to calling connection A; default B untouched")
+
+    observer.removed.clear()
+    require_ok(
+        await call(bus_a, ADAPTER_PATH, ADAPTER, "RemoveDevice", "o", [DEVICE_PATH]),
+        "RemoveDevice(paired)",
+    )
+    await wait_event(observer.removed, "InterfacesRemoved for paired device was not observed")
+    require(DEVICE_PATH not in observer.rows, "client retained row after InterfacesRemoved")
+
+    await discover(bus_a, observer)
+    require(await get_property(bus_a, "Paired") is False, "rediscovered fixture was not unpaired")
+    observer.removed.clear()
+    require_ok(
+        await call(bus_a, ADAPTER_PATH, ADAPTER, "RemoveDevice", "o", [DEVICE_PATH]),
+        "RemoveDevice(unpaired)",
+    )
+    await wait_event(observer.removed, "InterfacesRemoved for unpaired device was not observed")
+    require_error(
+        await call(bus_a, ADAPTER_PATH, ADAPTER, "RemoveDevice", "o", [DEVICE_PATH]),
+        "org.bluez.Error.DoesNotExist",
+        "RemoveDevice(missing)",
+    )
+    print("PASS 5 RemoveDevice removes paired or unpaired objects; missing path errors")
+
+    await discover(bus_a, observer)
+    pair_task = asyncio.create_task(call(bus_a, DEVICE_PATH, DEVICE, "Pair"))
+    await wait_event(agent_a.pin_event, "calling connection A did not receive RequestPinCode")
+    require(agent_b.pairing_prompts == 0, "default agent B received A's second scoped pairing prompt")
+    require_ok(await call(bus_a, DEVICE_PATH, DEVICE, "CancelPairing"), "CancelPairing")
+    require_error(await pair_task, "org.bluez.Error.AuthenticationCanceled", "canceled Pair")
+    require(agent_a.cancels == 1, "Cancel was not sent to the pending scoped agent")
+
+    require_ok(
+        await call(bus_a, "/org/bluez", AGENT_MANAGER, "UnregisterAgent", "o", [path_a]),
+        "UnregisterAgent(A)",
+    )
+    require(agent_a.releases == 1, "UnregisterAgent(A) did not invoke Release")
+    require_ok(
+        await call(bus_b, "/org/bluez", AGENT_MANAGER, "UnregisterAgent", "o", [path_b]),
+        "UnregisterAgent(B)",
+    )
+    require(agent_b.releases == 1, "UnregisterAgent(B) did not invoke Release")
+    print("PASS 6 registration preserves default; cancel invokes Cancel; unregister invokes Release")
+
+    require_ok(await call(bus_a, "/org/bluez", MOCK, "Quit"), "mock Quit")
+    await wait_event(observer.owner_lost, "org.bluez owner loss was not observed")
+    absent = await call(bus_a, "/", OBJECT_MANAGER, "GetManagedObjects")
+    require(absent.message_type == MessageType.ERROR, "org.bluez unexpectedly remained available")
+    require(
+        absent.error_name in ("org.freedesktop.DBus.Error.ServiceUnknown", "org.freedesktop.DBus.Error.NameHasNoOwner"),
+        f"unexpected absence error {absent.error_name}",
+    )
+    print("PASS 7 org.bluez absence detected as explicit unavailable state")
+
+    bus_a.disconnect()
+    bus_b.disconnect()
+    print("PASS bluez-contract: all private-bus contracts verified")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(asyncio.run(main()))
+    except ProbeFailure as error:
+        print(f"FAIL bluez-contract: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/bluez-contract/mock_bluez.py
+++ b/tests/bluez-contract/mock_bluez.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+import asyncio
+import os
+import sys
+
+from dbus_next import Message, MessageType, Variant
+from dbus_next.aio import MessageBus
+
+BLUEZ = "org.bluez"
+ADAPTER_PATH = "/org/bluez/hci0"
+DEVICE_PATH = "/org/bluez/hci0/dev_01_02_03_04_05_06"
+OBJECT_MANAGER = "org.freedesktop.DBus.ObjectManager"
+PROPERTIES = "org.freedesktop.DBus.Properties"
+ADAPTER = "org.bluez.Adapter1"
+DEVICE = "org.bluez.Device1"
+AGENT_MANAGER = "org.bluez.AgentManager1"
+MOCK = "org.bluez.Mock1"
+
+
+class MockBlueZ:
+    def __init__(self, bus):
+        self.bus = bus
+        self.device_present = False
+        self.discovering = False
+        self.paired = False
+        self.connected = False
+        self.trusted = False
+        self.agents = {}
+        self.default_owner = None
+        self.pair_attempt = 0
+        self.pending_pair = None
+        self.connect_pending = False
+        self.quit_event = asyncio.Event()
+
+    def managed_objects(self):
+        objects = {
+            ADAPTER_PATH: {
+                ADAPTER: {
+                    "Powered": Variant("b", True),
+                    "Discovering": Variant("b", self.discovering),
+                }
+            },
+            "/org/bluez": {AGENT_MANAGER: {}},
+        }
+        if self.device_present:
+            objects[DEVICE_PATH] = {DEVICE: self.device_properties()}
+        return objects
+
+    def device_properties(self):
+        return {
+            "Address": Variant("s", "01:02:03:04:05:06"),
+            "Name": Variant("s", "Private Fixture"),
+            "Paired": Variant("b", self.paired),
+            "Connected": Variant("b", self.connected),
+            "Trusted": Variant("b", self.trusted),
+        }
+
+    def reply(self, message, signature="", body=None):
+        self.bus.send(Message.new_method_return(message, signature, body or []))
+
+    def error(self, message, name, text):
+        self.bus.send(Message.new_error(message, name, text))
+
+    def signal(self, path, interface, member, signature, body):
+        self.bus.send(Message.new_signal(path, interface, member, signature, body))
+
+    def property_changed(self, name, value):
+        signature = "b" if isinstance(value, bool) else "s"
+        self.signal(
+            DEVICE_PATH,
+            PROPERTIES,
+            "PropertiesChanged",
+            "sa{sv}as",
+            [DEVICE, {name: Variant(signature, value)}, []],
+        )
+
+    def adapter_property_changed(self, name, value):
+        self.signal(
+            ADAPTER_PATH,
+            PROPERTIES,
+            "PropertiesChanged",
+            "sa{sv}as",
+            [ADAPTER, {name: Variant("b", value)}, []],
+        )
+
+    def add_device(self):
+        if self.device_present:
+            return
+        self.device_present = True
+        self.paired = False
+        self.connected = False
+        self.trusted = False
+        self.signal(
+            "/",
+            OBJECT_MANAGER,
+            "InterfacesAdded",
+            "oa{sa{sv}}",
+            [DEVICE_PATH, {DEVICE: self.device_properties()}],
+        )
+
+    def remove_device(self):
+        self.device_present = False
+        self.paired = False
+        self.connected = False
+        self.trusted = False
+        self.signal(
+            "/",
+            OBJECT_MANAGER,
+            "InterfacesRemoved",
+            "oas",
+            [DEVICE_PATH, [DEVICE]],
+        )
+
+    async def call_agent(self, owner, path, member, signature, body):
+        return await self.bus.call(
+            Message(
+                destination=owner,
+                path=path,
+                interface="org.bluez.Agent1",
+                member=member,
+                signature=signature,
+                body=body,
+            )
+        )
+
+    async def pair(self, message):
+        owner = message.sender
+        registration = self.agents.get(owner)
+        if registration is None and self.default_owner is not None:
+            registration = self.agents.get(self.default_owner)
+            owner = self.default_owner
+        if registration is None:
+            self.error(message, "org.bluez.Error.AuthenticationRejected", "no agent")
+            return
+
+        self.pair_attempt += 1
+        member = "RequestConfirmation" if self.pair_attempt == 1 else "RequestPinCode"
+        signature = "ou" if member == "RequestConfirmation" else "o"
+        body = [DEVICE_PATH, 123456] if member == "RequestConfirmation" else [DEVICE_PATH]
+        task = asyncio.create_task(self.call_agent(owner, registration[0], member, signature, body))
+        self.pending_pair = (message, owner, registration[0], task)
+        try:
+            response = await task
+        except asyncio.CancelledError:
+            return
+        finally:
+            if self.pending_pair is not None and self.pending_pair[0] is message:
+                self.pending_pair = None
+
+        if response.message_type == MessageType.ERROR:
+            self.error(message, "org.bluez.Error.AuthenticationRejected", "agent rejected pairing")
+            return
+        self.paired = True
+        self.property_changed("Paired", True)
+        self.reply(message)
+
+    async def cancel_pairing(self, message):
+        if self.pending_pair is None:
+            self.error(message, "org.bluez.Error.DoesNotExist", "no pairing in progress")
+            return
+        pair_message, owner, path, task = self.pending_pair
+        self.pending_pair = None
+        task.cancel()
+        await self.call_agent(owner, path, "Cancel", "", [])
+        self.error(pair_message, "org.bluez.Error.AuthenticationCanceled", "pairing canceled")
+        self.reply(message)
+
+    async def connect_device(self, message):
+        await asyncio.sleep(0.08)
+        self.connect_pending = False
+        self.connected = True
+        self.property_changed("Connected", True)
+        self.reply(message)
+
+    async def simulate_incoming(self, message):
+        if not self.trusted:
+            registration = self.agents.get(self.default_owner)
+            if registration is None:
+                self.error(message, "org.bluez.Error.Rejected", "no default agent")
+                return
+            response = await self.call_agent(
+                self.default_owner,
+                registration[0],
+                "AuthorizeService",
+                "os",
+                [DEVICE_PATH, "0000110b-0000-1000-8000-00805f9b34fb"],
+            )
+            if response.message_type == MessageType.ERROR:
+                self.error(message, "org.bluez.Error.Rejected", "service rejected")
+                return
+        self.connected = True
+        self.property_changed("Connected", True)
+        self.reply(message)
+
+    async def unregister_agent(self, message, owner, path):
+        registration = self.agents.get(owner)
+        if registration is None or registration[0] != path:
+            self.error(message, "org.bluez.Error.DoesNotExist", "agent not registered")
+            return
+        await self.call_agent(owner, path, "Release", "", [])
+        del self.agents[owner]
+        if self.default_owner == owner:
+            self.default_owner = None
+        self.reply(message)
+
+    async def quit_later(self, message):
+        self.reply(message)
+        await asyncio.sleep(0.02)
+        self.quit_event.set()
+
+    def handle(self, message):
+        if message.message_type != MessageType.METHOD_CALL:
+            return False
+
+        if message.path == "/" and message.interface == OBJECT_MANAGER and message.member == "GetManagedObjects":
+            return Message.new_method_return(message, "a{oa{sa{sv}}}", [self.managed_objects()])
+
+        if message.interface == PROPERTIES:
+            if message.member == "Get" and len(message.body) == 2:
+                interface, name = message.body
+                value = None
+                if message.path == DEVICE_PATH and interface == DEVICE and self.device_present:
+                    value = self.device_properties().get(name)
+                elif message.path == ADAPTER_PATH and interface == ADAPTER:
+                    value = self.managed_objects()[ADAPTER_PATH][ADAPTER].get(name)
+                if value is None:
+                    return Message.new_error(message, "org.freedesktop.DBus.Error.UnknownProperty", "unknown property")
+                return Message.new_method_return(message, "v", [value])
+            if message.member == "Set" and len(message.body) == 3:
+                interface, name, wrapped = message.body
+                if message.path == DEVICE_PATH and interface == DEVICE and name == "Trusted" and self.device_present:
+                    self.trusted = bool(wrapped.value)
+                    self.property_changed("Trusted", self.trusted)
+                    return Message.new_method_return(message)
+                return Message.new_error(message, "org.freedesktop.DBus.Error.PropertyReadOnly", "property is not writable")
+
+        if message.path == "/org/bluez" and message.interface == AGENT_MANAGER:
+            if message.member == "RegisterAgent":
+                path, capability = message.body
+                if message.sender in self.agents:
+                    return Message.new_error(message, "org.bluez.Error.AlreadyExists", "one agent per connection")
+                if capability not in ("", "DisplayOnly", "DisplayYesNo", "KeyboardOnly", "NoInputNoOutput", "KeyboardDisplay"):
+                    return Message.new_error(message, "org.bluez.Error.InvalidArguments", "invalid capability")
+                self.agents[message.sender] = (path, capability)
+                return Message.new_method_return(message)
+            if message.member == "RequestDefaultAgent":
+                path = message.body[0]
+                registration = self.agents.get(message.sender)
+                if registration is None or registration[0] != path:
+                    return Message.new_error(message, "org.bluez.Error.DoesNotExist", "agent not registered")
+                self.default_owner = message.sender
+                return Message.new_method_return(message)
+            if message.member == "UnregisterAgent":
+                asyncio.create_task(self.unregister_agent(message, message.sender, message.body[0]))
+                return True
+
+        if message.path == ADAPTER_PATH and message.interface == ADAPTER:
+            if message.member == "SetDiscoveryFilter":
+                if len(message.body) != 1:
+                    return Message.new_error(message, "org.bluez.Error.InvalidArguments", "filter required")
+                return Message.new_method_return(message)
+            if message.member == "StartDiscovery":
+                if self.discovering:
+                    return Message.new_error(message, "org.bluez.Error.InProgress", "discovery already active")
+                self.discovering = True
+                self.adapter_property_changed("Discovering", True)
+                self.add_device()
+                return Message.new_method_return(message)
+            if message.member == "StopDiscovery":
+                if not self.discovering:
+                    return Message.new_error(message, "org.bluez.Error.NotReady", "discovery is not active")
+                self.discovering = False
+                self.adapter_property_changed("Discovering", False)
+                return Message.new_method_return(message)
+            if message.member == "RemoveDevice":
+                path = message.body[0]
+                if path != DEVICE_PATH or not self.device_present:
+                    return Message.new_error(message, "org.bluez.Error.DoesNotExist", "device does not exist")
+                self.remove_device()
+                return Message.new_method_return(message)
+
+        if message.path == DEVICE_PATH and message.interface == DEVICE and self.device_present:
+            if message.member == "Pair":
+                if self.paired:
+                    return Message.new_error(message, "org.bluez.Error.AlreadyExists", "already paired")
+                if self.pending_pair is not None:
+                    return Message.new_error(message, "org.bluez.Error.InProgress", "pairing in progress")
+                asyncio.create_task(self.pair(message))
+                return True
+            if message.member == "CancelPairing":
+                asyncio.create_task(self.cancel_pairing(message))
+                return True
+            if message.member == "Connect":
+                if self.connected:
+                    return Message.new_error(message, "org.bluez.Error.AlreadyConnected", "already connected")
+                if self.connect_pending:
+                    return Message.new_error(message, "org.bluez.Error.InProgress", "connection in progress")
+                self.connect_pending = True
+                asyncio.create_task(self.connect_device(message))
+                return True
+            if message.member == "Disconnect":
+                if not self.connected:
+                    return Message.new_error(message, "org.bluez.Error.NotConnected", "not connected")
+                self.connected = False
+                self.property_changed("Connected", False)
+                return Message.new_method_return(message)
+
+        if message.path == "/org/bluez" and message.interface == MOCK:
+            if message.member == "SimulateIncomingConnection":
+                asyncio.create_task(self.simulate_incoming(message))
+                return True
+            if message.member == "Quit":
+                asyncio.create_task(self.quit_later(message))
+                return True
+
+        return Message.new_error(message, "org.freedesktop.DBus.Error.UnknownMethod", "unknown method")
+
+
+async def main():
+    address = os.environ.get("DBUS_SESSION_BUS_ADDRESS")
+    if not address:
+        print("private session bus address missing", file=sys.stderr)
+        return 2
+    bus = await MessageBus(bus_address=address).connect()
+    mock = MockBlueZ(bus)
+    bus.add_message_handler(mock.handle)
+    await bus.request_name(BLUEZ)
+    print("READY", flush=True)
+    await mock.quit_event.wait()
+    bus.disconnect()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/bluez-contract/run-probe.sh
+++ b/tests/bluez-contract/run-probe.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+fixture_root=$(mktemp -d "${TMPDIR:-/tmp}/nagi-bluez-contract.XXXXXX")
+cleanup_outer() {
+    rm -rf -- "$fixture_root"
+}
+trap cleanup_outer EXIT HUP INT TERM
+
+mkdir -p "$fixture_root/home" "$fixture_root/config" "$fixture_root/data" \
+    "$fixture_root/state" "$fixture_root/cache" "$fixture_root/runtime"
+chmod 700 "$fixture_root/runtime"
+
+HOME="$fixture_root/home" \
+XDG_CONFIG_HOME="$fixture_root/config" \
+XDG_DATA_HOME="$fixture_root/data" \
+XDG_STATE_HOME="$fixture_root/state" \
+XDG_CACHE_HOME="$fixture_root/cache" \
+XDG_RUNTIME_DIR="$fixture_root/runtime" \
+dbus-run-session -- sh -eu -c '
+    here=$1
+    fixture_root=$2
+    export DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS
+
+    mock_pid=
+    cleanup_inner() {
+        if [ -n "$mock_pid" ]; then
+            kill "$mock_pid" 2>/dev/null || true
+            wait "$mock_pid" 2>/dev/null || true
+        fi
+    }
+    trap cleanup_inner EXIT HUP INT TERM
+
+    python3 "$here/mock_bluez.py" >"$fixture_root/mock.log" 2>&1 &
+    mock_pid=$!
+    gdbus wait --session --timeout 5 org.bluez
+    python3 "$here/client_probe.py"
+    wait "$mock_pid"
+    mock_pid=
+' sh "$here" "$fixture_root"

--- a/tests/gaming-power-contract/gaming_power_probe.cpp
+++ b/tests/gaming-power-contract/gaming_power_probe.cpp
@@ -1,0 +1,577 @@
+#include <QCoreApplication>
+#include <QDBusConnection>
+#include <QDBusArgument>
+#include <QDBusError>
+#include <QDBusInterface>
+#include <QDBusMessage>
+#include <QDBusMetaType>
+#include <QDBusObjectPath>
+#include <QDBusReply>
+#include <QDBusVariant>
+#include <QDBusVirtualObject>
+#include <QElapsedTimer>
+#include <QProcess>
+#include <QTimer>
+#include <QThread>
+#include <QVariantMap>
+
+#include <functional>
+#include <cstdio>
+
+using ProfileList = QList<QVariantMap>;
+Q_DECLARE_METATYPE(ProfileList)
+
+namespace {
+constexpr auto GameService = "com.feralinteractive.GameMode";
+constexpr auto GamePath = "/com/feralinteractive/GameMode";
+constexpr auto GameInterface = "com.feralinteractive.GameMode";
+constexpr auto ModernService = "org.freedesktop.UPower.PowerProfiles";
+constexpr auto ModernPath = "/org/freedesktop/UPower/PowerProfiles";
+constexpr auto ModernInterface = "org.freedesktop.UPower.PowerProfiles";
+constexpr auto LegacyService = "net.hadess.PowerProfiles";
+constexpr auto LegacyPath = "/net/hadess/PowerProfiles";
+constexpr auto LegacyInterface = "net.hadess.PowerProfiles";
+constexpr auto PropertiesInterface = "org.freedesktop.DBus.Properties";
+constexpr auto ControlService = "org.nagishell.Test.GamingPowerControl";
+constexpr auto ControlPath = "/org/nagishell/Test/GamingPowerControl";
+constexpr auto ControlInterface = "org.nagishell.Test.GamingPowerControl";
+
+class GamingPowerMock final : public QDBusVirtualObject {
+public:
+    explicit GamingPowerMock(QDBusConnection connection)
+        : bus(std::move(connection))
+    {
+        profiles = {
+            QVariantMap{{QStringLiteral("Profile"), QStringLiteral("power-saver")}},
+            QVariantMap{{QStringLiteral("Profile"), QStringLiteral("balanced")}},
+            QVariantMap{{QStringLiteral("Profile"), QStringLiteral("performance")}},
+        };
+    }
+
+    QString introspect(const QString &path) const override
+    {
+        if (path == QString::fromLatin1(GamePath)) {
+            return QStringLiteral(R"XML(<node>
+  <interface name="com.feralinteractive.GameMode">
+    <property name="ClientCount" type="i" access="read"/>
+    <signal name="GameRegistered"><arg type="i"/><arg type="o"/></signal>
+    <signal name="GameUnregistered"><arg type="i"/><arg type="o"/></signal>
+  </interface>
+</node>)XML");
+        }
+        if (path == QString::fromLatin1(ModernPath) || path == QString::fromLatin1(LegacyPath)) {
+            const QString interface = path == QString::fromLatin1(ModernPath)
+                ? QString::fromLatin1(ModernInterface)
+                : QString::fromLatin1(LegacyInterface);
+            return QStringLiteral(R"XML(<node>
+  <interface name="%1">
+    <property name="ActiveProfile" type="s" access="readwrite"/>
+    <property name="Profiles" type="aa{sv}" access="read"/>
+    <property name="PerformanceDegraded" type="s" access="read"/>
+  </interface>
+</node>)XML").arg(interface);
+        }
+        return QStringLiteral("<node/>");
+    }
+
+    bool handleMessage(const QDBusMessage &message, const QDBusConnection &connection) override
+    {
+        if (message.path() == QString::fromLatin1(ControlPath)
+            && message.interface() == QString::fromLatin1(ControlInterface)) {
+            const auto arguments = message.arguments();
+            if (message.member() == QStringLiteral("RegisterGameFixture") && arguments.size() == 1) {
+                registerGame(arguments.at(0).toInt());
+                connection.send(message.createReply());
+                return true;
+            }
+            if (message.member() == QStringLiteral("UnregisterGameFixture") && arguments.size() == 1) {
+                unregisterGame(arguments.at(0).toInt());
+                connection.send(message.createReply());
+                return true;
+            }
+            if (message.member() == QStringLiteral("SwitchProfileFixture") && arguments.size() == 1) {
+                switchProfile(arguments.at(0).toString());
+                connection.send(message.createReply());
+                return true;
+            }
+            if (message.member() == QStringLiteral("MutationCalls")) {
+                connection.send(message.createReply(QVariantList{mutationCalls}));
+                return true;
+            }
+            if (message.member() == QStringLiteral("Quit")) {
+                connection.send(message.createReply());
+                QTimer::singleShot(0, QCoreApplication::instance(), &QCoreApplication::quit);
+                return true;
+            }
+        }
+        if (message.interface() == QString::fromLatin1(PropertiesInterface)) {
+            if (message.member() == QStringLiteral("Get")) {
+                return handleGet(message, connection);
+            }
+            if (message.member() == QStringLiteral("GetAll")) {
+                return handleGetAll(message, connection);
+            }
+            if (message.member() == QStringLiteral("Set")) {
+                ++mutationCalls;
+                connection.send(message.createErrorReply(
+                    QDBusError::AccessDenied,
+                    QStringLiteral("fixture is observation-only")));
+                return true;
+            }
+        }
+        if (message.member() == QStringLiteral("RegisterGame")
+            || message.member() == QStringLiteral("UnregisterGame")
+            || message.member() == QStringLiteral("HoldProfile")
+            || message.member() == QStringLiteral("ReleaseProfile")) {
+            ++mutationCalls;
+            connection.send(message.createErrorReply(
+                QDBusError::AccessDenied,
+                QStringLiteral("fixture is observation-only")));
+            return true;
+        }
+        return false;
+    }
+
+    void registerGame(qint32 pid)
+    {
+        clientCount = 1;
+        QDBusMessage signal = QDBusMessage::createSignal(
+            QString::fromLatin1(GamePath),
+            QString::fromLatin1(GameInterface),
+            QStringLiteral("GameRegistered"));
+        signal << pid << QVariant::fromValue(QDBusObjectPath(
+            QStringLiteral("/com/feralinteractive/GameMode/Games/%1").arg(pid)));
+        bus.send(signal);
+        sendPropertiesChanged(
+            QString::fromLatin1(GamePath),
+            QString::fromLatin1(GameInterface),
+            QVariantMap{{QStringLiteral("ClientCount"), clientCount}});
+    }
+
+    void unregisterGame(qint32 pid)
+    {
+        clientCount = 0;
+        QDBusMessage signal = QDBusMessage::createSignal(
+            QString::fromLatin1(GamePath),
+            QString::fromLatin1(GameInterface),
+            QStringLiteral("GameUnregistered"));
+        signal << pid << QVariant::fromValue(QDBusObjectPath(
+            QStringLiteral("/com/feralinteractive/GameMode/Games/%1").arg(pid)));
+        bus.send(signal);
+        sendPropertiesChanged(
+            QString::fromLatin1(GamePath),
+            QString::fromLatin1(GameInterface),
+            QVariantMap{{QStringLiteral("ClientCount"), clientCount}});
+    }
+
+    void switchProfile(const QString &profile)
+    {
+        activeProfile = profile;
+        sendPropertiesChanged(
+            QString::fromLatin1(ModernPath),
+            QString::fromLatin1(ModernInterface),
+            QVariantMap{{QStringLiteral("ActiveProfile"), activeProfile}});
+        sendPropertiesChanged(
+            QString::fromLatin1(LegacyPath),
+            QString::fromLatin1(LegacyInterface),
+            QVariantMap{{QStringLiteral("ActiveProfile"), activeProfile}});
+    }
+
+    int mutationCalls = 0;
+
+private:
+    QVariant property(const QString &interface, const QString &name) const
+    {
+        if (interface == QString::fromLatin1(GameInterface) && name == QStringLiteral("ClientCount")) {
+            return clientCount;
+        }
+        if ((interface == QString::fromLatin1(ModernInterface)
+             || interface == QString::fromLatin1(LegacyInterface))) {
+            if (name == QStringLiteral("ActiveProfile")) {
+                return activeProfile;
+            }
+            if (name == QStringLiteral("Profiles")) {
+                return QVariant::fromValue(profiles);
+            }
+            if (name == QStringLiteral("PerformanceDegraded")) {
+                return performanceDegraded;
+            }
+        }
+        return {};
+    }
+
+    bool handleGet(const QDBusMessage &message, const QDBusConnection &connection)
+    {
+        const auto arguments = message.arguments();
+        if (arguments.size() != 2) {
+            return false;
+        }
+        const QVariant value = property(arguments.at(0).toString(), arguments.at(1).toString());
+        if (!value.isValid()) {
+            connection.send(message.createErrorReply(QDBusError::UnknownProperty, QStringLiteral("unknown property")));
+            return true;
+        }
+        connection.send(message.createReply(QVariantList{QVariant::fromValue(QDBusVariant(value))}));
+        return true;
+    }
+
+    bool handleGetAll(const QDBusMessage &message, const QDBusConnection &connection)
+    {
+        const auto arguments = message.arguments();
+        if (arguments.size() != 1) {
+            return false;
+        }
+        const QString interface = arguments.at(0).toString();
+        QVariantMap values;
+        if (interface == QString::fromLatin1(GameInterface)) {
+            values.insert(QStringLiteral("ClientCount"), clientCount);
+        } else if (interface == QString::fromLatin1(ModernInterface)
+                   || interface == QString::fromLatin1(LegacyInterface)) {
+            values.insert(QStringLiteral("ActiveProfile"), activeProfile);
+            values.insert(QStringLiteral("Profiles"), QVariant::fromValue(profiles));
+            values.insert(QStringLiteral("PerformanceDegraded"), performanceDegraded);
+        } else {
+            connection.send(message.createErrorReply(QDBusError::UnknownInterface, QStringLiteral("unknown interface")));
+            return true;
+        }
+        connection.send(message.createReply(QVariantList{values}));
+        return true;
+    }
+
+    void sendPropertiesChanged(const QString &path, const QString &interface, const QVariantMap &changed)
+    {
+        QDBusMessage signal = QDBusMessage::createSignal(
+            path,
+            QString::fromLatin1(PropertiesInterface),
+            QStringLiteral("PropertiesChanged"));
+        signal << interface << changed << QStringList{};
+        bus.send(signal);
+    }
+
+    QDBusConnection bus;
+    qint32 clientCount = 0;
+    QString activeProfile = QStringLiteral("balanced");
+    QString performanceDegraded;
+    ProfileList profiles;
+};
+
+class Probe final : public QObject {
+    Q_OBJECT
+
+public:
+    explicit Probe(QCoreApplication &application)
+        : QObject(&application)
+        , bus(QDBusConnection::sessionBus())
+    {
+    }
+
+    int run()
+    {
+        if (!bus.isConnected()) {
+            return fail("private session bus unavailable");
+        }
+        if (!verifyAbsence()) {
+            return 1;
+        }
+        server.setProcessChannelMode(QProcess::ForwardedChannels);
+        server.start(QCoreApplication::applicationFilePath(), {QStringLiteral("--mock")});
+        if (!server.waitForStarted(2000)
+            || !waitFor([this] { return mockNamesOwned(); })) {
+            server.kill();
+            server.waitForFinished();
+            return fail("could not start private mock services");
+        }
+        if (!connectSignals()) {
+            stopServer();
+            return 1;
+        }
+        bool passed = verifyGameMode() && verifyPowerProfiles();
+        const QDBusReply<qint32> mutationCount(controlCall(QStringLiteral("MutationCalls")));
+        if (!mutationCount.isValid() || mutationCount.value() != 0) {
+            fail("observer attempted a mutating D-Bus call");
+            passed = false;
+        }
+        stopServer();
+        return passed ? 0 : 1;
+    }
+
+private slots:
+    void gameRegistered(qint32 pid, const QDBusObjectPath &path)
+    {
+        registeredPid = pid;
+        registeredPath = path.path();
+    }
+
+    void gameUnregistered(qint32 pid, const QDBusObjectPath &path)
+    {
+        unregisteredPid = pid;
+        unregisteredPath = path.path();
+    }
+
+    void propertiesChanged(const QString &interface, const QVariantMap &changed, const QStringList &)
+    {
+        if ((interface == QString::fromLatin1(ModernInterface)
+             || interface == QString::fromLatin1(LegacyInterface))
+            && changed.contains(QStringLiteral("ActiveProfile"))) {
+            const QVariant value = changed.value(QStringLiteral("ActiveProfile"));
+            if (value.metaType().id() == QMetaType::QString) {
+                eventProfiles.insert(interface, value.toString());
+            }
+        }
+    }
+
+private:
+    bool verifyAbsence()
+    {
+        QDBusInterface broker(
+            QStringLiteral("org.freedesktop.DBus"),
+            QStringLiteral("/org/freedesktop/DBus"),
+            QStringLiteral("org.freedesktop.DBus"),
+            bus);
+        const QDBusReply<QStringList> names = broker.call(QStringLiteral("ListNames"));
+        if (!names.isValid() || names.value().contains(QString::fromLatin1(GameService))) {
+            fail("GameMode absence was not detected through ListNames");
+            return false;
+        }
+        const QDBusMessage reply = broker.call(QStringLiteral("GetConnectionUnixProcessID"), QString::fromLatin1(GameService));
+        if (reply.type() != QDBusMessage::ErrorMessage
+            || reply.errorName() != QStringLiteral("org.freedesktop.DBus.Error.NameHasNoOwner")) {
+            fail("GameMode missing-owner lookup did not fail gracefully");
+            return false;
+        }
+        std::puts("PASS 3: unowned GameMode detected without activating or calling it");
+        return true;
+    }
+
+    bool connectSignals()
+    {
+        const bool gameSignals = bus.connect(
+            QString::fromLatin1(GameService), QString::fromLatin1(GamePath),
+            QString::fromLatin1(GameInterface), QStringLiteral("GameRegistered"),
+            this, SLOT(gameRegistered(qint32,QDBusObjectPath)))
+            && bus.connect(
+                QString::fromLatin1(GameService), QString::fromLatin1(GamePath),
+                QString::fromLatin1(GameInterface), QStringLiteral("GameUnregistered"),
+                this, SLOT(gameUnregistered(qint32,QDBusObjectPath)));
+        const bool profileSignals = bus.connect(
+            QString::fromLatin1(ModernService), QString::fromLatin1(ModernPath),
+            QString::fromLatin1(PropertiesInterface), QStringLiteral("PropertiesChanged"),
+            this, SLOT(propertiesChanged(QString,QVariantMap,QStringList)))
+            && bus.connect(
+                QString::fromLatin1(LegacyService), QString::fromLatin1(LegacyPath),
+                QString::fromLatin1(PropertiesInterface), QStringLiteral("PropertiesChanged"),
+                this, SLOT(propertiesChanged(QString,QVariantMap,QStringList)));
+        if (!gameSignals || !profileSignals) {
+            fail("could not subscribe before snapshots");
+            return false;
+        }
+        return true;
+    }
+
+    bool mockNamesOwned()
+    {
+        QDBusInterface broker(
+            QStringLiteral("org.freedesktop.DBus"),
+            QStringLiteral("/org/freedesktop/DBus"),
+            QStringLiteral("org.freedesktop.DBus"),
+            bus);
+        const QDBusReply<QStringList> names = broker.call(QStringLiteral("ListNames"));
+        return names.isValid()
+            && names.value().contains(QString::fromLatin1(GameService))
+            && names.value().contains(QString::fromLatin1(ModernService))
+            && names.value().contains(QString::fromLatin1(LegacyService))
+            && names.value().contains(QString::fromLatin1(ControlService));
+    }
+
+    QDBusMessage controlCall(const QString &member, const QVariant &argument = {})
+    {
+        QDBusMessage call = QDBusMessage::createMethodCall(
+            QString::fromLatin1(ControlService),
+            QString::fromLatin1(ControlPath),
+            QString::fromLatin1(ControlInterface),
+            member);
+        if (argument.isValid()) {
+            call << argument;
+        }
+        return bus.call(call, QDBus::Block, 2000);
+    }
+
+    bool fixtureCall(const QString &member, const QVariant &argument)
+    {
+        const QDBusMessage reply = controlCall(member, argument);
+        if (reply.type() == QDBusMessage::ReplyMessage) {
+            return true;
+        }
+        fail(QStringLiteral("fixture control %1 failed: %2").arg(member, reply.errorMessage()));
+        return false;
+    }
+
+    void stopServer()
+    {
+        controlCall(QStringLiteral("Quit"));
+        if (!server.waitForFinished(2000)) {
+            server.kill();
+            server.waitForFinished();
+        }
+    }
+
+    QVariant readProperty(const QString &service, const QString &path, const QString &interface, const QString &name)
+    {
+        QDBusInterface properties(service, path, QString::fromLatin1(PropertiesInterface), bus);
+        const QDBusReply<QDBusVariant> reply = properties.call(
+            QDBus::BlockWithGui,
+            QStringLiteral("Get"),
+            interface,
+            name);
+        if (!reply.isValid()) {
+            fail(QStringLiteral("property read failed: %1.%2: %3")
+                     .arg(interface, name, reply.error().message()));
+            return {};
+        }
+        return reply.value().variant();
+    }
+
+    bool verifyGameMode()
+    {
+        const QVariant initial = readProperty(
+            QString::fromLatin1(GameService), QString::fromLatin1(GamePath),
+            QString::fromLatin1(GameInterface), QStringLiteral("ClientCount"));
+        if (initial.metaType().id() != QMetaType::Int || initial.toInt() != 0) {
+            fail("ClientCount was not D-Bus INT32 zero");
+            return false;
+        }
+        std::puts("PASS 1: ClientCount property has signature i and returns the aggregate count");
+
+        if (!fixtureCall(QStringLiteral("RegisterGameFixture"), 4242)) {
+            return false;
+        }
+        if (!waitFor([this] { return registeredPid == 4242; })
+            || registeredPath != QStringLiteral("/com/feralinteractive/GameMode/Games/4242")) {
+            fail("GameRegistered(i,o) was not delivered after event-first subscription");
+            return false;
+        }
+        const QVariant active = readProperty(
+            QString::fromLatin1(GameService), QString::fromLatin1(GamePath),
+            QString::fromLatin1(GameInterface), QStringLiteral("ClientCount"));
+        if (!fixtureCall(QStringLiteral("UnregisterGameFixture"), 4242)) {
+            return false;
+        }
+        if (active.metaType().id() != QMetaType::Int || active.toInt() != 1
+            || !waitFor([this] { return unregisteredPid == 4242; })
+            || unregisteredPath != QStringLiteral("/com/feralinteractive/GameMode/Games/4242")) {
+            fail("GameRegistered/GameUnregistered payload or count transition was wrong");
+            return false;
+        }
+        std::puts("PASS 2: GameRegistered and GameUnregistered signals delivered event-first as (i,o)");
+        return true;
+    }
+
+    bool verifyPowerProfiles()
+    {
+        const QVariant initial = readProperty(
+            QString::fromLatin1(ModernService), QString::fromLatin1(ModernPath),
+            QString::fromLatin1(ModernInterface), QStringLiteral("ActiveProfile"));
+        if (initial.metaType().id() != QMetaType::QString || initial.toString() != QStringLiteral("balanced")) {
+            fail("modern ActiveProfile snapshot has the wrong type or value");
+            return false;
+        }
+        if (!fixtureCall(QStringLiteral("SwitchProfileFixture"), QStringLiteral("performance"))) {
+            return false;
+        }
+        if (!waitFor([this] {
+                return eventProfiles.value(QString::fromLatin1(ModernInterface)) == QStringLiteral("performance")
+                    && eventProfiles.value(QString::fromLatin1(LegacyInterface)) == QStringLiteral("performance");
+            })) {
+            fail("ActiveProfile PropertiesChanged was not delivered on both event-first subscriptions");
+            return false;
+        }
+        std::puts("PASS 4: ActiveProfile read and PropertiesChanged switch event are event-first");
+
+        const QVariant profileValue = readProperty(
+            QString::fromLatin1(ModernService), QString::fromLatin1(ModernPath),
+            QString::fromLatin1(ModernInterface), QStringLiteral("Profiles"));
+        const QVariant degraded = readProperty(
+            QString::fromLatin1(ModernService), QString::fromLatin1(ModernPath),
+            QString::fromLatin1(ModernInterface), QStringLiteral("PerformanceDegraded"));
+        const ProfileList advertised = qdbus_cast<ProfileList>(profileValue);
+        bool shapeOkay = advertised.size() == 3;
+        for (const QVariantMap &profile : advertised) {
+            shapeOkay = shapeOkay
+                && profile.value(QStringLiteral("Profile")).metaType().id() == QMetaType::QString;
+        }
+        if (!shapeOkay || degraded.metaType().id() != QMetaType::QString || !degraded.toString().isEmpty()) {
+            fail("Profiles aa{sv} or PerformanceDegraded s shape was wrong");
+            return false;
+        }
+        std::puts("PASS 5: Profiles is aa{sv} and PerformanceDegraded is s");
+
+        const QVariant legacy = readProperty(
+            QString::fromLatin1(LegacyService), QString::fromLatin1(LegacyPath),
+            QString::fromLatin1(LegacyInterface), QStringLiteral("ActiveProfile"));
+        const QVariant modern = readProperty(
+            QString::fromLatin1(ModernService), QString::fromLatin1(ModernPath),
+            QString::fromLatin1(ModernInterface), QStringLiteral("ActiveProfile"));
+        if (legacy.toString() != QStringLiteral("performance")
+            || modern.toString() != QStringLiteral("performance")) {
+            fail("modern and legacy name/path/interface triples do not agree");
+            return false;
+        }
+        std::puts("PASS 6: modern and legacy PowerProfiles name/path/interface triples both answer");
+        return true;
+    }
+
+    bool waitFor(const std::function<bool()> &predicate)
+    {
+        QElapsedTimer timer;
+        timer.start();
+        while (!predicate() && timer.elapsed() < 2000) {
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+            QThread::msleep(5);
+        }
+        return predicate();
+    }
+
+    int fail(const QString &message)
+    {
+        std::fprintf(stderr, "gaming-power-contract: %s\n", qPrintable(message));
+        return 1;
+    }
+
+    int fail(const char *message)
+    {
+        return fail(QString::fromUtf8(message));
+    }
+
+    QDBusConnection bus;
+    QProcess server;
+    qint32 registeredPid = -1;
+    qint32 unregisteredPid = -1;
+    QString registeredPath;
+    QString unregisteredPath;
+    QMap<QString, QString> eventProfiles;
+};
+} // namespace
+
+int main(int argc, char **argv)
+{
+    QCoreApplication app(argc, argv);
+    qDBusRegisterMetaType<ProfileList>();
+    if (app.arguments().contains(QStringLiteral("--mock"))) {
+        QDBusConnection bus = QDBusConnection::sessionBus();
+        GamingPowerMock mock(bus);
+        if (!bus.isConnected()
+            || !bus.registerVirtualObject(QStringLiteral("/"), &mock, QDBusConnection::SubPath)
+            || !bus.registerService(QString::fromLatin1(GameService))
+            || !bus.registerService(QString::fromLatin1(ModernService))
+            || !bus.registerService(QString::fromLatin1(LegacyService))
+            || !bus.registerService(QString::fromLatin1(ControlService))) {
+            std::fputs("gaming-power-contract: mock registration failed\n", stderr);
+            return 1;
+        }
+        return app.exec();
+    }
+    Probe probe(app);
+    return probe.run();
+}
+
+#include "gaming_power_probe.moc"

--- a/tests/gaming-power-contract/run-probe.sh
+++ b/tests/gaming-power-contract/run-probe.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Issue #70 Gaming Performance platform-contract gate.
+# Private mocks run on a disposable session bus. The live section is separate,
+# bounded, and performs only broker owner checks, property reads, and introspection.
+set -euo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+build_dir="$(mktemp -d "${TMPDIR:-/tmp}/nagi-gaming-power.XXXXXX")"
+trap 'rm -rf "$build_dir"' EXIT
+
+moc=""
+for candidate in moc-qt6 /usr/lib64/qt6/libexec/moc /usr/lib/qt6/libexec/moc moc; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        moc="$(command -v "$candidate")"
+        break
+    fi
+done
+if [[ -z "$moc" ]]; then
+    echo "gaming-power-contract: Qt 6 moc not found" >&2
+    exit 1
+fi
+if ! pkg-config --exists Qt6Core Qt6DBus; then
+    echo "gaming-power-contract: Qt6Core and Qt6DBus development files are required" >&2
+    exit 1
+fi
+
+"$moc" "$dir/gaming_power_probe.cpp" -o "$build_dir/gaming_power_probe.moc"
+${CXX:-c++} \
+    -std=c++20 -O2 -Wall -Wextra -Wpedantic \
+    $(pkg-config --cflags Qt6Core Qt6DBus) \
+    -I"$build_dir" \
+    "$dir/gaming_power_probe.cpp" \
+    -o "$build_dir/gaming-power-probe" \
+    $(pkg-config --libs Qt6Core Qt6DBus)
+
+echo "gaming-power-contract: private fixture checks"
+dbus-run-session -- "$build_dir/gaming-power-probe"
+
+echo "gaming-power-contract: bounded read-only live checks"
+
+name_owned() {
+    local bus_flag="$1"
+    local wanted="$2"
+    local listing
+    if ! listing="$(timeout 5 busctl "$bus_flag" call \
+        org.freedesktop.DBus /org/freedesktop/DBus \
+        org.freedesktop.DBus ListNames 2>/dev/null)"; then
+        return 2
+    fi
+    if [[ "$listing" == *"\"$wanted\""* ]]; then
+        return 0
+    fi
+    return 1
+}
+
+owner_pid_readable() {
+    local bus_flag="$1"
+    local wanted="$2"
+    timeout 5 busctl "$bus_flag" call \
+        org.freedesktop.DBus /org/freedesktop/DBus \
+        org.freedesktop.DBus GetConnectionUnixProcessID s "$wanted" \
+        >/dev/null 2>&1
+}
+
+if name_owned --user com.feralinteractive.GameMode; then
+    if owner_pid_readable --user com.feralinteractive.GameMode; then
+        echo "LIVE GameMode: existing owner observed read-only"
+    else
+        echo "LIVE GameMode: owner vanished before broker PID lookup; treated as unavailable"
+    fi
+else
+    result=$?
+    if ((result == 2)); then
+        echo "gaming-power-contract: could not query the live user bus" >&2
+        exit 1
+    fi
+    echo "LIVE GameMode: service absent; no direct service call made"
+fi
+
+live_service=""
+live_path=""
+live_interface=""
+if name_owned --system org.freedesktop.UPower.PowerProfiles; then
+    live_service="org.freedesktop.UPower.PowerProfiles"
+    live_path="/org/freedesktop/UPower/PowerProfiles"
+    live_interface="org.freedesktop.UPower.PowerProfiles"
+else
+    result=$?
+    if ((result == 2)); then
+        echo "gaming-power-contract: could not query the live system bus" >&2
+        exit 1
+    fi
+    if name_owned --system net.hadess.PowerProfiles; then
+        live_service="net.hadess.PowerProfiles"
+        live_path="/net/hadess/PowerProfiles"
+        live_interface="net.hadess.PowerProfiles"
+    else
+        result=$?
+        if ((result == 2)); then
+            echo "gaming-power-contract: could not query the live system bus" >&2
+            exit 1
+        fi
+    fi
+fi
+
+if [[ -z "$live_service" ]]; then
+    echo "PASS 7: live PowerProfiles service absent; no property or introspection call made"
+elif ! owner_pid_readable --system "$live_service"; then
+    echo "PASS 7: live PowerProfiles owner vanished before reads; treated as unavailable"
+else
+    active="$(timeout 5 busctl --system get-property \
+        "$live_service" "$live_path" "$live_interface" ActiveProfile)"
+    timeout 5 busctl --system introspect \
+        "$live_service" "$live_path" "$live_interface" \
+        >/dev/null
+    echo "PASS 7: live $live_service read-only ActiveProfile=$active and one introspection completed"
+fi
+
+echo "gaming-power-contract: all contracts verified"

--- a/tests/ipc-activation/run-probe.sh
+++ b/tests/ipc-activation/run-probe.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Issue #70 gate 3 wrapper: proves same-process singleton activation through
+# `qs ipc call`, that --no-duplicate never activates or duplicates, and that
+# the absent-instance path fails so a desktop entry can fall back to launch.
+set -uo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+log="$(mktemp "${TMPDIR:-/tmp}/nagi-ipc-log.XXXXXX")"
+deadline=$((SECONDS + 60))
+status=0
+pid=""
+
+fail() {
+    echo "ipc-activation: $1" >&2
+    status=1
+}
+
+qs -p "$dir" >"$log" 2>&1 &
+pid=$!
+
+ready=0
+while ((SECONDS < deadline)); do
+    if grep -q 'PROBE READY' "$log" 2>/dev/null; then
+        ready=1
+        break
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+        break
+    fi
+    sleep 0.2
+done
+
+if ((ready != 1)); then
+    fail "probe shell did not become ready"
+fi
+
+reply=""
+if ((status == 0)); then
+    reply="$(qs -p "$dir" ipc call nagi activate desktop-action 2>>"$log")"
+    if [[ "$reply" != "count=1" ]]; then
+        fail "first activation reply was '${reply:-none}', expected count=1"
+    fi
+fi
+
+if ((status == 0)); then
+    duplicate_exit=0
+    timeout 15 qs -p "$dir" --no-duplicate >>"$log" 2>&1 || duplicate_exit=$?
+    if ((duplicate_exit != 0)); then
+        fail "--no-duplicate exited with ${duplicate_exit}"
+    fi
+fi
+
+if ((status == 0)); then
+    reply="$(qs -p "$dir" ipc call nagi activate again 2>>"$log")"
+    if [[ "$reply" != "count=2" ]]; then
+        fail "second activation reply was '${reply:-none}', expected count=2 in the original process"
+    fi
+fi
+
+if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null
+fi
+wait "$pid" 2>/dev/null
+
+if qs -p "$dir" ipc call nagi activate ghost >/dev/null 2>&1; then
+    fail "ipc call succeeded with no running instance; absent-instance fallback would never trigger"
+fi
+
+if ((status != 0)); then
+    tail -n 60 "$log" >&2
+else
+    grep 'PROBE ' "$log"
+    echo "ipc-activation: raise-existing, no-duplicate, and absent-instance contracts verified"
+fi
+
+rm -f "$log"
+exit "$status"

--- a/tests/ipc-activation/shell.qml
+++ b/tests/ipc-activation/shell.qml
@@ -1,0 +1,37 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+// Issue #70 gate 3: same-process singleton activation probe. One root-scope
+// IpcHandler exposes a raise/activate target; an external caller uses the
+// `qs ipc` CLI against the running instance.
+ShellRoot {
+    id: root
+
+    property int activationCount: 0
+
+    function activate(reason: string): string {
+        root.activationCount += 1;
+        console.warn("PROBE ACTIVATED count=" + root.activationCount + " reason=" + reason);
+        return "count=" + root.activationCount;
+    }
+
+    PanelWindow {
+        implicitWidth: 120
+        implicitHeight: 40
+        color: "transparent"
+        visible: false
+    }
+
+    IpcHandler {
+        target: "nagi"
+
+        function activate(reason: string): string {
+            return root.activate(reason);
+        }
+    }
+
+    Component.onCompleted: console.warn("PROBE READY")
+}

--- a/tests/multi-surface/run-probe.sh
+++ b/tests/multi-surface/run-probe.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Issue #70 gate 1 wrapper: runs the multi-surface probe inside a disposable
+# dbus-run-session + kwin_wayland --virtual session created by
+# tests/run-kwin-virtual.sh, then verifies process-wide service uniqueness
+# while the shell is still alive.
+set -uo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+log="$(mktemp "${TMPDIR:-/tmp}/nagi-multi-surface-log.XXXXXX")"
+deadline=$((SECONDS + 120))
+status=1
+finished=0
+
+qs -p "$dir" >"$log" 2>&1 &
+pid=$!
+
+while ((SECONDS < deadline)); do
+    if grep -q 'PROBE DONE' "$log" 2>/dev/null; then
+        finished=1
+        break
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+        break
+    fi
+    sleep 0.2
+done
+
+if ((finished == 1)) && ! grep -q 'PROBE FAIL' "$log"; then
+    owner=$(busctl --user call org.freedesktop.DBus /org/freedesktop/DBus \
+        org.freedesktop.DBus GetConnectionUnixProcessID s org.freedesktop.Notifications \
+        2>/dev/null | tr -dc '0-9')
+    if [[ "$owner" == "$pid" ]]; then
+        status=0
+    else
+        echo "multi-surface: org.freedesktop.Notifications owner is '${owner:-none}', expected probe pid ${pid}" >&2
+    fi
+fi
+
+if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null
+fi
+wait "$pid" 2>/dev/null
+
+if ((status != 0)); then
+    tail -n 60 "$log" >&2
+else
+    grep 'PROBE ' "$log"
+fi
+
+rm -f "$log"
+exit "$status"

--- a/tests/multi-surface/shell.qml
+++ b/tests/multi-surface/shell.qml
@@ -1,0 +1,331 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Services.Notifications
+import QtQuick
+
+// Issue #70 gate 1: multi-PanelWindow contract probe. One process hosts one
+// PanelWindow per connected screen, exercises independent assignment,
+// destruction/recreation, and records observed display identity and scale data.
+// Runs entirely inside tests/run-kwin-virtual.sh disposable sessions.
+ShellRoot {
+    id: root
+
+    readonly property int expectedOutputs: parseInt(Quickshell.env("NAGI_PROBE_OUTPUTS") ?? "2")
+    readonly property int maximumRetryAttempts: 600
+    property int retryAttempts: 0
+    property var surfaces: []
+    property var reassignedFrom: null
+    property var destroyedScreen: null
+    property var reassignedSurface: null
+    property int stepIndex: 0
+
+    function advance() {
+        Qt.callLater(root.runStep);
+    }
+
+    function awaitState(condition, message) {
+        if (condition) {
+            root.retryAttempts = 0;
+            return true;
+        }
+
+        root.retryAttempts += 1;
+        if (root.retryAttempts > root.maximumRetryAttempts) {
+            root.fail(message);
+        }
+        retry.restart();
+        return false;
+    }
+
+    function fail(message) {
+        console.error("PROBE FAIL: " + message);
+        Qt.exit(1);
+    }
+
+    function emit(text) {
+        console.warn("PROBE " + text);
+    }
+
+    function identityDump(screen) {
+        const fields = {};
+        const keys = ["name", "model", "manufacturer", "serialNumber", "width", "height",
+            "physicalWidth", "physicalHeight"];
+        for (let index = 0; index < keys.length; index += 1) {
+            try {
+                const value = screen[keys[index]];
+                if (value !== undefined) {
+                    fields[keys[index]] = String(value);
+                }
+            } catch (error) {
+                fields[keys[index]] = "<unreadable>";
+            }
+        }
+        return JSON.stringify(fields);
+    }
+
+    function connectedScreens() {
+        const found = [];
+        for (let index = 0; index < Quickshell.screens.length; index += 1) {
+            found.push(Quickshell.screens[index]);
+        }
+        return found;
+    }
+
+    function surfaceOn(screen) {
+        for (let index = 0; index < root.surfaces.length; index += 1) {
+            if (root.surfaces[index].screen === screen) {
+                return root.surfaces[index];
+            }
+        }
+        return null;
+    }
+
+    function allSurfacesSettled(screens) {
+        if (root.surfaces.length !== screens.length) {
+            return false;
+        }
+        for (let index = 0; index < root.surfaces.length; index += 1) {
+            const surface = root.surfaces[index];
+            if (!surface.visible || surface.screen === null || surface.contentItem === null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function remainingSurfacesSettled(screens) {
+        if (root.surfaces.length !== screens.length - 1) {
+            return false;
+        }
+        for (let index = 0; index < root.surfaces.length; index += 1) {
+            const surface = root.surfaces[index];
+            if (!surface.visible || surface.screen === null
+                    || !screens.includes(surface.screen)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function othersUnchanged(exceptSurface, screens) {
+        for (let index = 0; index < root.surfaces.length; index += 1) {
+            const surface = root.surfaces[index];
+            if (surface === exceptSurface) {
+                continue;
+            }
+            if (!surface.visible || !screens.includes(surface.screen)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    component ProbeSurface: PanelWindow {
+        id: surface
+
+        color: "transparent"
+
+        Rectangle {
+            anchors.fill: parent
+            color: "#202124"
+
+            Text {
+                anchors.centerIn: parent
+                color: "#e8eaed"
+                text: "probe"
+            }
+        }
+    }
+
+    Component {
+        id: probeSurfaceComponent
+
+        ProbeSurface {}
+    }
+
+    NotificationServer {
+        id: server
+
+        keepOnReload: false
+    }
+
+    Timer {
+        id: retry
+
+        interval: 50
+        onTriggered: root.runStep()
+    }
+
+    Timer {
+        id: settleTimer
+
+        interval: 100
+        onTriggered: root.advance()
+    }
+
+    Component.onCompleted: root.advance()
+
+    function runStep() {
+        switch (root.stepIndex) {
+        case 0:
+            if (!root.awaitState(Quickshell.screens.length === root.expectedOutputs,
+                                 "expected " + root.expectedOutputs + " screens, saw "
+                                     + Quickshell.screens.length)) {
+                return;
+            }
+            root.emit("screens=" + root.expectedOutputs);
+            for (let index = 0; index < Quickshell.screens.length; index += 1) {
+                root.emit("IDENTITY " + root.identityDump(Quickshell.screens[index]));
+            }
+            root.stepIndex = 1;
+            root.advance();
+            return;
+        case 1: {
+            const screens = root.connectedScreens();
+            for (let index = 0; index < screens.length; index += 1) {
+                const surface = probeSurfaceComponent.createObject(root, {
+                                                                       "screen": screens[index],
+                                                                       "visible": true
+                                                                   });
+                surface.objectName = "probe-" + index;
+                root.surfaces.push(surface);
+            }
+            root.stepIndex = 2;
+            settleTimer.restart();
+            return;
+        }
+        case 2:
+            if (!root.awaitState(root.allSurfacesSettled(root.connectedScreens()),
+                                 "surfaces did not settle onto their assigned screens")) {
+                return;
+            }
+            for (let index = 0; index < root.surfaces.length; index += 1) {
+                const surface = root.surfaces[index];
+                if (!root.connectedScreens().includes(surface.screen)) {
+                    root.fail("surface " + surface.objectName + " lost its assigned screen");
+                    return;
+                }
+            }
+            root.emit("ASSIGN one-surface-per-screen OK");
+            root.stepIndex = 3;
+            root.advance();
+            return;
+        case 3: {
+            if (root.expectedOutputs < 2) {
+                root.emit("REASSIGN skipped (single output)");
+                root.stepIndex = 5;
+                root.advance();
+                return;
+            }
+            const screens = root.connectedScreens();
+            root.reassignedSurface = root.surfaceOn(screens[0]);
+            const mover = root.reassignedSurface;
+            if (mover === null) {
+                root.fail("no surface on the first screen");
+                return;
+            }
+            root.reassignedFrom = screens[0];
+            const target = screens[screens.length - 1];
+            if (target === screens[0]) {
+                root.fail("need a distinct target screen");
+                return;
+            }
+            mover.screen = target;
+            root.stepIndex = 4;
+            settleTimer.restart();
+            return;
+        }
+        case 4: {
+            const screens = root.connectedScreens();
+            const target = screens[screens.length - 1];
+            const mover = root.reassignedSurface;
+            if (!root.awaitState(mover !== null && mover.screen === target,
+                                 "moved surface did not follow independent assignment")) {
+                return;
+            }
+            let duplicates = 0;
+            for (let index = 0; index < root.surfaces.length; index += 1) {
+                if (root.surfaces[index].screen === target) {
+                    duplicates += 1;
+                }
+            }
+            if (duplicates !== 2) {
+                root.fail("target screen should host moved + native surfaces, saw " + duplicates);
+                return;
+            }
+            if (!root.othersUnchanged(mover, screens)) {
+                root.fail("unrelated surfaces changed during reassignment");
+                return;
+            }
+            root.emit("REASSIGN independent assignment OK");
+            mover.screen = root.reassignedFrom;
+            root.stepIndex = 5;
+            settleTimer.restart();
+            return;
+        }
+        case 5: {
+            if (root.expectedOutputs < 2) {
+                root.emit("DESTROY skipped (single output)");
+                return;
+            }
+            const screens = root.connectedScreens();
+            const victim = root.surfaces[root.surfaces.length - 1];
+            root.destroyedScreen = victim.screen;
+            root.surfaces.splice(root.surfaces.indexOf(victim), 1);
+            victim.destroy();
+            root.stepIndex = 6;
+            settleTimer.restart();
+            return;
+        }
+        case 6:
+            if (!root.awaitState(root.remainingSurfacesSettled(root.connectedScreens())
+                                     && root.destroyedScreen !== null
+                                     && root.surfaceOn(root.destroyedScreen) === null,
+                                 "remaining surfaces did not survive sibling destruction")) {
+                return;
+            }
+            root.emit("DESTROY sibling survival OK");
+            const replacement = probeSurfaceComponent.createObject(root, {
+                                                                       "screen": root.destroyedScreen,
+                                                                       "visible": true
+                                                                   });
+            replacement.objectName = "probe-replacement";
+            root.surfaces.push(replacement);
+            root.stepIndex = 7;
+            settleTimer.restart();
+            return;
+        case 7:
+            if (!root.awaitState(root.surfaceOn(root.destroyedScreen) !== null
+                                     && root.surfaceOn(root.destroyedScreen).visible,
+                                 "replacement surface did not appear on its screen")) {
+                return;
+            }
+            root.emit("DESTROY recreation OK");
+            root.stepIndex = 8;
+            root.advance();
+            return;
+        case 8:
+            for (let index = 0; index < root.surfaces.length; index += 1) {
+                const surface = root.surfaces[index];
+                const inner = surface.contentItem.children.length > 0
+                              && surface.contentItem.children[0] !== null ? surface.contentItem
+                    .children[0] : null;
+                const dpr = inner !== null ? inner.Screen.devicePixelRatio : 0;
+                root.emit("SCALE surface=" + surface.objectName + " dpr=" + dpr + " window="
+                              + surface.width + "x" + surface.height + " screen="
+                              + (surface.screen === null ? "?" : surface.screen.width + "x"
+                                                         + surface.screen.height));
+            }
+            if (server === null) {
+                root.fail("NotificationServer vanished during surface churn");
+                return;
+            }
+            root.emit("SERVICE notification-server alive after churn");
+            root.emit("DONE");
+            return;
+        default:
+            root.fail("unknown step " + root.stepIndex);
+        }
+    }
+}

--- a/tests/networkmanager-contract/mock_service.py
+++ b/tests/networkmanager-contract/mock_service.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+import sys
+
+import dbus
+import dbus.service
+from dbus.mainloop.glib import DBusGMainLoop
+from gi.repository import GLib
+
+SERVICE = "org.freedesktop.NetworkManager"
+MANAGER_PATH = "/org/freedesktop/NetworkManager"
+MANAGER_IFACE = SERVICE
+DEVICE_PATH = MANAGER_PATH + "/Devices/0"
+DEVICE_IFACE = SERVICE + ".Device"
+WIRELESS_IFACE = DEVICE_IFACE + ".Wireless"
+AP_IFACE = SERVICE + ".AccessPoint"
+ACTIVE_PATH = MANAGER_PATH + "/ActiveConnection/1"
+ACTIVE_IFACE = SERVICE + ".Connection.Active"
+PROFILE_IFACE = SERVICE + ".Settings.Connection"
+PROPERTIES_IFACE = "org.freedesktop.DBus.Properties"
+CONTROL_IFACE = "io.github.Anthodev.NagiShell.NetworkManagerContract"
+USER_PROFILE = MANAGER_PATH + "/Settings/User"
+SYSTEM_PROFILE = MANAGER_PATH + "/Settings/System"
+NO_AGENT_PROFILE = MANAGER_PATH + "/Settings/NoAgent"
+
+
+def variant_dict(values):
+    return dbus.Dictionary(values, signature="sv")
+
+
+class PropertiesObject(dbus.service.Object):
+    @dbus.service.method(PROPERTIES_IFACE, in_signature="ss", out_signature="v")
+    def Get(self, interface, name):
+        try:
+            return self.properties(interface)[name]
+        except KeyError as error:
+            raise dbus.exceptions.DBusException(
+                f"unknown property {interface}.{name}",
+                name="org.freedesktop.DBus.Error.UnknownProperty",
+            ) from error
+
+    @dbus.service.method(PROPERTIES_IFACE, in_signature="s", out_signature="a{sv}")
+    def GetAll(self, interface):
+        return variant_dict(self.properties(interface))
+
+    @dbus.service.signal(PROPERTIES_IFACE, signature="sa{sv}as")
+    def PropertiesChanged(self, interface, changed, invalidated):
+        pass
+
+
+class AccessPoint(PropertiesObject):
+    def __init__(self, bus, path, ssid, strength, flags, wpa_flags, rsn_flags, bssid):
+        super().__init__(bus, path)
+        self.path = path
+        self.ssid = dbus.ByteArray(ssid)
+        self.strength = dbus.Byte(strength)
+        self.flags = dbus.UInt32(flags)
+        self.wpa_flags = dbus.UInt32(wpa_flags)
+        self.rsn_flags = dbus.UInt32(rsn_flags)
+        self.bssid = bssid
+
+    def properties(self, interface):
+        if interface != AP_IFACE:
+            return {}
+        return {
+            "Ssid": self.ssid,
+            "Strength": self.strength,
+            "Flags": self.flags,
+            "WpaFlags": self.wpa_flags,
+            "RsnFlags": self.rsn_flags,
+            "HwAddress": self.bssid,
+            "Frequency": dbus.UInt32(5180),
+            "Mode": dbus.UInt32(2),
+        }
+
+
+class WirelessDevice(PropertiesObject):
+    def __init__(self, bus, access_points):
+        super().__init__(bus, DEVICE_PATH)
+        self.access_points = access_points
+        self.visible_paths = list(access_points)[:3]
+        self.last_scan = dbus.Int64(-1)
+
+    def properties(self, interface):
+        if interface == DEVICE_IFACE:
+            return {
+                "DeviceType": dbus.UInt32(2),
+                "State": dbus.UInt32(30),
+                "ActiveConnection": dbus.ObjectPath("/"),
+            }
+        if interface == WIRELESS_IFACE:
+            return {
+                "AccessPoints": dbus.Array(
+                    [dbus.ObjectPath(path) for path in self.visible_paths], signature="o"
+                ),
+                "LastScan": self.last_scan,
+                "ActiveAccessPoint": dbus.ObjectPath("/"),
+                "Mode": dbus.UInt32(2),
+                "WirelessCapabilities": dbus.UInt32(0x7F),
+            }
+        return {}
+
+    @dbus.service.method(WIRELESS_IFACE, in_signature="a{sv}", out_signature="")
+    def RequestScan(self, options):
+        if "ssid" in options:
+            raise dbus.exceptions.DBusException(
+                "singular ssid option is invalid",
+                name="org.freedesktop.DBus.Error.InvalidArgs",
+            )
+        GLib.timeout_add(20, self._finish_scan)
+
+    def _finish_scan(self):
+        new_path = list(self.access_points)[3]
+        self.visible_paths.append(new_path)
+        self.last_scan = dbus.Int64(424242)
+        self.AccessPointAdded(dbus.ObjectPath(new_path))
+        self.PropertiesChanged(
+            WIRELESS_IFACE,
+            variant_dict(
+                {
+                    "AccessPoints": dbus.Array(
+                        [dbus.ObjectPath(path) for path in self.visible_paths], signature="o"
+                    ),
+                    "LastScan": self.last_scan,
+                }
+            ),
+            dbus.Array([], signature="s"),
+        )
+        return False
+
+    @dbus.service.method(WIRELESS_IFACE, in_signature="", out_signature="ao")
+    def GetAllAccessPoints(self):
+        return dbus.Array(
+            [dbus.ObjectPath(path) for path in self.visible_paths], signature="o"
+        )
+
+    @dbus.service.signal(WIRELESS_IFACE, signature="o")
+    def AccessPointAdded(self, path):
+        pass
+
+
+class ActiveConnection(PropertiesObject):
+    def __init__(self, bus):
+        super().__init__(bus, ACTIVE_PATH)
+        self.state = dbus.UInt32(0)
+
+    def properties(self, interface):
+        return {"State": self.state} if interface == ACTIVE_IFACE else {}
+
+    def transition(self, state, reason):
+        self.state = dbus.UInt32(state)
+        self.StateChanged(self.state, dbus.UInt32(reason))
+        self.PropertiesChanged(
+            ACTIVE_IFACE,
+            variant_dict({"State": self.state}),
+            dbus.Array([], signature="s"),
+        )
+        return False
+
+    @dbus.service.signal(ACTIVE_IFACE, signature="uu")
+    def StateChanged(self, state, reason):
+        pass
+
+
+class Profile(PropertiesObject):
+    def __init__(self, bus, path, user_owned):
+        super().__init__(bus, path)
+        self.user_owned = user_owned
+
+    def properties(self, interface):
+        return {}
+    @dbus.service.method(PROFILE_IFACE, in_signature="", out_signature="a{sa{sv}}")
+    def GetSettings(self):
+        permissions = (
+            dbus.Array(["user:test:"], signature="s")
+            if self.user_owned
+            else dbus.Array([], signature="s")
+        )
+        return dbus.Dictionary(
+            {
+                "connection": variant_dict(
+                    {
+                        "id": "Personal fixture" if self.user_owned else "System fixture",
+                        "type": "802-11-wireless",
+                        "permissions": permissions,
+                    }
+                ),
+                "802-11-wireless-security": variant_dict(
+                    {"key-mgmt": "wpa-psk", "psk-flags": dbus.UInt32(0)}
+                ),
+            },
+            signature="sa{sv}",
+        )
+
+
+    @dbus.service.method(PROFILE_IFACE, in_signature="s", out_signature="a{sa{sv}}")
+    def GetSecrets(self, setting_name):
+        if setting_name != "802-11-wireless-security":
+            return dbus.Dictionary({}, signature="sa{sv}")
+        return dbus.Dictionary(
+            {
+                setting_name: variant_dict(
+                    {"psk": "fixture-passphrase", "psk-flags": dbus.UInt32(0)}
+                )
+            },
+            signature="sa{sv}",
+        )
+
+    @dbus.service.method(PROFILE_IFACE, in_signature="", out_signature="")
+    def Delete(self):
+        if not self.user_owned:
+            raise dbus.exceptions.DBusException(
+                "system profile requires authorization",
+                name="org.freedesktop.NetworkManager.Settings.PermissionDenied",
+            )
+        self.Removed()
+
+    @dbus.service.signal(PROFILE_IFACE, signature="")
+    def Removed(self):
+        pass
+
+
+class Manager(PropertiesObject):
+    def __init__(self, bus, loop, device, active):
+        super().__init__(bus, MANAGER_PATH)
+        self.bus = bus
+        self.loop = loop
+        self.device = device
+        self.active = active
+        self.wireless_enabled = True
+        self.networking_enabled = True
+        self.hidden_shape_valid = False
+
+    def properties(self, interface):
+        if interface != MANAGER_IFACE:
+            return {}
+        return {
+            "WirelessEnabled": dbus.Boolean(self.wireless_enabled),
+            "NetworkingEnabled": dbus.Boolean(self.networking_enabled),
+            "WirelessHardwareEnabled": dbus.Boolean(True),
+            "Version": "1.56.1-fixture",
+        }
+
+    @dbus.service.method(MANAGER_IFACE, in_signature="", out_signature="ao")
+    def GetDevices(self):
+        return dbus.Array([dbus.ObjectPath(DEVICE_PATH)], signature="o")
+
+    @dbus.service.method(MANAGER_IFACE, in_signature="ooo", out_signature="o")
+    def ActivateConnection(self, connection, device, specific_object):
+        if str(connection) == NO_AGENT_PROFILE:
+            raise dbus.exceptions.DBusException(
+                "no Secret Agent returned secrets",
+                name="org.freedesktop.NetworkManager.AgentManager.NoSecrets",
+            )
+        if str(device) != DEVICE_PATH or str(specific_object) not in ("/", *self.device.visible_paths):
+            raise dbus.exceptions.DBusException(
+                "invalid activation target", name="org.freedesktop.DBus.Error.InvalidArgs"
+            )
+        GLib.timeout_add(20, self.active.transition, 1, 1)
+        GLib.timeout_add(40, self.active.transition, 2, 1)
+        return dbus.ObjectPath(ACTIVE_PATH)
+
+    @dbus.service.method(MANAGER_IFACE, in_signature="o", out_signature="")
+    def DeactivateConnection(self, active_connection):
+        if str(active_connection) != ACTIVE_PATH:
+            raise dbus.exceptions.DBusException(
+                "unknown active connection", name="org.freedesktop.DBus.Error.InvalidArgs"
+            )
+        GLib.timeout_add(20, self.active.transition, 3, 2)
+        GLib.timeout_add(40, self.active.transition, 4, 2)
+
+    @dbus.service.method(MANAGER_IFACE, in_signature="a{sa{sv}}oo", out_signature="oo")
+    def AddAndActivateConnection(self, settings, device, specific_object):
+        wireless = settings.get("802-11-wireless", {})
+        connection = settings.get("connection", {})
+        security = settings.get("802-11-wireless-security", {})
+        self.hidden_shape_valid = (
+            str(device) == DEVICE_PATH
+            and str(specific_object) == "/"
+            and bytes(wireless.get("ssid", b"")) == b"Hidden Lab"
+            and bool(wireless.get("hidden", False))
+            and str(wireless.get("mode", "")) == "infrastructure"
+            and str(connection.get("type", "")) == "802-11-wireless"
+            and list(connection.get("permissions", [])) == ["user:test:"]
+            and str(security.get("key-mgmt", "")) == "wpa-psk"
+            and int(security.get("psk-flags", 99)) == 1
+        )
+        return dbus.ObjectPath(USER_PROFILE), dbus.ObjectPath(ACTIVE_PATH)
+
+    @dbus.service.method(CONTROL_IFACE, in_signature="", out_signature="")
+    def ToggleRadios(self):
+        self.wireless_enabled = False
+        self.networking_enabled = False
+        self.PropertiesChanged(
+            MANAGER_IFACE,
+            variant_dict(
+                {
+                    "WirelessEnabled": dbus.Boolean(False),
+                    "NetworkingEnabled": dbus.Boolean(False),
+                }
+            ),
+            dbus.Array([], signature="s"),
+        )
+
+    @dbus.service.method(CONTROL_IFACE, in_signature="", out_signature="b")
+    def HiddenShapeValid(self):
+        return dbus.Boolean(self.hidden_shape_valid)
+
+    @dbus.service.method(CONTROL_IFACE, in_signature="", out_signature="")
+    def Quit(self):
+        GLib.idle_add(self.loop.quit)
+
+
+def main():
+    DBusGMainLoop(set_as_default=True)
+    bus = dbus.SessionBus()
+    loop = GLib.MainLoop()
+    name = dbus.service.BusName(SERVICE, bus=bus, do_not_queue=True)
+    aps = {}
+    specs = [
+        ("/AccessPoint/1", b"Mesh", 42, 1, 0, 0x100, "02:00:00:00:00:01"),
+        ("/AccessPoint/2", b"Mesh", 83, 1, 0, 0x100, "02:00:00:00:00:02"),
+        ("/AccessPoint/3", b"Cafe", 61, 0, 0, 0, "02:00:00:00:00:03"),
+        ("/AccessPoint/4", b"Secure", 70, 1, 0, 0x400, "02:00:00:00:00:04"),
+    ]
+    for suffix, ssid, strength, flags, wpa, rsn, bssid in specs:
+        path = MANAGER_PATH + suffix
+        aps[path] = AccessPoint(bus, path, ssid, strength, flags, wpa, rsn, bssid)
+    device = WirelessDevice(bus, aps)
+    active = ActiveConnection(bus)
+    profiles = [
+        Profile(bus, USER_PROFILE, True),
+        Profile(bus, SYSTEM_PROFILE, False),
+        Profile(bus, NO_AGENT_PROFILE, True),
+    ]
+    manager = Manager(bus, loop, device, active)
+    print("READY", flush=True)
+    loop.run()
+    _keep_alive = (name, manager, device, active, profiles, aps)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/networkmanager-contract/probe.py
+++ b/tests/networkmanager-contract/probe.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+import sys
+import time
+
+import dbus
+from dbus.mainloop.glib import DBusGMainLoop
+from gi.repository import GLib
+
+SERVICE = "org.freedesktop.NetworkManager"
+MANAGER_PATH = "/org/freedesktop/NetworkManager"
+MANAGER_IFACE = SERVICE
+DEVICE_PATH = MANAGER_PATH + "/Devices/0"
+WIRELESS_IFACE = SERVICE + ".Device.Wireless"
+AP_IFACE = SERVICE + ".AccessPoint"
+ACTIVE_PATH = MANAGER_PATH + "/ActiveConnection/1"
+ACTIVE_IFACE = SERVICE + ".Connection.Active"
+PROFILE_IFACE = SERVICE + ".Settings.Connection"
+PROPERTIES_IFACE = "org.freedesktop.DBus.Properties"
+CONTROL_IFACE = "io.github.Anthodev.NagiShell.NetworkManagerContract"
+USER_PROFILE = MANAGER_PATH + "/Settings/User"
+SYSTEM_PROFILE = MANAGER_PATH + "/Settings/System"
+NO_AGENT_PROFILE = MANAGER_PATH + "/Settings/NoAgent"
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def wait_until(predicate, description, timeout=3.0):
+    context = GLib.MainContext.default()
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        while context.pending():
+            context.iteration(False)
+        if predicate():
+            return
+        time.sleep(0.005)
+    raise AssertionError(f"timed out waiting for {description}")
+
+
+def changed_receiver(target, interface, sink):
+    def receive(changed_interface, changed, invalidated):
+        if str(changed_interface) == target:
+            sink.append((dict(changed), list(invalidated)))
+
+    interface.connect_to_signal("PropertiesChanged", receive)
+
+
+def classify_security(flags, wpa_flags, rsn_flags):
+    psk = 0x00000100
+    sae = 0x00000400
+    if rsn_flags & sae:
+        return "WPA3-SAE"
+    if rsn_flags & psk:
+        return "WPA2-PSK"
+    if flags == 0 and wpa_flags == 0 and rsn_flags == 0:
+        return "open"
+    return "secured-other"
+
+
+def secret_flag_semantics(value):
+    labels = []
+    if value == 0:
+        return ["system-owned"]
+    if value & 0x1:
+        labels.append("agent-owned")
+    if value & 0x2:
+        labels.append("not-saved")
+    if value & 0x4:
+        labels.append("not-required")
+    return labels
+
+
+def main():
+    DBusGMainLoop(set_as_default=True)
+    bus = dbus.SessionBus()
+    dbus_daemon = dbus.Interface(
+        bus.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus"),
+        "org.freedesktop.DBus",
+    )
+    require(bool(dbus_daemon.NameHasOwner(SERVICE)), "mock service has no owner")
+
+    manager_object = bus.get_object(SERVICE, MANAGER_PATH)
+    manager = dbus.Interface(manager_object, MANAGER_IFACE)
+    manager_properties = dbus.Interface(manager_object, PROPERTIES_IFACE)
+    control = dbus.Interface(manager_object, CONTROL_IFACE)
+
+    # 1. Initial reads and event-driven radio updates.
+    require(bool(manager_properties.Get(MANAGER_IFACE, "WirelessEnabled")), "wireless read")
+    require(bool(manager_properties.Get(MANAGER_IFACE, "NetworkingEnabled")), "networking read")
+    radio_changes = []
+    changed_receiver(MANAGER_IFACE, manager_properties, radio_changes)
+    control.ToggleRadios()
+    wait_until(lambda: bool(radio_changes), "radio PropertiesChanged")
+    changed = radio_changes[-1][0]
+    require(changed.get("WirelessEnabled") is not None and not bool(changed["WirelessEnabled"]), "wireless event")
+    require(changed.get("NetworkingEnabled") is not None and not bool(changed["NetworkingEnabled"]), "networking event")
+    print("PASS 1 radio properties and PropertiesChanged event", flush=True)
+
+    # 2. RequestScan acknowledges first; completion and AP changes arrive as events.
+    devices = list(manager.GetDevices())
+    require([str(path) for path in devices] == [DEVICE_PATH], "Wi-Fi device enumeration")
+    device_object = bus.get_object(SERVICE, DEVICE_PATH)
+    wireless = dbus.Interface(device_object, WIRELESS_IFACE)
+    device_properties = dbus.Interface(device_object, PROPERTIES_IFACE)
+    scan_changes = []
+    added = []
+    changed_receiver(WIRELESS_IFACE, device_properties, scan_changes)
+    wireless.connect_to_signal("AccessPointAdded", lambda path: added.append(str(path)))
+    require(int(device_properties.Get(WIRELESS_IFACE, "LastScan")) == -1, "initial LastScan")
+    wireless.RequestScan(dbus.Dictionary({}, signature="sv"))
+    require(int(device_properties.Get(WIRELESS_IFACE, "LastScan")) == -1, "scan ack is not completion")
+    wait_until(
+        lambda: any("LastScan" in changed for changed, _ in scan_changes),
+        "LastScan PropertiesChanged",
+    )
+    require(int(device_properties.Get(WIRELESS_IFACE, "LastScan")) == 424242, "scan completion value")
+    require(added == [MANAGER_PATH + "/AccessPoint/4"], "AccessPointAdded")
+    require(any("AccessPoints" in changed for changed, _ in scan_changes), "AccessPoints update")
+    print("PASS 2 RequestScan ack and event-driven AP/LastScan updates", flush=True)
+
+    # 3 and 4. Build the client-side SSID model from individual AP properties.
+    access_points = list(device_properties.Get(WIRELESS_IFACE, "AccessPoints"))
+    groups = {}
+    classifications = {}
+    for path_value in access_points:
+        path = str(path_value)
+        ap_properties = dbus.Interface(bus.get_object(SERVICE, path), PROPERTIES_IFACE)
+        ssid = bytes(ap_properties.Get(AP_IFACE, "Ssid"))
+        strength = int(ap_properties.Get(AP_IFACE, "Strength"))
+        candidate = (strength, path)
+        groups.setdefault(ssid, []).append(candidate)
+        flags = int(ap_properties.Get(AP_IFACE, "Flags"))
+        wpa_flags = int(ap_properties.Get(AP_IFACE, "WpaFlags"))
+        rsn_flags = int(ap_properties.Get(AP_IFACE, "RsnFlags"))
+        classifications[ssid] = classify_security(flags, wpa_flags, rsn_flags)
+    require(len(groups[b"Mesh"]) == 2, "same-SSID BSS candidates were discarded")
+    strongest = max(groups[b"Mesh"])
+    require(strongest == (83, MANAGER_PATH + "/AccessPoint/2"), "strongest BSS selection")
+    print("PASS 3 client groups equal raw SSIDs and keeps strongest AP", flush=True)
+    require(classifications[b"Cafe"] == "open", "open classification")
+    require(classifications[b"Mesh"] == "WPA2-PSK", "WPA2 PSK classification")
+    require(classifications[b"Secure"] == "WPA3-SAE", "WPA3 SAE classification")
+    require(classify_security(1, 0, 0x500) == "WPA3-SAE", "transition SAE capability")
+    print("PASS 4 Flags/WpaFlags/RsnFlags security classification", flush=True)
+
+    # 5. Hidden SSID shape: complete profile, device path, and '/' specific object.
+    settings = dbus.Dictionary(
+        {
+            "connection": dbus.Dictionary(
+                {
+                    "id": "Hidden Lab",
+                    "uuid": "12345678-1234-4234-9234-123456789abc",
+                    "type": "802-11-wireless",
+                    "permissions": dbus.Array(["user:test:"], signature="s"),
+                },
+                signature="sv",
+            ),
+            "802-11-wireless": dbus.Dictionary(
+                {
+                    "ssid": dbus.ByteArray(b"Hidden Lab"),
+                    "hidden": dbus.Boolean(True),
+                    "mode": "infrastructure",
+                },
+                signature="sv",
+            ),
+            "802-11-wireless-security": dbus.Dictionary(
+                {
+                    "key-mgmt": "wpa-psk",
+                    "psk": "fixture-passphrase",
+                    "psk-flags": dbus.UInt32(1),
+                },
+                signature="sv",
+            ),
+        },
+        signature="sa{sv}",
+    )
+    profile_path, active_path = manager.AddAndActivateConnection(
+        settings, dbus.ObjectPath(DEVICE_PATH), dbus.ObjectPath("/")
+    )
+    require(str(profile_path) == USER_PROFILE and str(active_path) == ACTIVE_PATH, "hidden activation result")
+    require(bool(control.HiddenShapeValid()), "hidden connection argument shape")
+    print("PASS 5 hidden SSID AddAndActivateConnection argument shape", flush=True)
+
+    # 6. Secret flag bits, profile GetSecrets, and the no-agent error contract.
+    require(secret_flag_semantics(0) == ["system-owned"], "psk-flags NONE")
+    require(secret_flag_semantics(1) == ["agent-owned"], "psk-flags AGENT_OWNED")
+    require(secret_flag_semantics(2) == ["not-saved"], "psk-flags NOT_SAVED")
+    require(secret_flag_semantics(4) == ["not-required"], "psk-flags NOT_REQUIRED")
+    require(secret_flag_semantics(3) == ["agent-owned", "not-saved"], "combined psk flags")
+    user_profile = dbus.Interface(bus.get_object(SERVICE, USER_PROFILE), PROFILE_IFACE)
+    secrets = user_profile.GetSecrets("802-11-wireless-security")
+    security_secrets = secrets["802-11-wireless-security"]
+    require(str(security_secrets["psk"]) == "fixture-passphrase", "GetSecrets PSK")
+    require(int(security_secrets["psk-flags"]) == 0, "GetSecrets psk-flags")
+    try:
+        manager.ActivateConnection(
+            dbus.ObjectPath(NO_AGENT_PROFILE), dbus.ObjectPath(DEVICE_PATH), dbus.ObjectPath("/")
+        )
+        raise AssertionError("no-agent activation unexpectedly succeeded")
+    except dbus.exceptions.DBusException as error:
+        require(
+            error.get_dbus_name() == "org.freedesktop.NetworkManager.AgentManager.NoSecrets",
+            f"wrong no-agent error: {error.get_dbus_name()}",
+        )
+    print("PASS 6 psk-flags, GetSecrets, and AgentManager.NoSecrets", flush=True)
+
+    # 7. Signal-driven activation/deactivation plus personal/system deletion ownership.
+    active_object = bus.get_object(SERVICE, ACTIVE_PATH)
+    active = dbus.Interface(active_object, ACTIVE_IFACE)
+    active_states = []
+    active.connect_to_signal("StateChanged", lambda state, reason: active_states.append((int(state), int(reason))))
+    returned_active = manager.ActivateConnection(
+        dbus.ObjectPath(USER_PROFILE), dbus.ObjectPath(DEVICE_PATH), dbus.ObjectPath("/")
+    )
+    require(str(returned_active) == ACTIVE_PATH, "ActivateConnection active path")
+    wait_until(lambda: [state for state, _ in active_states][:2] == [1, 2], "activation states")
+    manager.DeactivateConnection(dbus.ObjectPath(ACTIVE_PATH))
+    wait_until(lambda: [state for state, _ in active_states] == [1, 2, 3, 4], "deactivation states")
+    user_permissions = list(user_profile.GetSettings()["connection"]["permissions"])
+    require([str(value) for value in user_permissions] == ["user:test:"], "personal profile permissions")
+    system_profile = dbus.Interface(bus.get_object(SERVICE, SYSTEM_PROFILE), PROFILE_IFACE)
+    system_permissions = list(system_profile.GetSettings()["connection"]["permissions"])
+    require(not system_permissions, "system profile permissions must be empty")
+
+    removed = []
+    user_profile.connect_to_signal("Removed", lambda: removed.append(True))
+    user_profile.Delete()
+    wait_until(lambda: bool(removed), "user profile Removed")
+    try:
+        system_profile.Delete()
+        raise AssertionError("system profile deletion unexpectedly succeeded")
+    except dbus.exceptions.DBusException as error:
+        require(
+            error.get_dbus_name() == "org.freedesktop.NetworkManager.Settings.PermissionDenied",
+            f"wrong system deletion error: {error.get_dbus_name()}",
+        )
+    print("PASS 7 activation lifecycle, Deactivate, and profile ownership", flush=True)
+
+    # 8. Remove the fixture owner; capability detection is a bus-name query, not a crash.
+    control.Quit()
+    wait_until(lambda: not bool(dbus_daemon.NameHasOwner(SERVICE)), "mock owner exit")
+    require(SERVICE not in [str(name) for name in dbus_daemon.ListNames()], "service remained listed")
+    try:
+        bus.call_blocking(
+            SERVICE,
+            MANAGER_PATH,
+            MANAGER_IFACE,
+            "GetDevices",
+            "",
+            (),
+            timeout=1,
+        )
+        raise AssertionError("absent service call unexpectedly succeeded")
+    except dbus.exceptions.DBusException as error:
+        require(
+            error.get_dbus_name()
+            in ("org.freedesktop.DBus.Error.ServiceUnknown", "org.freedesktop.DBus.Error.NameHasNoOwner"),
+            f"unexpected absent-service error: {error.get_dbus_name()}",
+        )
+    print("PASS 8 graceful capability detection when NM has no owner", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as error:
+        print(f"FAIL networkmanager-contract: {error}", file=sys.stderr, flush=True)
+        sys.exit(1)

--- a/tests/networkmanager-contract/run-probe.sh
+++ b/tests/networkmanager-contract/run-probe.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ ${1:-} != "--inside-private-bus" ]]; then
+    root="$(mktemp -d "${TMPDIR:-/tmp}/nagi-networkmanager-contract.XXXXXX")"
+    trap 'rm -rf "$root"' EXIT
+    mkdir -p "$root/home" "$root/config" "$root/data" "$root/state" "$root/cache" "$root/runtime"
+    chmod 700 "$root/runtime"
+    dbus-run-session -- env \
+        HOME="$root/home" \
+        XDG_CONFIG_HOME="$root/config" \
+        XDG_DATA_HOME="$root/data" \
+        XDG_STATE_HOME="$root/state" \
+        XDG_CACHE_HOME="$root/cache" \
+        XDG_RUNTIME_DIR="$root/runtime" \
+        DBUS_SYSTEM_BUS_ADDRESS="unix:path=$root/no-system-bus" \
+        "$0" --inside-private-bus "$root"
+    exit $?
+fi
+
+root=$2
+mock_log="$root/mock.log"
+probe_log="$root/probe.log"
+mock_pid=""
+
+cleanup() {
+    if [[ -n "$mock_pid" ]] && kill -0 "$mock_pid" 2>/dev/null; then
+        kill "$mock_pid" 2>/dev/null || true
+    fi
+    if [[ -n "$mock_pid" ]]; then
+        wait "$mock_pid" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+python3 "$dir/mock_service.py" >"$mock_log" 2>&1 &
+mock_pid=$!
+
+deadline=$((SECONDS + 10))
+while ! grep -qFx READY "$mock_log" 2>/dev/null; do
+    if ! kill -0 "$mock_pid" 2>/dev/null; then
+        cat "$mock_log" >&2
+        echo "networkmanager-contract: mock exited before readiness" >&2
+        exit 1
+    fi
+    if ((SECONDS >= deadline)); then
+        cat "$mock_log" >&2
+        echo "networkmanager-contract: mock readiness timed out" >&2
+        exit 1
+    fi
+    sleep 0.02
+done
+
+if ! timeout 15s python3 "$dir/probe.py" | tee "$probe_log"; then
+    cat "$mock_log" >&2
+    exit 1
+fi
+
+for point in 1 2 3 4 5 6 7 8; do
+    grep -qE "^PASS ${point} " "$probe_log" || {
+        echo "networkmanager-contract: missing PASS line for point ${point}" >&2
+        exit 1
+    }
+done
+[[ $(grep -c '^PASS ' "$probe_log") -eq 8 ]] || {
+    echo "networkmanager-contract: expected exactly eight PASS lines" >&2
+    exit 1
+}
+
+wait "$mock_pid"
+mock_pid=""
+echo "networkmanager-contract: verified on private session bus"

--- a/tests/settings-writer/run-probe.sh
+++ b/tests/settings-writer/run-probe.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Issue #70 gate 5 wrapper: drives the settings writer/watch probe and asserts
+# the resulting filesystem truth (backup bytes, external replacement, symlink
+# disposition).
+set -uo pipefail
+
+root="$(mktemp -d "${TMPDIR:-/tmp}/nagi-settings.XXXXXX")"
+config="$root/config"
+outside="$root/outside"
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+log="$(mktemp "${TMPDIR:-/tmp}/nagi-settings-log.XXXXXX")"
+deadline=$((SECONDS + 60))
+status=0
+pid=""
+
+mkdir -p "$config" "$outside"
+printf '[theme]\nmode=accent\naccent=#FF8800\n' >"$config/legacy.conf"
+printf 'original-secret\n' >"$outside/evil.conf"
+ln -s "$outside/evil.conf" "$config/link.conf"
+
+fail() {
+    echo "settings-writer: $1" >&2
+    status=1
+}
+
+await_line() {
+    local needle=$1
+    while ((SECONDS < deadline)); do
+        if grep -qF "$needle" "$log" 2>/dev/null; then
+            return 0
+        fi
+        if [[ -n "$pid" ]] && ! kill -0 "$pid" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+    grep 'SETTINGS ' "$log" >&2 || true
+    fail "timed out waiting for: $needle"
+    return 1
+}
+
+QT_QPA_PLATFORM='offscreen' XDG_CONFIG_HOME="$config" HOME="$root/home" \
+    mkdir -p "$root/home"
+QT_QPA_PLATFORM='offscreen' XDG_CONFIG_HOME="$config" HOME="$root/home" \
+    qs -p "$dir" >"$log" 2>&1 &
+pid=$!
+
+await_line 'SETTINGS MARKER READY-FOR-MALFORMED'
+
+if ((status == 0)); then
+    printf '[bogus\nthis is not valid\n' >"$config/settings.conf.new"
+    mv -f "$config/settings.conf.new" "$config/settings.conf"
+fi
+
+await_line 'SETTINGS DONE'
+
+if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null
+fi
+wait "$pid" 2>/dev/null
+
+if ! grep -qF 'MIGRATION backed_up=true' "$log"; then
+    fail "migration backup was not written"
+fi
+if ! cmp -s "$config/legacy.conf" "$config/settings.conf.bak"; then
+    fail "backup does not match legacy content byte-for-byte"
+fi
+if ! grep -qE 'LOOPQUIET selfWriteEvents=[1-9] generation=1' "$log"; then
+    fail "own-write reload behavior missing or generation churned"
+fi
+if ! grep -qF 'LASTGOOD kept=true generation=1' "$log"; then
+    fail "malformed replacement did not preserve last-good state"
+fi
+if ! cmp -s "$config/settings.conf" <(printf '[bogus\nthis is not valid\n'); then
+    fail "external malformed replacement was not observed on disk as-is"
+fi
+
+link_kind="missing"
+if [[ -L "$config/link.conf" ]]; then
+    link_kind="symlink"
+elif [[ -f "$config/link.conf" ]]; then
+    link_kind="regular-file"
+fi
+escaped="no"
+grep -q 'escaped-content' "$outside/evil.conf" 2>/dev/null && escaped="yes"
+
+if ((status == 0)); then
+    grep -E 'SETTINGS (MIGRATION|LOOPQUIET|LASTGOOD|SYMLINK|SERVICE|WROTE)' "$log"
+    echo "settings-writer: verified (link disposition=${link_kind}, escaped=${escaped})"
+fi
+
+rm -f "$log"
+rm -rf "$root"
+exit "$status"

--- a/tests/settings-writer/shell.qml
+++ b/tests/settings-writer/shell.qml
@@ -1,0 +1,244 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+// Issue #70 gate 5: settings writer/watch path probe. Proves private atomic
+// replacement, migration backup, own-write reload without generation churn,
+// last-good retention on malformed external content, and the filesystem
+// effect of atomicWrites over a symlink.
+ShellRoot {
+    id: root
+
+    readonly property string configHome: {
+        const xdgHome = Quickshell.env("XDG_CONFIG_HOME") ?? "";
+        return xdgHome !== "" ? xdgHome : (Quickshell.env("HOME") ?? "") + "/.config";
+    }
+    readonly property string settingsPath: configHome + "/settings.conf"
+    readonly property string legacyPath: configHome + "/legacy.conf"
+    readonly property string backupPath: configHome + "/settings.conf.bak"
+    readonly property string linkPath: configHome + "/link.conf"
+    readonly property int maximumRetryAttempts: 600
+
+    property int retryAttempts: 0
+    property int stepIndex: 0
+    property int generation: 0
+    property string normalized: ""
+    property int selfWriteEvents: 0
+
+    function advance() {
+        Qt.callLater(root.runStep);
+    }
+
+    function awaitState(condition, message) {
+        if (condition) {
+            root.retryAttempts = 0;
+            return true;
+        }
+        root.retryAttempts += 1;
+        if (root.retryAttempts > root.maximumRetryAttempts) {
+            root.fail(message);
+        }
+        retry.restart();
+        return false;
+    }
+
+    function fail(message) {
+        console.error("SETTINGS FAIL: " + message);
+        Qt.exit(1);
+    }
+
+    function emit(text) {
+        console.warn("SETTINGS " + text);
+    }
+
+    function parse(content) {
+        // Strict bounded parser: exactly one [theme] section with one key.
+        const lines = content.replace(/\r?\n$/, "").split(/\r?\n/);
+        if (lines.length !== 2 || lines[0] !== "[theme]" || !lines[1].startsWith("mode=")) {
+            return null;
+        }
+        return lines[1].slice(5).trim() === "wallpaper" ? "wallpaper" : null;
+    }
+
+    function publish(candidate) {
+        if (candidate === null) {
+            return false;
+        }
+        if (candidate === root.normalized) {
+            return true;
+        }
+        root.normalized = candidate;
+        root.generation += 1;
+        return true;
+    }
+
+    Timer {
+        id: retry
+
+        interval: 50
+        onTriggered: root.runStep()
+    }
+
+    Timer {
+        id: quietWindow
+
+        interval: 800
+        onTriggered: root.advance()
+    }
+
+    Component.onCompleted: root.advance()
+
+    function runStep() {
+        switch (root.stepIndex) {
+        case 0:
+            if (!root.awaitState(legacyLoader.loaded || !legacyLoader.path,
+                                 "legacy file was never inspected")) {
+                return;
+            }
+            root.emit("MIGRATION legacy_present=" + legacyLoader.loaded);
+            if (legacyLoader.loaded) {
+                backupWriter.setText(legacyLoader.text());
+                return;
+            }
+            root.stepIndex = 1;
+            root.advance();
+            return;
+        case 1:
+            mainFile.path = root.settingsPath;
+            root.stepIndex = 2;
+            root.advance();
+            return;
+        case 2:
+            if (!root.awaitState(mainFile.loaded || root.loadFailed,
+                                 "settings path was never resolved")) {
+                return;
+            }
+            root.selfWriteEvents = 0;
+            mainFile.setText("[theme]\nmode=wallpaper\n");
+            root.stepIndex = 3;
+            root.advance();
+            return;
+        case 3:
+            if (!root.awaitState(root.normalized === "wallpaper" && root.generation === 1,
+                                 "first write did not normalize")) {
+                return;
+            }
+            root.stepIndex = 4;
+            quietWindow.restart();
+            return;
+        case 4:
+            root.emit("LOOPQUIET selfWriteEvents=" + root.selfWriteEvents
+                          + " generation=" + root.generation);
+            root.emit("MARKER READY-FOR-MALFORMED");
+            root.stepIndex = 5;
+            root.advance();
+            return;
+        case 5:
+            if (!root.awaitState(mainFile.loaded && root.normalized === "wallpaper"
+                                     && root.generation === 1
+                                     && parse(mainFile.text()) === null,
+                                 "malformed replacement was not observed")) {
+                return;
+            }
+            root.emit("LASTGOOD kept=true generation=" + root.generation);
+            root.emit("MARKER READY-FOR-SYMLINK");
+            symlinkProbe.path = root.linkPath;
+            root.stepIndex = 6;
+            root.advance();
+            return;
+        case 6:
+            if (!root.awaitState(symlinkProbe.path === root.linkPath,
+                                 "symlink probe never attached")) {
+                return;
+            }
+            symlinkProbe.setText("escaped-content\n");
+            root.stepIndex = 7;
+            return;
+        case 7:
+            if (!root.awaitState(symlinkResult !== "",
+                                 "symlink write never completed")) {
+                return;
+            }
+            root.emit("SERVICE generation=" + root.generation);
+            root.emit("DONE");
+            return;
+        default:
+            root.fail("unknown step " + root.stepIndex);
+        }
+    }
+
+    property string symlinkResult: ""
+
+    FileView {
+        id: legacyLoader
+
+        path: root.legacyPath
+        preload: true
+        printErrors: false
+    }
+
+    FileView {
+        id: backupWriter
+
+        path: root.backupPath
+        atomicWrites: true
+        printErrors: false
+
+        onSaved: {
+            root.emit("MIGRATION backed_up=true");
+            root.stepIndex = 1;
+            root.advance();
+        }
+        onSaveFailed: root.fail("migration backup write failed")
+    }
+
+    FileView {
+        id: mainFile
+
+        path: ""
+        watchChanges: true
+        atomicWrites: true
+        printErrors: false
+
+        onFileChanged: {
+            root.selfWriteEvents += 1;
+            console.warn("SETTINGS EVENT fileChanged=" + root.selfWriteEvents);
+            reload();
+        }
+        onLoaded: {
+            const candidate = parse(text());
+            root.publish(candidate);
+            console.warn("SETTINGS LOADED parsed=" + (candidate ?? "null"));
+        }
+        onSaved: {
+            const candidate = parse(text());
+            root.publish(candidate);
+            console.warn("SETTINGS SAVED parsed=" + (candidate ?? "null"));
+        }
+        onLoadFailed: function (error) {
+            root.loadFailed = true;
+            console.warn("SETTINGS LOADFAILED error=" + error);
+        }
+    }
+
+    FileView {
+        id: symlinkProbe
+
+        path: ""
+        atomicWrites: true
+        printErrors: false
+
+        onSaved: {
+            root.symlinkResult = "saved";
+            root.advance();
+        }
+        onSaveFailed: {
+            root.symlinkResult = "failed";
+            root.advance();
+        }
+    }
+    property bool loadFailed: false
+}
+

--- a/tests/wallpaper-write-contract/mock_plasmashell.py
+++ b/tests/wallpaper-write-contract/mock_plasmashell.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Issue #70 gate 9 mock: a deliberately limited org.kde.plasmashell fixture.
+
+Models only the documented scripting surface (evaluateScript(s)->s plus the
+observed wallpaper(u)/setWallpaper/wallpaperChanged shapes) with sequential,
+non-transactional containment writes, matching Plasma 6.7.4 source behavior.
+"""
+import json
+import os
+
+import dbus
+import dbus.service
+from dbus.mainloop.glib import DBusGMainLoop
+
+dbus.set_default_main_loop(DBusGMainLoop(set_as_default=True))
+
+PLUGIN_AVAILABLE = os.environ.get("MOCK_IMAGE_PLUGIN", "1") == "1"
+SESSION_FILE = os.environ.get("MOCK_STATE_FILE", "/tmp/mock-wallpaper-state.json")
+
+
+class Containment:
+    def __init__(self, activity, screen, plugin, image):
+        self.activity = activity
+        self.screen = screen
+        self.plugin = plugin
+        self.config = {"Image": image} if plugin else {}
+
+
+STATE = {
+    "activities": ["act1", "act2"],
+    "current": "act1",
+    "known_plugins": {"org.kde.image": "/usr/share/wallpapers"} if PLUGIN_AVAILABLE else {},
+    "containments": [
+        Containment("act1", 0, "org.kde.image", "file:///usr/share/wallpapers/old-a.png"),
+        Containment("act1", 1, "org.kde.potd", ""),
+        Containment("act2", 0, "org.kde.image", "file:///usr/share/wallpapers/other-activity.png"),
+    ],
+}
+
+
+def save_state():
+    import json
+    data = {
+        "containments": [
+            {
+                "activity": c.activity,
+                "screen": c.screen,
+                "plugin": c.plugin,
+                "config": dict(c.config),
+            }
+            for c in STATE["containments"]
+        ]
+    }
+    with open(SESSION_FILE, "w") as handle:
+        json.dump(data, handle)
+
+
+class PlasmaShellMock(dbus.service.Object):
+    def __init__(self, connection):
+        self.bus = connection
+        super().__init__(connection, "/PlasmaShell")
+
+    def current_containments(self):
+        return [c for c in STATE["containments"] if c.activity == STATE["current"]]
+
+    @dbus.service.method("org.kde.PlasmaShell", in_signature="u", out_signature="a{sv}")
+    def Wallpaper(self, screen):  # noqa: N802 - D-Bus member name
+        for containment in self.current_containments():
+            if containment.screen == screen:
+                result = {"wallpaperPlugin": containment.plugin}
+                if containment.plugin == "org.kde.image" and containment.config.get("Image"):
+                    result["Image"] = containment.config["Image"]
+                return result
+        return {}
+
+    @dbus.service.method("org.kde.PlasmaShell", in_signature="sa{sv}u", out_signature="")
+    def SetWallpaper(self, plugin, parameters, screen):  # noqa: N802
+        for containment in self.current_containments():
+            if containment.screen == screen:
+                containment.plugin = plugin
+                if "Image" in parameters:
+                    containment.config["Image"] = str(parameters["Image"])
+        self.WallpaperChanged(screen)
+
+    @dbus.service.signal("org.kde.PlasmaShell", signature="u")
+    def WallpaperChanged(self, screen):  # noqa: N802
+        pass
+
+    @dbus.service.method(
+        "org.kde.PlasmaShell", in_signature="s", out_signature="s",
+        sender_keyword="sender")
+    def EvaluateScript(self, script, sender=None):  # noqa: N802
+        output = []
+        lines = [line.strip() for line in script.splitlines() if line.strip()]
+        # Recognize ONLY the generated grammar; anything else is a script error.
+        for line in lines:
+            if line.startswith("throw "):
+                raise dbus.DBusException(
+                    "Injected script failure",
+                    name="org.freedesktop.DBus.Error.Failed")
+        applied = []
+        for containment in self.current_containments():
+            if "knownWallpaperPlugins()" in "".join(lines):
+                if "org.kde.image" not in STATE["known_plugins"]:
+                    raise dbus.DBusException(
+                        "Required wallpaper plugin unavailable: org.kde.image",
+                        name="org.freedesktop.DBus.Error.Failed")
+            target = None
+            for line in lines:
+                if line.startswith("const image ="):
+                    image = line.split("'", 2)[1]
+                elif line == "throw new Error('injected-after-first-screen');" and applied:
+                    raise dbus.DBusException(
+                        "Injected script failure",
+                        name="org.freedesktop.DBus.Error.Failed")
+                elif line.startswith("desktop.wallpaperPlugin ="):
+                    plugin = line.split("=", 1)[1].strip().rstrip(";").strip("'")
+                    containment.plugin = plugin
+                    target = containment
+                elif line.startswith("desktop.writeConfig('Image',") and target is not None:
+                    containment.config["Image"] = image
+                    applied.append(containment.screen)
+                elif line.startswith("print('requested screen="):
+                    output.append(f"requested screen={containment.screen}")
+                elif line.startswith("print(desktop.screen"):
+                    output.append(
+                        f"screen={containment.screen} plugin={containment.plugin} "
+                        f"image={containment.config.get('Image', '')}"
+                    )
+        save_state()
+        return "\n".join(output)
+
+
+def main():
+    override = os.environ.get("MOCK_PRESEED")
+    if override:
+        seeded = json.loads(override)
+        STATE["containments"] = [
+            Containment(c["activity"], c["screen"], c["plugin"], c.get("image", ""))
+            for c in seeded
+        ]
+    save_state()
+    bus = dbus.SessionBus()
+    name = dbus.service.BusName("org.kde.plasmashell", bus)
+    PlasmaShellMock(bus)
+    from gi.repository import GLib
+
+    GLib.MainLoop().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/wallpaper-write-contract/probe.py
+++ b/tests/wallpaper-write-contract/probe.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Issue #70 gate 9 client probe: exercises the documented evaluateScript
+wallpaper write path against the private mock and classifies every outcome."""
+import os
+import sys
+
+import dbus
+
+PASS = []
+FAIL = []
+
+
+def record(number, ok, detail):
+    (PASS if ok else FAIL).append(detail)
+    prefix = "PASS" if ok else "FAIL"
+    print(f"{prefix} {number}: {detail}", flush=True)
+
+
+WRITE_TEMPLATE = """\
+const plugin = 'org.kde.image';
+const image = '%(image)s';
+const available = knownWallpaperPlugins();
+if (!Object.prototype.hasOwnProperty.call(available, plugin)) %(guard)s
+for (const desktop of desktopsForActivity(currentActivity())) {
+    desktop.wallpaperPlugin = plugin;
+    desktop.currentConfigGroup = ['Wallpaper', plugin, 'General'];
+    desktop.writeConfig('Image', image);
+    desktop.reloadConfig();
+    print('requested screen=' + desktop.screen);
+}
+"""
+
+READBACK_SCRIPT = """\
+for (const desktop of desktopsForActivity(currentActivity())) {
+    desktop.currentConfigGroup = ['Wallpaper', 'org.kde.image', 'General'];
+    print(desktop.screen, desktop.wallpaperPlugin, desktop.readConfig('Image', ''));
+}
+"""
+
+
+def call_evaluate(script):
+    bus = dbus.SessionBus()
+    shell = bus.get_object("org.kde.plasmashell", "/PlasmaShell")
+    return shell.EvaluateScript(script, dbus_interface="org.kde.PlasmaShell")
+
+
+def readback():
+    return call_evaluate(READBACK_SCRIPT)
+
+
+def main():
+    image_url = "file:///tmp/nagi-wallpaper-target.jpg"
+
+    # 1. All-screens write on the current activity + fresh readback.
+    try:
+        reply = call_evaluate(WRITE_TEMPLATE % {"image": image_url, "guard": "{ throw new Error(plugin); }"})
+        wrote_two = reply.count("requested screen=") == 2
+        back = readback()
+        ok = wrote_two and back.count(image_url) >= 2
+        record(1, ok, f"all-screens write+readback (reply_lines={reply.count(chr(10)) + 1}, readback_has_image={ok})")
+    except dbus.DBusException as error:
+        record(1, False, f"all-screens write raised {error.get_dbus_name()}")
+
+    # 2. Mixed current state: other activity stays untouched.
+    state = open(os.environ["MOCK_STATE_FILE"]).read()
+    record(2, "other-activity.png" in state and image_url in state,
+           "mixed state: non-current activity containment untouched")
+
+    # 3. Missing-file URL accepted as configuration (renderer success unprovable here).
+    ghost = "file:///nonexistent/ghost.png"
+    try:
+        call_evaluate(WRITE_TEMPLATE % {"image": ghost, "guard": "{ throw new Error(plugin); }"})
+        back = readback()
+        record(3, ghost in back, "nonexistent image URL stored as string without validation")
+    except dbus.DBusException as error:
+        record(3, False, f"ghost URL write raised {error.get_dbus_name()}")
+
+    # 4. Sequential partial failure: earlier writes persist, outcome indeterminate.
+    partial = WRITE_TEMPLATE % {"image": image_url, "guard": "{ throw new Error(plugin); }"}
+    partial += "throw new Error('injected-after-first-screen');\n"
+    partial = partial.replace(
+        "for (const desktop of desktopsForActivity(currentActivity())) {",
+        "let seen = 0;\nfor (const desktop of desktopsForActivity(currentActivity())) {\n    seen += 1;\n    if (seen > 1) throw new Error('injected');",
+        1)
+    try:
+        call_evaluate(partial)
+        record(4, False, "injected mid-loop failure did not surface as D-Bus error")
+    except dbus.DBusException as error:
+        failed = error.get_dbus_name() == "org.freedesktop.DBus.Error.Failed"
+        persisted = image_url in readback() or ghost in readback()
+        record(4, failed and persisted,
+               f"partial failure classified (error={error.get_dbus_name()}, earlier_writes_persisted={persisted})")
+
+    # 5. Preflight guard: unavailable plugin makes the script itself fail closed.
+    if os.environ.get("MOCK_IMAGE_PLUGIN", "1") != "1":
+        try:
+            call_evaluate(WRITE_TEMPLATE % {"image": image_url, "guard": "{ throw new Error(plugin); }"})
+            record(5, False, "preflight guard did not stop execution without org.kde.image")
+        except dbus.DBusException as error:
+            record(5, True, f"preflight plugin guard failed closed ({error.get_dbus_name()})")
+
+    print(f"SUMMARY pass={len(PASS)} fail={len(FAIL)}", flush=True)
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/wallpaper-write-contract/run-probe.sh
+++ b/tests/wallpaper-write-contract/run-probe.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Issue #70 gate 9 wrapper: private-session wallpaper write/readback probe.
+# Phases exercise the documented evaluateScript path against the limited
+# mock (plugin present, plugin absent) and absent-service classification.
+# No host mutation.
+set -uo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(mktemp -d "${TMPDIR:-/tmp}/nagi-wallpaper-write.XXXXXX")"
+status=0
+
+cleanup() {
+    rm -rf "$root"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "wallpaper-write-contract: $1" >&2
+    status=1
+}
+
+preseed='[{"activity":"act1","screen":0,"plugin":"org.kde.image","image":"file:///old-a.png"},{"activity":"act1","screen":1,"plugin":"org.kde.potd","image":""},{"activity":"act2","screen":0,"plugin":"org.kde.image","image":"file:///other-activity.png"}]'
+
+phase() {
+    local plugin_enabled=$1
+    local probe_filter=$2
+    SCRIPT_DIR="$dir" ROOT="$root" PLUGIN_ENABLED="$plugin_enabled" \
+        PRESEED="$preseed" STATE_FILE="$root/state-$plugin_enabled.json" \
+        dbus-run-session -- bash -c '
+            export XDG_CONFIG_HOME="$ROOT/config" XDG_DATA_HOME="$ROOT/data" \
+                XDG_CACHE_HOME="$ROOT/cache" XDG_STATE_HOME="$ROOT/state" \
+                HOME="$ROOT/home"
+            mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$HOME"
+            export MOCK_STATE_FILE="$STATE_FILE" MOCK_PRESEED="$PRESEED" MOCK_IMAGE_PLUGIN="$PLUGIN_ENABLED"
+            python3 "$SCRIPT_DIR/mock_plasmashell.py" & mock=$!
+            sleep 1
+            python3 "$SCRIPT_DIR/probe.py"; rc=$?
+            kill $mock 2>/dev/null
+            exit $rc
+        '
+}
+
+absent_phase() {
+    dbus-run-session -- bash -c '
+        export XDG_RUNTIME_DIR='"$root"'/runtime-absent
+        mkdir -p "$XDG_RUNTIME_DIR"; chmod 0700 "$XDG_RUNTIME_DIR"
+        python3 - <<PYEOF
+import dbus
+try:
+    bus = dbus.SessionBus()
+    bus.get_object("org.kde.plasmashell", "/PlasmaShell").EvaluateScript(
+        "print(1)", dbus_interface="org.kde.PlasmaShell")
+    print("FAIL 6: absent-service call unexpectedly succeeded")
+except dbus.DBusException as error:
+    name = error.get_dbus_name()
+    ok = name in (
+        "org.freedesktop.DBus.Error.ServiceUnknown",
+        "org.freedesktop.DBus.Error.NameHasNoOwner",
+    )
+    print(("PASS" if ok else "FAIL") + f" 6: absent service classified ({name})")
+PYEOF
+    '
+}
+
+out="$(phase 1 '1|2|3|4')" || fail "main phase exited nonzero"
+out_guard="$(phase 0 '5')" || true
+out_absent="$(absent_phase)" || true
+
+printf '%s\n' "$out" "$out_guard" "$out_absent"
+
+all_out="$out
+$out_guard
+$out_absent"
+passes=$(printf '%s\n' "$all_out" | grep -c '^PASS ' || true)
+fails=$(printf '%s\n' "$out" "$out_absent" | grep -c '^FAIL ' || true)
+if ((fails > 0)); then
+    fail "${fails} main-phase contract point(s) failed"
+fi
+if ((passes < 6)); then
+    fail "expected at least 6 PASS lines, saw ${passes}"
+fi
+
+echo "wallpaper-write-contract: ${passes} verified, ${fails} failed (renderer success remains a real-Plasma-only gap)"
+exit "$status"


### PR DESCRIPTION
Add eight retained contract-probe suites gating downstream
configurable-shell work (#71-#80):

- multi-surface PanelWindow lifecycle and IpcHandler singleton
  activation under virtual KWin (tests/multi-surface/,
  tests/ipc-activation/)
- event-first kdeglobals appearance observation and FileView
  settings-writer semantics incl. symlink-follow hazard
  (tests/appearance-watcher/, tests/settings-writer/)
- private dbus-run-session fixtures for NetworkManager, BlueZ
  scoped-agent routing, GameMode/PowerProfiles, and Plasma
  evaluateScript wallpaper writes
- wire every probe into `make check`; verified contracts and
  binding decisions are recorded in ADRs 0013-0016 and
  docs/reports/issue70-platform-contracts.md (kept local per
  .gitignore policy)

Closes #70