### PR TITLE
feat(core)!: add multi-island orchestration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ AUDIO_TEST_DIR := $(BUILD_DIR)/audio-test
 AUDIO_LIVE_TEST_DIR := $(BUILD_DIR)/audio-live-test
 AUDIO_LIVE_WRITE_TEST_DIR := $(BUILD_DIR)/audio-live-write-test
 SURFACE_STATE_TEST_DIR := $(BUILD_DIR)/surface-state-test
+DISPLAY_TEST_DIR := $(BUILD_DIR)/display-orchestration-test
 UI_PRIMITIVES_TEST_DIR := $(BUILD_DIR)/ui-primitives-test
 POLKIT_UI_TEST_DIR := $(BUILD_DIR)/polkit-ui-test
 DASHBOARD_TEST_DIR := $(BUILD_DIR)/dashboard-test
@@ -88,6 +89,11 @@ NOTIFICATION_MODULE_DIR := $(BUILD_DIR)/qml/Nagi/Notifications
 NOTIFICATION_PLUGIN := $(NOTIFICATION_MODULE_DIR)/libnaginotificationsplugin.so
 NOTIFICATION_RUNTIME_MOC := $(NOTIFICATION_BUILD_DIR)/moc_runtime.cpp
 NOTIFICATION_PLUGIN_MOC := $(NOTIFICATION_BUILD_DIR)/plugin.moc
+PLATFORM_BUILD_DIR := $(BUILD_DIR)/platform
+PLATFORM_MODULE_DIR := $(BUILD_DIR)/qml/Nagi/Platform
+PLATFORM_PLUGIN := $(PLATFORM_MODULE_DIR)/libnagiplatformplugin.so
+PLATFORM_PLUGIN_MOC := $(PLATFORM_BUILD_DIR)/plugin.moc
+PLATFORM_ROUTER_MOC := $(PLATFORM_BUILD_DIR)/moc_pointer_router.cpp
 NOTIFICATION_TEST := $(BUILD_DIR)/notification-runtime-test
 NOTIFICATION_TEST_MOC := $(NOTIFICATION_BUILD_DIR)/notification_runtime_test.moc
 NOTIFICATION_DBUS_TEST := $(BUILD_DIR)/notification-dbus-test
@@ -105,6 +111,8 @@ QT_CFLAGS := $(shell $(PKG_CONFIG) --cflags Qt6Core Qt6DBus)
 QT_LIBS := $(shell $(PKG_CONFIG) --libs Qt6Core Qt6DBus)
 NOTIFICATION_QT_CFLAGS := $(shell $(PKG_CONFIG) --cflags Qt6Core Qt6DBus Qt6Qml)
 NOTIFICATION_QT_LIBS := $(shell $(PKG_CONFIG) --libs Qt6Core Qt6DBus Qt6Qml)
+PLATFORM_QT_CFLAGS := $(shell $(PKG_CONFIG) --cflags Qt6Core Qt6Gui Qt6Qml)
+PLATFORM_QT_LIBS := $(shell $(PKG_CONFIG) --libs Qt6Core Qt6Gui Qt6Qml)
 TRAY_QT_CFLAGS := $(shell $(PKG_CONFIG) --cflags Qt6Core Qt6Gui Qt6Widgets)
 TRAY_QT_LIBS := $(shell $(PKG_CONFIG) --libs Qt6Core Qt6Gui Qt6Widgets)
 PIPEWIRE_CFLAGS := $(shell $(PKG_CONFIG) --cflags libpipewire-0.3)
@@ -120,7 +128,7 @@ QUICKSHELL_CHANNEL := stable
 FEDORA_QUICKSHELL_COPR := errornointernet/quickshell
 FEDORA_QUICKSHELL_PACKAGE := quickshell
 
-.PHONY: help requirements prepare check-quickshell check-helper-toolchain check-audio-toolchain check-application-toolchain check-global-shortcut-toolchain check-notification-toolchain check-tray-toolchain helper audio-helper connectivity-helper brightness-helper session-helper application-helper global-shortcut-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-brightness-dbus test-brightness test-brightness-live-write test-session-dbus test-session test-applications test-launcher test-global-shortcut test-notifications test-adapter test-coordinator test-transients test-weather test-media test-audio test-audio-live test-audio-live-write test-connectivity test-connectivity-live-write test-tray test-tray-live test-idle test-surface-state test-ui-primitives check-nondisplay check format format-check lint-advisory launch diagnose instances logs logs-follow stop
+.PHONY: help requirements prepare check-quickshell check-helper-toolchain check-audio-toolchain check-application-toolchain check-global-shortcut-toolchain check-notification-toolchain check-platform-toolchain check-tray-toolchain helper audio-helper connectivity-helper brightness-helper session-helper application-helper global-shortcut-helper notification-plugin platform-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-brightness-dbus test-brightness test-brightness-live-write test-session-dbus test-session test-applications test-launcher test-global-shortcut test-notifications test-adapter test-coordinator test-transients test-weather test-media test-audio test-audio-live test-audio-live-write test-connectivity test-connectivity-live-write test-tray test-tray-live test-surface-state test-ui-primitives test-idle test-dashboard test-polkit-ui test-theme-config test-onboarding test-icons test-subview-frame test-typography test-global-shortcut-live test-multi-surface test-ipc-activation test-appearance-watcher test-settings-writer test-networkmanager-contract test-bluez-contract test-gaming-power-contract test-wallpaper-write-contract format format-check lint-advisory launch diagnose instances logs logs-follow stop check check-nondisplay clean
 .PHONY: test-dashboard
 .PHONY: test-polkit-ui
 .PHONY: test-theme-config
@@ -131,6 +139,7 @@ FEDORA_QUICKSHELL_PACKAGE := quickshell
 .PHONY: test-typography
 .PHONY: test-global-shortcut-live
 .PHONY: test-multi-surface
+.PHONY: test-display-orchestration
 .PHONY: test-ipc-activation
 .PHONY: test-appearance-watcher
 .PHONY: test-settings-writer
@@ -150,6 +159,7 @@ help:
 		'make application-helper  Build desktop-entry and persistence bridge' \
 		'make global-shortcut-helper  Build the KF6 KGlobalAccel global shortcut helper' \
 		'make notification-plugin  Build the process-scoped notification runtime' \
+		'make platform-plugin  Build the pointer-to-live-surface routing bridge' \
 		'make wallpaper-helper  Build the read-only Plasma wallpaper palette helper' \
 		'make test-native     Test KWin tuple normalization' \
 		'make test-owner-lifecycle  Test KWin owner loss and replacement' \
@@ -173,6 +183,7 @@ help:
 		'make test-coordinator  Test island ownership and restoration' \
 		'make test-transients  Test workspace, brightness, audio, and notification routing' \
 		'make test-surface-state  Exercise the actual island surface in isolated virtual KWin' \
+		'make test-display-orchestration  Test live multi-island display routing and visibility' \
 		'make test-weather    Test compact clock and weather adapter state' \
 		'make test-media      Test the MPRIS media adapter state' \
 		'make test-audio      Test the PipeWire audio adapter state' \
@@ -215,6 +226,7 @@ requirements:
 	@$(MAKE) --no-print-directory check-global-shortcut-toolchain
 	@$(MAKE) --no-print-directory check-notification-toolchain
 	@$(MAKE) --no-print-directory check-wallpaper-toolchain
+	@$(MAKE) --no-print-directory check-platform-toolchain
 	@$(MAKE) --no-print-directory check-tray-toolchain
 
 prepare:
@@ -242,6 +254,10 @@ check-notification-toolchain:
 	@$(PKG_CONFIG) --exists Qt6Core Qt6DBus Qt6Qml
 	@test -x '$(MOC)'
 
+check-platform-toolchain:
+	@$(PKG_CONFIG) --exists Qt6Core Qt6Gui Qt6Qml
+	@test -x '$(MOC)'
+
 check-tray-toolchain:
 	@$(PKG_CONFIG) --exists Qt6Core Qt6Gui Qt6Widgets
 
@@ -253,6 +269,12 @@ $(NOTIFICATION_BUILD_DIR):
 
 $(NOTIFICATION_MODULE_DIR):
 	mkdir -p $(NOTIFICATION_MODULE_DIR)
+
+$(PLATFORM_BUILD_DIR):
+	mkdir -p $(PLATFORM_BUILD_DIR)
+
+$(PLATFORM_MODULE_DIR):
+	mkdir -p $(PLATFORM_MODULE_DIR)
 
 $(HELPER_MOC): src/kwin-virtual-desktops/main.cpp | $(BUILD_DIR)
 	$(MOC) $< -o $@
@@ -285,6 +307,12 @@ $(NOTIFICATION_RUNTIME_MOC): src/notifications/runtime.h | $(NOTIFICATION_BUILD_
 	$(MOC) $< -o $@
 
 $(NOTIFICATION_PLUGIN_MOC): src/notifications/plugin.cpp | $(NOTIFICATION_BUILD_DIR)
+	$(MOC) $< -o $@
+
+$(PLATFORM_PLUGIN_MOC): src/platform/plugin.cpp | $(PLATFORM_BUILD_DIR)
+	$(MOC) $< -o $@
+
+$(PLATFORM_ROUTER_MOC): src/platform/pointer_router.h | $(PLATFORM_BUILD_DIR)
 	$(MOC) $< -o $@
 
 $(NOTIFICATION_TEST_MOC): tests/notification_runtime_test.cpp | $(NOTIFICATION_BUILD_DIR)
@@ -352,6 +380,10 @@ $(NOTIFICATION_PLUGIN): $(NOTIFICATION_SOURCES) $(NOTIFICATION_HEADERS) src/noti
 	cp src/notifications/qmldir $(NOTIFICATION_MODULE_DIR)/qmldir
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) -fPIC -shared $(NOTIFICATION_QT_CFLAGS) -Isrc/notifications -I$(NOTIFICATION_BUILD_DIR) $(NOTIFICATION_SOURCES) src/notifications/plugin.cpp $(NOTIFICATION_RUNTIME_MOC) -o $@ $(LDFLAGS) $(NOTIFICATION_QT_LIBS)
 
+$(PLATFORM_PLUGIN): src/platform/pointer_router.cpp src/platform/pointer_router.h src/platform/plugin.cpp src/platform/qmldir $(PLATFORM_ROUTER_MOC) $(PLATFORM_PLUGIN_MOC) | $(PLATFORM_MODULE_DIR)
+	cp src/platform/qmldir $(PLATFORM_MODULE_DIR)/qmldir
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) -fPIC -shared $(PLATFORM_QT_CFLAGS) -Isrc/platform -I$(PLATFORM_BUILD_DIR) src/platform/pointer_router.cpp src/platform/plugin.cpp $(PLATFORM_ROUTER_MOC) -o $@ $(LDFLAGS) $(PLATFORM_QT_LIBS)
+
 $(NOTIFICATION_TEST): tests/notification_runtime_test.cpp $(NOTIFICATION_TEST_MOC) $(NOTIFICATION_SOURCES) $(NOTIFICATION_HEADERS) $(NOTIFICATION_RUNTIME_MOC) | $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(NATIVE_CXXFLAGS) $(NOTIFICATION_QT_CFLAGS) -Isrc/notifications -I$(NOTIFICATION_BUILD_DIR) tests/notification_runtime_test.cpp $(NOTIFICATION_SOURCES) $(NOTIFICATION_RUNTIME_MOC) -o $@ $(LDFLAGS) $(NOTIFICATION_QT_LIBS)
 
@@ -379,6 +411,8 @@ wallpaper-helper: check-wallpaper-toolchain
 	$(CMAKE) --build '$(WALLPAPER_BUILD_DIR)' --target nagi-wallpaper
 
 notification-plugin: check-notification-toolchain $(NOTIFICATION_PLUGIN)
+
+platform-plugin: check-platform-toolchain $(PLATFORM_PLUGIN)
 
 test-applications: check-application-toolchain $(APPLICATION_HELPER) $(APPLICATION_TEST)
 	$(APPLICATION_TEST) $(abspath $(APPLICATION_HELPER))
@@ -548,12 +582,23 @@ test-launcher: check-quickshell | $(BUILD_DIR)
 	cp assets/icons/nagi/*.svg $(LAUNCHER_TEST_DIR)/assets/icons/nagi/
 	QT_QPA_PLATFORM='offscreen' $(QS) -p $(LAUNCHER_TEST_DIR) --no-duplicate
 
-test-surface-state: check-quickshell | $(BUILD_DIR)
+test-surface-state: check-quickshell platform-plugin | $(BUILD_DIR)
 	mkdir -p $(SURFACE_STATE_TEST_DIR)/qml $(SURFACE_STATE_TEST_DIR)/assets/icons/nagi
 	cp tests/surface-state/shell.qml $(SURFACE_STATE_TEST_DIR)/shell.qml
-	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/AudioSelectionView.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IconResolver.qml qml/IslandIcon.qml qml/SubviewFrame.qml qml/TrayView.qml qml/IslandStateCoordinator.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(SURFACE_STATE_TEST_DIR)/qml/
+	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/DashboardMedia.qml qml/DashboardClock.qml qml/DashboardQuickControls.qml qml/DashboardAudio.qml qml/DashboardVolumeControl.qml qml/DashboardNotifications.qml qml/DashboardNavigation.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/AudioSelectionView.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IconResolver.qml qml/IslandIcon.qml qml/SubviewFrame.qml qml/TrayView.qml qml/IslandStateCoordinator.qml qml/DisplayManager.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(SURFACE_STATE_TEST_DIR)/qml/
 	cp assets/icons/nagi/*.svg $(SURFACE_STATE_TEST_DIR)/assets/icons/nagi/
-	$(KWIN_VIRTUAL_RUNNER) $(KWIN_TEST_ARGS) -- $(QS) -p $(SURFACE_STATE_TEST_DIR) --no-duplicate
+	$(KWIN_VIRTUAL_RUNNER) $(KWIN_TEST_ARGS) -- env QML_IMPORT_PATH='$(abspath $(BUILD_DIR)/qml)' $(QS) -p $(SURFACE_STATE_TEST_DIR) --no-duplicate
+
+test-display-orchestration: check-quickshell platform-plugin | $(BUILD_DIR)
+	rm -rf $(DISPLAY_TEST_DIR)
+	mkdir -p $(DISPLAY_TEST_DIR)/qml $(DISPLAY_TEST_DIR)/assets/icons/nagi
+	cp tests/displays/shell.qml $(DISPLAY_TEST_DIR)/shell.qml
+	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/DashboardMedia.qml qml/DashboardClock.qml qml/DashboardQuickControls.qml qml/DashboardAudio.qml qml/DashboardVolumeControl.qml qml/DashboardNotifications.qml qml/DashboardNavigation.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/AudioSelectionView.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IconResolver.qml qml/IslandIcon.qml qml/SubviewFrame.qml qml/TrayView.qml qml/IslandStateCoordinator.qml qml/DisplayManager.qml qml/DisplaysPage.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(DISPLAY_TEST_DIR)/qml/
+	cp assets/icons/nagi/*.svg $(DISPLAY_TEST_DIR)/assets/icons/nagi/
+	@set -eu; \
+	for outputs in 1 2 3; do \
+		NAGI_TEST_OUTPUTS="$$outputs" $(KWIN_VIRTUAL_RUNNER) $(KWIN_TEST_SCALE_ARGS) --outputs "$$outputs" --width '$(KWIN_TEST_WIDTH)' --height '$(KWIN_TEST_HEIGHT)' -- env QML_IMPORT_PATH='$(abspath $(BUILD_DIR)/qml)' NAGI_TEST_OUTPUTS="$$outputs" $(QS) -p $(DISPLAY_TEST_DIR) --no-duplicate; \
+	done
 
 test-polkit-ui: check-quickshell | $(BUILD_DIR)
 	rm -rf $(POLKIT_UI_TEST_DIR)
@@ -699,10 +744,10 @@ check-quickshell:
 	fi; \
 	printf 'Quickshell %s satisfies the >= %s requirement.\n' "$$version" '$(QUICKSHELL_MIN_VERSION)'
 
-launch: check-quickshell prepare helper audio-helper connectivity-helper brightness-helper session-helper application-helper global-shortcut-helper wallpaper-helper notification-plugin
+launch: check-quickshell prepare helper audio-helper connectivity-helper brightness-helper session-helper application-helper global-shortcut-helper wallpaper-helper notification-plugin platform-plugin
 	QML_IMPORT_PATH='$(abspath $(BUILD_DIR)/qml)' $(QS) -p . --no-duplicate
 
-diagnose: check-quickshell prepare helper audio-helper connectivity-helper brightness-helper session-helper application-helper global-shortcut-helper wallpaper-helper notification-plugin
+diagnose: check-quickshell prepare helper audio-helper connectivity-helper brightness-helper session-helper application-helper global-shortcut-helper wallpaper-helper notification-plugin platform-plugin
 	QML_IMPORT_PATH='$(abspath $(BUILD_DIR)/qml)' $(QS) -p . --no-duplicate -vv --log-times
 
 instances:
@@ -747,9 +792,9 @@ lint-advisory:
 		exit 0; \
 	}
 
-check: check-nondisplay test-surface-state test-ui-primitives test-multi-surface test-ipc-activation test-appearance-watcher test-settings-writer test-networkmanager-contract test-bluez-contract test-gaming-power-contract test-wallpaper-write-contract
+check: check-nondisplay test-surface-state test-ui-primitives test-display-orchestration test-multi-surface test-ipc-activation test-appearance-watcher test-settings-writer test-networkmanager-contract test-bluez-contract test-gaming-power-contract test-wallpaper-write-contract
 
-check-nondisplay: check-quickshell format-check audio-helper connectivity-helper brightness-helper session-helper application-helper global-shortcut-helper wallpaper-helper notification-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-brightness-dbus test-brightness test-session-dbus test-session test-applications test-launcher test-global-shortcut test-notifications test-adapter test-coordinator test-transients test-weather test-media test-audio test-connectivity test-tray test-theme-config test-onboarding test-icons test-subview-frame test-wallpaper-dbus test-wallpaper test-idle test-dashboard test-polkit-ui
+check-nondisplay: check-quickshell format-check audio-helper connectivity-helper brightness-helper session-helper application-helper global-shortcut-helper wallpaper-helper notification-plugin platform-plugin test-native test-owner-lifecycle test-audio-protocol test-audio-volume test-connectivity-dbus test-brightness-dbus test-brightness test-session-dbus test-session test-applications test-launcher test-global-shortcut test-notifications test-adapter test-coordinator test-transients test-weather test-media test-audio test-connectivity test-tray test-theme-config test-onboarding test-icons test-subview-frame test-wallpaper-dbus test-wallpaper test-idle test-dashboard test-polkit-ui
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ Polkit credentials never enter the production shell because the backend is dorma
 
 ## Limitations
 
-- The runtime creates one island on the primary/default display Qt selects when the surface starts; there is no per-monitor island set. Changing the desktop primary while that display stays connected does not move the island dynamically — losing the output or recreating the surface selects the then-current primary/default again. Events without reliable output identity, including global shortcut activation, target the one live surface; a Nagi-initiated brightness confirmation may return only to the surface that started it.
-- Moving pointer focus between outputs with different current virtual desktops updates Idle state without presenting a workspace-switch transient.
+- Every connected display starts with an enabled island. Visibility and fallback selection are session-only because Quickshell 0.3.x exposes no reliable persistent display identity; Nagi never guesses from connector names, labels, serials, indexes, or geometry. Global shortcuts target the pointer screen, then the enabled fallback.
+- One Interactive task or Modal flow exists across all islands. Notifications and confirmed output-volume feedback may appear on every eligible island, while workspace and brightness remain routed and sensitive flows never mirror.
 - Wi-Fi supports state and toggle only. Network selection is outside the island.
 - Bluetooth supports adapter state and toggle only. Discovery, pairing, and device management are outside the island.
 - Audio covers default output/input selection, volume, and mute. It has no per-application mixer.
@@ -240,24 +240,24 @@ Polkit credentials never enter the production shell because the backend is dorma
 ```text
 shell.qml
    │
-   ├── one PanelWindow and adaptive content host
-   │      ├── Idle / Expanded
-   │      ├── focused subviews
-   │      └── transient replacement
+   ├── one PanelWindow per enabled live display
+   │      ├── independent Idle / Expanded / focus / geometry
+   │      ├── one globally exclusive focused or Modal task
+   │      └── shared-event transient projections
    │
-   ├── IslandStateCoordinator
-   │      └── priority · deadlines · preemption · restoration
+   ├── one IslandStateCoordinator
+   │      └── per-surface records · global priority · mailbox · deadlines · restoration
    │
    ├── normalized QML adapters
    │      └── media · audio · connectivity · apps · tray · notifications
    │
-   └── native helpers and runtime plugin
-          └── KWin · PowerDevil · PipeWire · session · wallpaper · KGlobalAccel
+   └── native helpers and runtime plugins
+          └── pointer routing · KWin · PowerDevil · PipeWire · session · wallpaper · KGlobalAccel
 ```
 
 Presentation consumes semantic theme roles and normalized adapter state. Native protocol details remain inside helpers and bridges. Rare views load lazily; histories, queues, caches, strings, and wallpaper analysis are bounded.
 
-Changes must preserve the single-surface coordinator, normalized adapter boundary, semantic presentation layer, bounded lazy views, and native-helper isolation shown above.
+Changes must preserve the single process-wide coordinator, one service graph, normalized adapter boundary, semantic presentation layer, bounded lazy views, and native-helper isolation shown above.
 
 ## Quality assurance
 

--- a/install.sh
+++ b/install.sh
@@ -434,7 +434,7 @@ log_info "Building native helpers in the checkout..."
     # shellcheck disable=SC2086
     make -s helper audio-helper connectivity-helper brightness-helper \
         session-helper application-helper global-shortcut-helper \
-        wallpaper-helper notification-plugin
+        wallpaper-helper notification-plugin platform-plugin
 )
 
 # Required artifacts, relative to the checkout root (paths mirror what
@@ -450,6 +450,8 @@ build/global-shortcut/nagi-global-shortcut
 build/wallpaper/nagi-wallpaper
 build/qml/Nagi/Notifications/libnaginotificationsplugin.so
 build/qml/Nagi/Notifications/qmldir
+build/qml/Nagi/Platform/libnagiplatformplugin.so
+build/qml/Nagi/Platform/qmldir
 "
 for artifact in $ARTIFACTS; do
     [ -f "$SOURCE_DIR/$artifact" ] || log_fatal "Expected artifact is missing after build: $artifact"

--- a/qml/DisplayManager.qml
+++ b/qml/DisplayManager.qml
@@ -1,0 +1,181 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import QtQuick
+
+Scope {
+    id: root
+
+    readonly property int revision: state.revision
+    readonly property int activeDisplayCount: state.records.length
+    readonly property int enabledDisplayCount: state.enabledCount()
+    readonly property var fallbackScreen: state.fallbackScreen
+    readonly property var rememberedDisplays: Object.freeze([])
+
+    signal changeRejected(string reason)
+
+    function activeDisplays() {
+        const rows = [];
+        for (let index = 0; index < state.records.length; index += 1) {
+            const record = state.records[index];
+            rows.push(Object.freeze({
+                                        "connected": true,
+                                        "enabled": record.enabled,
+                                        "fallback": record.screen === state.fallbackScreen,
+                                        "label": "Connected display " + (index + 1),
+                                        "reliable": false,
+                                        "screen": record.screen
+                                    }));
+        }
+        return Object.freeze(rows);
+    }
+
+    function forgetRemembered(identity) {
+        // Issue #70 proved that ShellScreen 0.3.x exposes no reliable identity.
+        // Remembered rows remain empty until a future adapter supplies one.
+        return false;
+    }
+
+    function isEnabled(screen) {
+        const record = state.recordFor(screen);
+        return record !== null && record.enabled;
+    }
+
+    function isFallback(screen) {
+        return screen !== null && screen === state.fallbackScreen;
+    }
+
+    function requestEnabled(screen, enabled) {
+        if (typeof enabled !== "boolean") {
+            return false;
+        }
+        const record = state.recordFor(screen);
+        if (record === null || record.enabled === enabled) {
+            return record !== null;
+        }
+        if (!enabled && state.enabledCount() <= 1) {
+            root.changeRejected("At least one island must remain enabled.");
+            return false;
+        }
+
+        record.enabled = enabled;
+        if (!enabled && state.fallbackScreen === screen) {
+            state.fallbackScreen = state.firstEnabledScreen();
+        } else if (enabled && state.fallbackScreen === null) {
+            state.fallbackScreen = screen;
+        }
+        state.publish();
+        return true;
+    }
+
+    function requestFallback(screen) {
+        const record = state.recordFor(screen);
+        if (record === null || !record.enabled) {
+            root.changeRejected("The fallback must be an active enabled display.");
+            return false;
+        }
+        if (state.fallbackScreen === screen) {
+            return true;
+        }
+        state.fallbackScreen = screen;
+        state.publish();
+        return true;
+    }
+
+    function syncScreens() {
+        state.syncScreens();
+    }
+
+    QtObject {
+        id: state
+
+        property var records: []
+        property var fallbackScreen: null
+        property int revision: 0
+
+        function connected(screen) {
+            for (let index = 0; index < Quickshell.screens.length; index += 1) {
+                if (Quickshell.screens[index] === screen) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function enabledCount() {
+            let count = 0;
+            for (let index = 0; index < records.length; index += 1) {
+                if (records[index].enabled) {
+                    count += 1;
+                }
+            }
+            return count;
+        }
+
+        function firstEnabledScreen() {
+            for (let index = 0; index < records.length; index += 1) {
+                if (records[index].enabled) {
+                    return records[index].screen;
+                }
+            }
+            return null;
+        }
+
+        function publish() {
+            records = records.slice();
+            revision += 1;
+        }
+
+        function recordFor(screen) {
+            for (let index = 0; index < records.length; index += 1) {
+                if (records[index].screen === screen) {
+                    return records[index];
+                }
+            }
+            return null;
+        }
+
+        function syncScreens() {
+            const next = [];
+            for (let index = 0; index < records.length; index += 1) {
+                if (connected(records[index].screen)) {
+                    next.push(records[index]);
+                }
+            }
+            for (let index = 0; index < Quickshell.screens.length; index += 1) {
+                const screen = Quickshell.screens[index];
+                let known = false;
+                for (let recordIndex = 0; recordIndex < next.length; recordIndex += 1) {
+                    if (next[recordIndex].screen === screen) {
+                        known = true;
+                        break;
+                    }
+                }
+                if (!known) {
+                    // With no stable identity contract, every newly seen screen is
+                    // a fresh session-only display and starts enabled.
+                    next.push({
+                                  "enabled": true,
+                                  "screen": screen
+                              });
+                }
+            }
+            records = next;
+            if (fallbackScreen === null || !connected(fallbackScreen) || !root.isEnabled(
+                        fallbackScreen)) {
+                fallbackScreen = firstEnabledScreen();
+            }
+            revision += 1;
+        }
+    }
+
+    Connections {
+        target: Quickshell
+
+        function onScreensChanged() {
+            state.syncScreens();
+        }
+    }
+
+    Component.onCompleted: state.syncScreens()
+}

--- a/qml/DisplaysPage.qml
+++ b/qml/DisplaysPage.qml
@@ -1,0 +1,166 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+
+ColumnLayout {
+    id: root
+
+    required property var displayController
+    property string failureText: ""
+
+    spacing: Theme.spacing.md
+
+    function activeRows() {
+        const ignored = displayController.revision;
+        return displayController.activeDisplays();
+    }
+
+    function requestEnabled(screen, enabled) {
+        if (displayController.setEnabled(screen, enabled)) {
+            failureText = "";
+            return;
+        }
+        failureText = displayController.lastFailure;
+    }
+
+    function requestFallback(screen) {
+        if (displayController.setFallback(screen)) {
+            failureText = "";
+            return;
+        }
+        failureText = displayController.lastFailure;
+    }
+
+    IslandText {
+        text: "Displays"
+        size: "title"
+        Accessible.role: Accessible.Heading
+        Accessible.name: text
+    }
+
+    IslandText {
+        Layout.fillWidth: true
+        text: "Choose where Nagi islands are visible and which enabled display receives global actions when the pointer has no usable target."
+        size: "body"
+        color: Theme.color.textSecondary
+        wrapMode: Text.Wrap
+    }
+
+    Repeater {
+        model: root.activeRows()
+
+        delegate: IslandPanel {
+            id: activeRow
+
+            required property var modelData
+
+            Layout.fillWidth: true
+            implicitHeight: rowLayout.implicitHeight + Theme.spacing.md * 2
+            Accessible.role: Accessible.Grouping
+            Accessible.name: modelData.label
+
+            RowLayout {
+                id: rowLayout
+
+                anchors.fill: parent
+                anchors.margins: Theme.spacing.md
+                spacing: Theme.spacing.sm
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.spacing.xs
+
+                    IslandText {
+                        text: activeRow.modelData.label
+                        size: "body"
+                        font.weight: Theme.type.weightMedium
+                    }
+
+                    IslandText {
+                        text: activeRow.modelData.reliable ? "Remembered across sessions" :
+                                                             "Available for this session only"
+                        size: "caption"
+                        color: Theme.color.textMuted
+                    }
+                }
+
+                IslandButton {
+                    label: activeRow.modelData.enabled ? "Disable island" : "Enable island"
+                    enabled: !activeRow.modelData.enabled
+                             || root.displayController.enabledDisplayCount > 1
+                    onClicked: root.requestEnabled(activeRow.modelData.screen,
+                                                   !activeRow.modelData.enabled)
+                }
+
+                IslandButton {
+                    label: activeRow.modelData.fallback ? "Fallback" : "Make fallback"
+                    variant: activeRow.modelData.fallback ? "accent" : "standard"
+                    enabled: activeRow.modelData.enabled && !activeRow.modelData.fallback
+                    onClicked: root.requestFallback(activeRow.modelData.screen)
+                }
+            }
+        }
+    }
+
+    IslandText {
+        Layout.fillWidth: true
+        visible: root.failureText !== ""
+        text: root.failureText
+        size: "caption"
+        color: Theme.color.danger
+        wrapMode: Text.Wrap
+        Accessible.role: Accessible.AlertMessage
+        Accessible.name: text
+    }
+
+    IslandText {
+        text: "Remembered"
+        size: "title"
+        Accessible.role: Accessible.Heading
+        Accessible.name: text
+    }
+
+    IslandText {
+        Layout.fillWidth: true
+        visible: root.displayController.rememberedDisplays.length === 0
+        text: "No disconnected displays can be remembered reliably on this platform."
+        size: "body"
+        color: Theme.color.textMuted
+        wrapMode: Text.Wrap
+    }
+
+    Repeater {
+        model: root.displayController.rememberedDisplays
+
+        delegate: IslandPanel {
+            id: rememberedRow
+
+            required property var modelData
+
+            Layout.fillWidth: true
+            implicitHeight: rememberedLayout.implicitHeight + Theme.spacing.md * 2
+
+            RowLayout {
+                id: rememberedLayout
+
+                anchors.fill: parent
+                anchors.margins: Theme.spacing.md
+
+                IslandText {
+                    Layout.fillWidth: true
+                    text: rememberedRow.modelData.label
+                    size: "body"
+                }
+
+                IslandButton {
+                    label: "Forget"
+                    variant: "danger"
+                    Accessible.description: "Forget this disconnected display after confirmation"
+                    onClicked: root.displayController.confirmForget(
+                                   rememberedRow.modelData.identity)
+                }
+            }
+        }
+    }
+}

--- a/qml/IslandStateCoordinator.qml
+++ b/qml/IslandStateCoordinator.qml
@@ -31,273 +31,224 @@ Scope {
     readonly property int focusTray: 6
     readonly property int focusAudio: 7
 
-    readonly property int surfaceGeneration: reducer.surfaceGeneration
-    readonly property var surfaceToken: reducer.surfaceToken
-    readonly property int ownerKind: reducer.ownerKind
-    readonly property string ownerName: reducer.ownerName(reducer.ownerKind)
-    readonly property int ownerRank: reducer.ownerRank
-    readonly property real ownerEpoch: reducer.ownerEpoch
-    readonly property real revision: reducer.revision
-    readonly property var ownerSourceToken: reducer.ownerSourceToken
-    readonly property int ownerSourceGeneration: reducer.ownerSourceGeneration
-    readonly property int ownerSourceRevision: reducer.ownerSourceRevision
-    readonly property bool presentationVisible: reducer.presentationVisible
-    readonly property int focusTarget: reducer.focusTarget
-    readonly property real focusRequestSerial: reducer.focusRequestSerial
-    readonly property bool hoverIntent: reducer.hoverIntent
-    readonly property bool explicitExpandedIntent: reducer.explicitExpandedIntent
-    readonly property int pendingTransientCount: reducer.pending.length
-    readonly property int restorationDepth: reducer.restoration.length
-    readonly property bool modalPresent: reducer.modalPresent
-    readonly property int modalFlowGeneration: reducer.modalFlowGeneration
+    readonly property int stateSerial: state.serial
+    readonly property int surfaceCount: state.surfaces.length
+    readonly property int pendingTransientCount: state.transients.length
+    readonly property bool modalPresent: state.modalIsActive || state.modalFlowPresent
+    readonly property int modalFlowGeneration: state.modalFlowGeneration
+    readonly property var modalHostToken: state.modalHostToken
+    readonly property var interactiveHostToken: state.interactiveHostToken()
+    readonly property bool anyExpanded: state.anyOwner(root.ownerExpanded)
 
-    // Tests may inject a monotonic millisecond source. Production uses Quickshell's
-    // QElapsedTimer-backed clock and one relative one-shot scheduler.
+    // IslandSurfaceHost implements routeSurfaceToken(excludedToken) using only
+    // live surface tokens, QWindow->QScreen equality, and configured fallback.
+    property var surfaceRouter: null
     property var monotonicNow: null
 
-    function acknowledgeVisible(generation, epoch, contentRevision) {
-        return reducer.acknowledgeVisible(generation, epoch, contentRevision);
+    function acknowledgeVisible(token, generation, epoch, contentRevision) {
+        return state.acknowledgeVisible(token, generation, epoch, contentRevision);
     }
 
     function attachSurface(token, generation) {
-        return reducer.attachSurface(token, generation);
+        return state.attachSurface(token, generation);
     }
 
     function cancelInteractive(epoch) {
-        return reducer.finishInteractive(epoch);
+        return state.finishInteractive(epoch);
     }
 
     function completeInteractive(epoch) {
-        return reducer.finishInteractive(epoch);
-    }
-
-    function resetToIdle(initiatingSurfaceToken) {
-        return reducer.resetToIdle(initiatingSurfaceToken);
+        return state.finishInteractive(epoch);
     }
 
     function detachSurface(token, generation) {
-        return reducer.detachSurface(token, generation);
+        return state.detachSurface(token, generation);
+    }
+
+    function invalidateTransient(sourceToken, sourceGeneration) {
+        return state.invalidateTransient(sourceToken, sourceGeneration);
+    }
+
+    function openAudio(initiatingSurfaceToken) {
+        return state.openInteractive(root.ownerAudio, initiatingSurfaceToken);
     }
 
     function openDashboard(initiatingSurfaceToken) {
-        if (!reducer.matchingSurface(initiatingSurfaceToken)) {
-            return false;
-        }
-        return reducer.setExplicitExpanded(reducer.surfaceGeneration, true);
-    }
-
-    function openLauncher(initiatingSurfaceToken) {
-        return reducer.openLauncher(initiatingSurfaceToken);
+        const token = state.routedToken(initiatingSurfaceToken, null);
+        const record = state.recordForToken(token);
+        return record !== null && state.setBaselineIntent(record.token, record.generation, true,
+                                                          true);
     }
 
     function openHistory(initiatingSurfaceToken) {
-        return reducer.openHistory(initiatingSurfaceToken);
+        return state.openInteractive(root.ownerHistory, initiatingSurfaceToken);
     }
-    function openTray(initiatingSurfaceToken) {
-        return reducer.openTray(initiatingSurfaceToken);
-    }
-    function openAudio(initiatingSurfaceToken) {
-        return reducer.openAudio(initiatingSurfaceToken);
+
+    function openLauncher(initiatingSurfaceToken) {
+        return state.openInteractive(root.ownerLauncher, initiatingSurfaceToken);
     }
 
     function openSession(initiatingSurfaceToken) {
-        return reducer.openSession(initiatingSurfaceToken);
+        return state.openInteractive(root.ownerSession, initiatingSurfaceToken);
+    }
+
+    function openTray(initiatingSurfaceToken) {
+        return state.openInteractive(root.ownerTray, initiatingSurfaceToken);
+    }
+
+    function ownerNameFor(kind) {
+        return state.ownerName(kind);
+    }
+
+    function prepareSurfaceDisable(token) {
+        return state.prepareSurfaceDisable(token);
     }
 
     function requestBrightness(sourceToken, sourceGeneration, sourceRevision,
                                initiatingSurfaceToken) {
-        return reducer.requestTransient(root.ownerBrightness, sourceToken, sourceGeneration,
-                                        sourceRevision, initiatingSurfaceToken);
+        return state.requestTransient(root.ownerBrightness, sourceToken, sourceGeneration,
+                                      sourceRevision, initiatingSurfaceToken, false);
     }
 
     function requestNotification(sourceToken, sourceGeneration, sourceRevision,
                                  initiatingSurfaceToken) {
-        return reducer.requestTransient(root.ownerNotification, sourceToken, sourceGeneration,
-                                        sourceRevision, initiatingSurfaceToken);
+        return state.requestTransient(root.ownerNotification, sourceToken, sourceGeneration,
+                                      sourceRevision, initiatingSurfaceToken, true);
     }
 
     function requestVolume(sourceToken, sourceGeneration, sourceRevision, initiatingSurfaceToken) {
-        return reducer.requestTransient(root.ownerVolume, sourceToken, sourceGeneration,
-                                        sourceRevision, initiatingSurfaceToken);
+        return state.requestTransient(root.ownerVolume, sourceToken, sourceGeneration,
+                                      sourceRevision, initiatingSurfaceToken, true);
     }
 
     function requestWorkspace(sourceToken, sourceGeneration, sourceRevision,
                               initiatingSurfaceToken) {
-        return reducer.requestTransient(root.ownerWorkspace, sourceToken, sourceGeneration,
-                                        sourceRevision, initiatingSurfaceToken);
+        return state.requestTransient(root.ownerWorkspace, sourceToken, sourceGeneration,
+                                      sourceRevision, initiatingSurfaceToken, false);
     }
 
-    function invalidateTransient(sourceToken, sourceGeneration) {
-        return reducer.invalidateTransient(sourceToken, sourceGeneration);
+    function resetToIdle(initiatingSurfaceToken) {
+        return state.resetToIdle(initiatingSurfaceToken);
     }
 
-    function setExplicitExpanded(generation, expanded) {
-        return reducer.setExplicitExpanded(generation, expanded);
+    function setExplicitExpanded(token, generation, expanded) {
+        return state.setBaselineIntent(token, generation, expanded, true);
     }
 
-    function setHover(generation, hovered) {
-        return reducer.setHover(generation, hovered);
+    function setHover(token, generation, hovered) {
+        return state.setBaselineIntent(token, generation, hovered, false);
+    }
+
+    function surfaceSnapshot(token) {
+        return state.surfaceSnapshot(token);
     }
 
     function syncPolkitModal(isActive, flowPresent, flowGeneration) {
-        return reducer.syncPolkitModal(isActive, flowPresent, flowGeneration);
+        return state.syncPolkitModal(isActive, flowPresent, flowGeneration);
     }
 
     QtObject {
-        id: reducer
+        id: state
 
-        property int surfaceGeneration: 0
-        property var surfaceToken: null
-        property bool hoverIntent: false
-        property bool explicitExpandedIntent: false
-        readonly property bool baselineExpanded: hoverIntent || explicitExpandedIntent
-
-        property int ownerKind: root.ownerNone
-        property int ownerRank: -1
-        property real ownerEpoch: 0
-        property real revision: 0
-        property var ownerSourceToken: null
-        property int ownerSourceGeneration: 0
-        property int ownerSourceRevision: 0
-        property real ownerAdmission: 0
-        property real ownerFreshUntil: -1
-        property real ownerHoldDuration: 0
-        property real ownerHoldUntil: -1
-        property bool presentationVisible: false
-        property bool focusPending: false
-
-        property var pending: []
-        property var restoration: []
+        property var surfaces: []
+        property var transients: []
         property real nextAdmission: 0
         property real nextOwnerEpoch: 0
+        property real lastNow: -1
+        property int serial: 0
 
         property bool modalIsActive: false
         property bool modalFlowPresent: false
         property int modalFlowGeneration: 0
-        readonly property bool modalPresent: modalIsActive || modalFlowPresent
+        property var modalHostToken: null
 
-        property int focusTarget: root.focusNone
-        property real focusRequestSerial: 0
-
-        property real lastNow: -1
-        property real scheduleSerial: 0
-        property int scheduledSurfaceGeneration: 0
-        property real scheduledOwnerEpoch: 0
-        property real scheduledRevision: 0
-        property real armedScheduleSerial: 0
-
-        function acknowledgeVisible(generation, epoch, contentRevision) {
+        function acknowledgeVisible(token, generation, epoch, contentRevision) {
             const now = currentTime();
             expireDue(now);
-
-            if (generation !== surfaceGeneration || epoch !== ownerEpoch || contentRevision
-                    !== revision || ownerKind === root.ownerNone) {
+            const record = recordForToken(token);
+            if (record === null || record.generation !== generation || record.owner.epoch !== epoch
+                    || record.owner.revision !== contentRevision || record.owner.kind
+                    === root.ownerNone) {
                 schedule(now);
                 return false;
             }
 
-            if (!presentationVisible) {
-                presentationVisible = true;
-                if (isTransient(ownerKind)) {
-                    ownerHoldUntil = now + ownerHoldDuration;
+            record.owner.presentationVisible = true;
+            if (record.owner.focusPending) {
+                record.owner.focusPending = false;
+                record.focusRequestSerial += 1;
+            }
+            if (isTransient(record.owner.kind)) {
+                const event = eventForId(record.owner.eventId);
+                if (event !== null && event.visibleTokens.indexOf(token) < 0) {
+                    event.visibleTokens.push(token);
+                    let everyProjectionVisible = true;
+                    for (let index = 0; index < surfaces.length; index += 1) {
+                        const candidate = surfaces[index];
+                        if (candidate.owner.eventId === event.id && event.visibleTokens.indexOf(
+                                    candidate.token) < 0) {
+                            everyProjectionVisible = false;
+                            break;
+                        }
+                    }
+                    if (everyProjectionVisible) {
+                        event.holdUntil = now + event.holdDuration;
+                    }
                 }
             }
-
-            if (focusPending) {
-                focusPending = false;
-                focusRequestSerial += 1;
-            }
-
+            publish();
             schedule(now);
             return true;
+        }
+
+        function anyOwner(kind) {
+            for (let index = 0; index < surfaces.length; index += 1) {
+                if (surfaces[index].owner.kind === kind) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         function attachSurface(token, generation) {
             if (token === null || token === undefined || !Number.isInteger(generation) || generation
-                    <= 0) {
+                    <= 0 || recordForToken(token) !== null) {
                 return false;
             }
-
-            const now = currentTime();
-            expireDue(now);
-
-            if (surfaceToken === token && surfaceGeneration === generation) {
-                schedule(now);
-                return true;
+            surfaces.push({
+                              "explicitExpanded": false,
+                              "focusRequestSerial": 0,
+                              "generation": generation,
+                              "hover": false,
+                              "owner": baselineOwner(false),
+                              "restoration": [],
+                              "token": token
+                          });
+            if (root.modalPresent && modalHostToken === null) {
+                rehomeModal(null, false);
             }
-
-            clearLocalState();
-            surfaceToken = token;
-            surfaceGeneration = generation;
-            enterOwner(baselineExpanded ? root.ownerExpanded : root.ownerIdle, null, null, now);
-
-            if (modalPresent) {
-                captureCurrent(now);
-                enterOwner(root.ownerPolkitModal, null, null, now);
-            }
-
-            schedule(now);
+            publish();
+            schedule(currentTime());
             return true;
         }
 
-        function captureCurrent(now) {
-            if (ownerKind === root.ownerNone || ownerKind === root.ownerIdle || ownerKind
-                    === root.ownerPolkitModal) {
-                return;
-            }
-
-            if (restoration.length >= root.maximumRestorationDepth) {
-                return;
-            }
-
-            if (restoration.length > 0 && restoration[restoration.length - 1].rank >= ownerRank) {
-                return;
-            }
-
-            let holdRemaining = ownerHoldDuration;
-            if (isTransient(ownerKind) && presentationVisible) {
-                holdRemaining = Math.max(0, ownerHoldUntil - now);
-            }
-
-            const frames = restoration.slice();
-            frames.push({
-                            "admission": ownerAdmission,
-                            "freshUntil": ownerFreshUntil,
-                            "holdDuration": holdRemaining,
-                            "kind": ownerKind,
-                            "rank": ownerRank,
-                            "revision": revision,
-                            "taskEpoch": isInteractiveKind(ownerKind) ? ownerEpoch : 0,
-                            "sourceToken": ownerSourceToken,
-                            "sourceGeneration": ownerSourceGeneration,
-                            "sourceRevision": ownerSourceRevision,
-                            "surfaceGeneration": surfaceGeneration
-                        });
-            restoration = frames;
+        function baselineKind(record) {
+            return record.hover || record.explicitExpanded ? root.ownerExpanded : root.ownerIdle;
         }
 
-        function clearLocalState() {
-            scheduler.stop();
-            surfaceToken = null;
-            surfaceGeneration = 0;
-            hoverIntent = false;
-            explicitExpandedIntent = false;
-            ownerKind = root.ownerNone;
-            ownerRank = -1;
-            ownerEpoch = 0;
-            revision = 0;
-            ownerSourceToken = null;
-            ownerSourceGeneration = 0;
-            ownerSourceRevision = 0;
-            ownerAdmission = 0;
-            ownerFreshUntil = -1;
-            ownerHoldDuration = 0;
-            ownerHoldUntil = -1;
-            presentationVisible = false;
-            focusPending = false;
-            focusTarget = root.focusNone;
-            pending = [];
-            restoration = [];
+        function baselineOwner(expanded) {
+            return ownerRecord(expanded ? root.ownerExpanded : root.ownerIdle, null, null, false);
+        }
+
+        function captureCurrent(record) {
+            if (record.owner.kind === root.ownerNone || record.owner.kind === root.ownerIdle
+                    || record.owner.kind === root.ownerPolkitModal || record.restoration.length
+                    >= root.maximumRestorationDepth) {
+                return;
+            }
+            const frames = record.restoration.slice();
+            frames.push(Object.assign({}, record.owner));
+            record.restoration = frames;
         }
 
         function currentTime() {
@@ -315,132 +266,96 @@ Scope {
         }
 
         function detachSurface(token, generation) {
-            if (surfaceToken !== token || surfaceGeneration !== generation) {
+            const record = recordForToken(token);
+            if (record === null || record.generation !== generation) {
                 return false;
             }
-
-            clearLocalState();
+            const modalLost = modalHostToken === token;
+            const interactiveLost = isInteractiveKind(record.owner.kind);
+            const interactiveKind = interactiveLost ? record.owner.kind : root.ownerNone;
+            const interactiveEpoch = interactiveLost ? record.owner.epoch : 0;
+            const next = [];
+            for (let index = 0; index < surfaces.length; index += 1) {
+                if (surfaces[index] !== record) {
+                    next.push(surfaces[index]);
+                }
+            }
+            surfaces = next;
+            removeTargetFromEvents(token);
+            if (modalLost) {
+                modalHostToken = null;
+                rehomeModal(token, false);
+            } else if (interactiveLost) {
+                transferInteractiveAfterLoss(interactiveKind, interactiveEpoch, token);
+            }
+            publish();
+            schedule(currentTime());
             return true;
         }
 
-        function enterOwner(kind, sourceToken, record, now) {
-            const restoredTaskEpoch = record === null ? 0 : record.taskEpoch;
-            if (isInteractiveKind(kind) && typeof restoredTaskEpoch === "number"
-                    && restoredTaskEpoch > 0) {
-                ownerEpoch = restoredTaskEpoch;
-                revision = Math.max(1, record.revision + 1);
-            } else {
-                nextOwnerEpoch += 1;
-                ownerEpoch = nextOwnerEpoch;
-                revision = 1;
+        function enterOwner(record, kind, event, preservedEpoch, preservedRevision) {
+            const epoch = preservedEpoch > 0 ? preservedEpoch : ++nextOwnerEpoch;
+            const revision = preservedRevision > 0 ? preservedRevision : 1;
+            record.owner = ownerRecord(kind, event, epoch, true);
+            record.owner.revision = revision;
+        }
+
+        function eventForId(id) {
+            if (id === 0) {
+                return null;
             }
-            ownerKind = kind;
-            ownerRank = rankFor(kind);
-            ownerSourceToken = sourceToken;
-            ownerSourceGeneration = record === null ? 0 : record.sourceGeneration;
-            ownerSourceRevision = record === null ? 0 : record.sourceRevision;
-            ownerAdmission = record === null ? 0 : record.admission;
-            ownerFreshUntil = record === null ? -1 : record.freshUntil;
-            ownerHoldDuration = record === null ? holdFor(kind) : record.holdDuration;
-            ownerHoldUntil = -1;
-            presentationVisible = false;
-            focusPending = isInteractiveKind(kind) || kind === root.ownerPolkitModal || (kind
-                                                                                         === root.ownerExpanded
-                                                                                         && explicitExpandedIntent);
-            focusTarget = focusFor(kind);
+            for (let index = 0; index < transients.length; index += 1) {
+                if (transients[index].id === id) {
+                    return transients[index];
+                }
+            }
+            return null;
+        }
+
+        function eventMatches(event, kind, sourceToken, sourceGeneration) {
+            return event.kind === kind && event.sourceToken === sourceToken
+                    && event.sourceGeneration === sourceGeneration;
         }
 
         function expireDue(now) {
-            if (surfaceToken === null) {
-                return;
-            }
-
-            let pendingExpired = false;
-            for (let index = 0; index < pending.length; index += 1) {
-                if (pending[index].freshUntil <= now) {
-                    pendingExpired = true;
-                    break;
+            const expired = [];
+            for (let index = 0; index < transients.length; index += 1) {
+                const event = transients[index];
+                if (event.freshUntil <= now || (event.holdUntil >= 0 && event.holdUntil <= now)) {
+                    expired.push(event.id);
                 }
             }
-            if (pendingExpired) {
-                const nextPending = [];
-                for (let index = 0; index < pending.length; index += 1) {
-                    if (pending[index].freshUntil > now) {
-                        nextPending.push(pending[index]);
-                    }
-                }
-                pending = nextPending;
-            }
-
-            let restorationExpired = false;
-            for (let index = 0; index < restoration.length; index += 1) {
-                const frame = restoration[index];
-                if (isTransient(frame.kind) && frame.freshUntil <= now) {
-                    restorationExpired = true;
-                    break;
-                }
-            }
-            if (restorationExpired) {
-                const nextRestoration = [];
-                for (let index = 0; index < restoration.length; index += 1) {
-                    const frame = restoration[index];
-                    if (!isTransient(frame.kind) || frame.freshUntil > now) {
-                        nextRestoration.push(frame);
-                    }
-                }
-                restoration = nextRestoration;
-            }
-
-            if (isTransient(ownerKind) && (ownerFreshUntil <= now || (presentationVisible
-                                                                      && ownerHoldUntil <= now))) {
-                restoreNext(now);
+            for (let index = 0; index < expired.length; index += 1) {
+                removeEvent(expired[index], now);
             }
         }
+
         function finishInteractive(epoch) {
             const now = currentTime();
             expireDue(now);
-
-            if (isInteractiveKind(ownerKind) && ownerEpoch === epoch) {
-                restoreNext(now);
-                schedule(now);
-                return true;
-            }
-
-            for (let index = restoration.length - 1; index >= 0; index -= 1) {
-                const frame = restoration[index];
-                if (isInteractiveKind(frame.kind) && frame.taskEpoch === epoch) {
-                    const frames = restoration.slice();
-                    frames.splice(index, 1);
-                    restoration = frames;
+            for (let index = 0; index < surfaces.length; index += 1) {
+                const record = surfaces[index];
+                if (isInteractiveKind(record.owner.kind) && record.owner.epoch === epoch) {
+                    restoreNext(record, now);
+                    publish();
                     schedule(now);
                     return true;
                 }
+                for (let frameIndex = record.restoration.length - 1; frameIndex >= 0; frameIndex
+                     -= 1) {
+                    if (isInteractiveKind(record.restoration[frameIndex].kind)
+                            && record.restoration[frameIndex].epoch === epoch) {
+                        const frames = record.restoration.slice();
+                        frames.splice(frameIndex, 1);
+                        record.restoration = frames;
+                        publish();
+                        schedule(now);
+                        return true;
+                    }
+                }
             }
-
             schedule(now);
             return false;
-        }
-
-        function resetToIdle(initiatingSurfaceToken) {
-            const now = currentTime();
-            expireDue(now);
-            if (!matchingSurface(initiatingSurfaceToken) || modalPresent || ownerKind
-                    === root.ownerPolkitModal) {
-                schedule(now);
-                return false;
-            }
-
-            hoverIntent = false;
-            explicitExpandedIntent = false;
-            pending = [];
-            restoration = [];
-            focusPending = false;
-            focusTarget = root.focusNone;
-            if (ownerKind !== root.ownerIdle) {
-                enterOwner(root.ownerIdle, null, null, now);
-            }
-            schedule(now);
-            return true;
         }
 
         function focusFor(kind) {
@@ -456,16 +371,23 @@ Scope {
             if (kind === root.ownerAudio) {
                 return root.focusAudio;
             }
-            if (kind === root.ownerPolkitModal) {
-                return root.focusPolkitModal;
-            }
-            if (kind === root.ownerExpanded && explicitExpandedIntent) {
-                return root.focusExpandedDashboard;
-            }
             if (kind === root.ownerSession) {
                 return root.focusSessionActions;
             }
+            if (kind === root.ownerPolkitModal) {
+                return root.focusPolkitModal;
+            }
+            if (kind === root.ownerExpanded) {
+                return root.focusExpandedDashboard;
+            }
             return root.focusNone;
+        }
+
+        function forceIdle(record) {
+            record.hover = false;
+            record.explicitExpanded = false;
+            record.restoration = [];
+            record.owner = baselineOwner(false);
         }
 
         function freshnessFor(kind) {
@@ -475,10 +397,7 @@ Scope {
             if (kind === root.ownerVolume || kind === root.ownerBrightness) {
                 return 3000;
             }
-            if (kind === root.ownerWorkspace) {
-                return 2000;
-            }
-            return 0;
+            return kind === root.ownerWorkspace ? 2000 : 0;
         }
 
         function holdFor(kind) {
@@ -488,21 +407,31 @@ Scope {
             if (kind === root.ownerVolume || kind === root.ownerBrightness) {
                 return 1800;
             }
-            if (kind === root.ownerWorkspace) {
-                return 1200;
-            }
-            return 0;
+            return kind === root.ownerWorkspace ? 1200 : 0;
         }
 
-        function isRelevantFrame(frame, now) {
-            if (frame.surfaceGeneration !== surfaceGeneration) {
-                return false;
+        function interactiveHostToken() {
+            for (let index = 0; index < surfaces.length; index += 1) {
+                if (isInteractiveKind(surfaces[index].owner.kind)) {
+                    return surfaces[index].token;
+                }
             }
+            return null;
+        }
+
+        function isInteractiveKind(kind) {
+            return kind === root.ownerLauncher || kind === root.ownerHistory || kind === root.ownerTray || kind
+                    === root.ownerAudio || kind === root.ownerSession;
+        }
+
+        function isRelevantFrame(frame, record, now) {
             if (isTransient(frame.kind)) {
-                return frame.freshUntil > now && frame.holdDuration > 0;
+                const event = eventForId(frame.eventId);
+                return event !== null && event.freshUntil > now && event.targets.indexOf(
+                            record.token) >= 0;
             }
             if (frame.kind === root.ownerExpanded) {
-                return baselineExpanded;
+                return record.hover || record.explicitExpanded;
             }
             return isInteractiveKind(frame.kind);
         }
@@ -511,552 +440,531 @@ Scope {
             return (typeof token === "string" && token.length > 0 && token.length <= 128) || (
                         typeof token === "number" && Number.isSafeInteger(token));
         }
+
         function isSourceVersion(sourceGeneration, sourceRevision) {
             return Number.isInteger(sourceGeneration) && sourceGeneration > 0 && sourceGeneration
                     <= root.maximumSourceVersion && Number.isInteger(sourceRevision)
                     && sourceRevision > 0 && sourceRevision <= root.maximumSourceVersion;
         }
 
-        function matchesSource(record, kind, sourceToken, sourceGeneration) {
-            return record.kind === kind && record.sourceToken === sourceToken
-                    && record.sourceGeneration === sourceGeneration;
+        function invalidateTransient(sourceToken, sourceGeneration) {
+            if (!isSourceToken(sourceToken) || !Number.isInteger(sourceGeneration)
+                    || sourceGeneration <= 0) {
+                return false;
+            }
+            const now = currentTime();
+            const matches = [];
+            for (let index = 0; index < transients.length; index += 1) {
+                if (transients[index].sourceToken === sourceToken
+                        && transients[index].sourceGeneration === sourceGeneration) {
+                    matches.push(transients[index].id);
+                }
+            }
+            for (let index = 0; index < matches.length; index += 1) {
+                removeEvent(matches[index], now);
+            }
+            if (matches.length > 0) {
+                publish();
+            }
+            schedule(now);
+            return matches.length > 0;
         }
 
-        function matchesInvalidation(record, sourceToken, sourceGeneration) {
-            return isTransient(record.kind) && record.sourceToken === sourceToken
-                    && record.sourceGeneration === sourceGeneration;
-        }
-
-        function isInteractiveKind(kind) {
-            return kind === root.ownerLauncher || kind === root.ownerHistory || kind === root.ownerTray || kind
-                    === root.ownerAudio || kind === root.ownerSession;
-        }
         function isTransient(kind) {
             return kind === root.ownerWorkspace || kind === root.ownerBrightness || kind === root.ownerVolume || kind
                     === root.ownerNotification;
         }
 
-        function matchingSurface(initiatingSurfaceToken) {
-            if (surfaceToken === null) {
+        function openInteractive(kind, initiatingSurfaceToken) {
+            if (!isInteractiveKind(kind) || root.modalPresent) {
                 return false;
             }
-            return initiatingSurfaceToken === null || initiatingSurfaceToken === undefined
-                    || initiatingSurfaceToken === surfaceToken;
-        }
+            const token = routedToken(initiatingSurfaceToken, null);
+            const target = recordForToken(token);
+            if (target === null) {
+                return false;
+            }
 
-        function nextPendingIndex(now) {
-            let selected = -1;
-            for (let index = 0; index < pending.length; index += 1) {
-                const candidate = pending[index];
-                if (candidate.freshUntil <= now) {
+            for (let index = 0; index < surfaces.length; index += 1) {
+                const current = surfaces[index];
+                if (!isInteractiveKind(current.owner.kind)) {
                     continue;
                 }
-                if (selected < 0 || candidate.rank > pending[selected].rank || (candidate.rank
-                                                                                === pending[selected].rank
-                                                                                && candidate.admission
-                                                                                < pending[selected].admission)) {
-                    selected = index;
+                if (rankFor(kind) < current.owner.rank) {
+                    return false;
                 }
-            }
-            return selected;
-        }
-
-        function openLauncher(initiatingSurfaceToken) {
-            const now = currentTime();
-            expireDue(now);
-
-            if (!matchingSurface(initiatingSurfaceToken) || ownerKind === root.ownerPolkitModal
-                    || ownerRank > 6 || (isInteractiveKind(ownerKind) && ownerKind
-                                         !== root.ownerLauncher)) {
-                schedule(now);
-                return false;
-            }
-
-            if (ownerKind === root.ownerLauncher) {
-                if (presentationVisible) {
-                    focusRequestSerial += 1;
-                } else {
-                    focusPending = true;
+                if (current === target && current.owner.kind === kind) {
+                    if (current.owner.presentationVisible) {
+                        current.focusRequestSerial += 1;
+                    } else {
+                        current.owner.focusPending = true;
+                    }
+                    publish();
+                    return true;
                 }
-                schedule(now);
-                return true;
+                forceIdle(current);
             }
 
-            captureCurrent(now);
-            enterOwner(root.ownerLauncher, null, null, now);
-            schedule(now);
-            return true;
-        }
-
-        function openHistory(initiatingSurfaceToken) {
-            const now = currentTime();
-            expireDue(now);
-
-            if (!matchingSurface(initiatingSurfaceToken) || ownerKind === root.ownerPolkitModal
-                    || ownerRank > 6 || (isInteractiveKind(ownerKind) && ownerKind
-                                         !== root.ownerHistory)) {
-                schedule(now);
-                return false;
-            }
-
-            if (ownerKind === root.ownerHistory) {
-                if (presentationVisible) {
-                    focusRequestSerial += 1;
-                } else {
-                    focusPending = true;
-                }
-                schedule(now);
-                return true;
-            }
-
-            captureCurrent(now);
-            enterOwner(root.ownerHistory, null, null, now);
-            schedule(now);
-            return true;
-        }
-        function openTray(initiatingSurfaceToken) {
-            const now = currentTime();
-            expireDue(now);
-
-            if (!matchingSurface(initiatingSurfaceToken) || ownerKind === root.ownerPolkitModal
-                    || ownerRank > 6 || (isInteractiveKind(ownerKind) && ownerKind
-                                         !== root.ownerTray)) {
-                schedule(now);
-                return false;
-            }
-
-            if (ownerKind === root.ownerTray) {
-                if (presentationVisible) {
-                    focusRequestSerial += 1;
-                } else {
-                    focusPending = true;
-                }
-                schedule(now);
-                return true;
-            }
-
-            captureCurrent(now);
-            enterOwner(root.ownerTray, null, null, now);
-            schedule(now);
-            return true;
-        }
-
-        function openAudio(initiatingSurfaceToken) {
-            const now = currentTime();
-            expireDue(now);
-
-            if (!matchingSurface(initiatingSurfaceToken) || ownerKind === root.ownerPolkitModal
-                    || ownerRank > 6 || (isInteractiveKind(ownerKind) && ownerKind
-                                         !== root.ownerAudio)) {
-                schedule(now);
-                return false;
-            }
-
-            if (ownerKind === root.ownerAudio) {
-                if (presentationVisible) {
-                    focusRequestSerial += 1;
-                } else {
-                    focusPending = true;
-                }
-                schedule(now);
-                return true;
-            }
-
-            captureCurrent(now);
-            enterOwner(root.ownerAudio, null, null, now);
-            schedule(now);
-            return true;
-        }
-
-        function openSession(initiatingSurfaceToken) {
-            const now = currentTime();
-            expireDue(now);
-
-            if (!matchingSurface(initiatingSurfaceToken) || ownerKind === root.ownerPolkitModal) {
-                schedule(now);
-                return false;
-            }
-
-            if (ownerKind === root.ownerSession) {
-                schedule(now);
-                return true;
-            }
-
-            captureCurrent(now);
-            enterOwner(root.ownerSession, null, null, now);
-            schedule(now);
+            captureCurrent(target);
+            enterOwner(target, kind, null, 0, 0);
+            publish();
+            schedule(currentTime());
             return true;
         }
 
         function ownerName(kind) {
-            if (kind === root.ownerIdle) {
+            if (kind === root.ownerIdle)
                 return "idle";
-            }
-            if (kind === root.ownerWorkspace) {
+            if (kind === root.ownerWorkspace)
                 return "workspace";
-            }
-            if (kind === root.ownerBrightness) {
+            if (kind === root.ownerBrightness)
                 return "brightness";
-            }
-            if (kind === root.ownerVolume) {
+            if (kind === root.ownerVolume)
                 return "volume";
-            }
-            if (kind === root.ownerNotification) {
+            if (kind === root.ownerNotification)
                 return "notification";
-            }
-            if (kind === root.ownerExpanded) {
+            if (kind === root.ownerExpanded)
                 return "expanded";
-            }
-            if (kind === root.ownerLauncher) {
+            if (kind === root.ownerLauncher)
                 return "launcher";
-            }
-            if (kind === root.ownerSession) {
+            if (kind === root.ownerSession)
                 return "session";
-            }
-            if (kind === root.ownerHistory) {
+            if (kind === root.ownerHistory)
                 return "history";
-            }
-            if (kind === root.ownerTray) {
+            if (kind === root.ownerTray)
                 return "tray";
-            }
-            if (kind === root.ownerAudio) {
+            if (kind === root.ownerAudio)
                 return "audio";
-            }
-            if (kind === root.ownerPolkitModal) {
+            if (kind === root.ownerPolkitModal)
                 return "polkitModal";
-            }
             return "none";
         }
 
-        function queueTransient(record) {
-            let eviction = -1;
-            if (pending.length >= root.maximumPendingTransients) {
-                eviction = 0;
-                for (let index = 1; index < pending.length; index += 1) {
-                    if (pending[index].rank < pending[eviction].rank || (pending[index].rank
-                                                                         === pending[eviction].rank
-                                                                         && pending[index].admission
-                                                                         < pending[eviction].admission)) {
-                        eviction = index;
-                    }
-                }
+        function ownerRecord(kind, event, epoch, focusPending) {
+            return {
+                "epoch": epoch === null || epoch === undefined ? 0 : epoch,
+                "eventId": event === null ? 0 : event.id,
+                "focusPending": focusPending === true && (isInteractiveKind(kind) || kind
+                                                          === root.ownerPolkitModal || kind
+                                                          === root.ownerExpanded),
+                "focusTarget": focusFor(kind),
+                "kind": kind,
+                "presentationVisible": false,
+                "rank": rankFor(kind),
+                "revision": 1,
+                "sourceGeneration": event === null ? 0 : event.sourceGeneration,
+                "sourceRevision": event === null ? 0 : event.sourceRevision,
+                "sourceToken": event === null ? null : event.sourceToken
+            };
+        }
 
-                if (record.rank < pending[eviction].rank) {
-                    return false;
-                }
+        function prepareSurfaceDisable(token) {
+            const record = recordForToken(token);
+            if (record === null || modalHostToken === token) {
+                return false;
             }
-
-            const records = pending.slice();
-            if (eviction >= 0) {
-                records.splice(eviction, 1);
+            if (!isInteractiveKind(record.owner.kind)) {
+                return true;
             }
-            records.push(record);
-            pending = records;
+            const replacementToken = routedToken(null, token);
+            const replacement = recordForToken(replacementToken);
+            if (replacement === null) {
+                return false;
+            }
+            const kind = record.owner.kind;
+            const epoch = record.owner.epoch;
+            const revision = record.owner.revision;
+            forceIdle(record);
+            captureCurrent(replacement);
+            enterOwner(replacement, kind, null, epoch, revision + 1);
+            publish();
             return true;
         }
 
+        function projectEvent(event, now) {
+            for (let index = 0; index < event.targets.length; index += 1) {
+                const record = recordForToken(event.targets[index]);
+                if (record === null || record.owner.eventId === event.id) {
+                    continue;
+                }
+                if (event.rank > record.owner.rank) {
+                    captureCurrent(record);
+                    enterOwner(record, event.kind, event, 0, 0);
+                }
+            }
+        }
+
+        function publish() {
+            surfaces = surfaces.slice();
+            transients = transients.slice();
+            serial += 1;
+        }
+
         function rankFor(kind) {
-            if (kind === root.ownerIdle) {
+            if (kind === root.ownerIdle)
                 return 0;
-            }
-            if (kind === root.ownerWorkspace) {
+            if (kind === root.ownerWorkspace)
                 return 1;
-            }
-            if (kind === root.ownerBrightness) {
+            if (kind === root.ownerBrightness)
                 return 2;
-            }
-            if (kind === root.ownerVolume) {
+            if (kind === root.ownerVolume)
                 return 3;
-            }
-            if (kind === root.ownerNotification) {
+            if (kind === root.ownerNotification)
                 return 4;
-            }
-            if (kind === root.ownerExpanded) {
+            if (kind === root.ownerExpanded)
                 return 5;
-            }
-            if (kind === root.ownerLauncher) {
+            if (kind === root.ownerLauncher || kind === root.ownerHistory || kind === root.ownerTray
+                    || kind === root.ownerAudio)
                 return 6;
-            }
-            if (kind === root.ownerHistory) {
-                return 6;
-            }
-            if (kind === root.ownerTray) {
-                return 6;
-            }
-            if (kind === root.ownerAudio) {
-                return 6;
-            }
-            if (kind === root.ownerSession) {
+            if (kind === root.ownerSession)
                 return 7;
-            }
-            if (kind === root.ownerPolkitModal) {
+            if (kind === root.ownerPolkitModal)
                 return 8;
-            }
             return -1;
         }
 
-        function transientRecord(kind, sourceToken, sourceGeneration, sourceRevision, admission,
-                                 freshUntil) {
-            return {
-                "admission": admission,
-                "freshUntil": freshUntil,
+        function recordForToken(token) {
+            if (token === null || token === undefined) {
+                return null;
+            }
+            for (let index = 0; index < surfaces.length; index += 1) {
+                if (surfaces[index].token === token) {
+                    return surfaces[index];
+                }
+            }
+            return null;
+        }
+
+        function rehomeModal(excludedToken, capturePredecessor) {
+            if (!(modalIsActive || modalFlowPresent) || modalHostToken !== null) {
+                return;
+            }
+            const token = routedToken(null, excludedToken);
+            const record = recordForToken(token);
+            if (record === null) {
+                return;
+            }
+            if (capturePredecessor) {
+                for (let index = 0; index < surfaces.length; index += 1) {
+                    const current = surfaces[index];
+                    if (current !== record && isInteractiveKind(current.owner.kind)) {
+                        forceIdle(current);
+                    }
+                }
+            }
+            if (capturePredecessor) {
+                captureCurrent(record);
+            } else {
+                forceIdle(record);
+            }
+            enterOwner(record, root.ownerPolkitModal, null, 0, 0);
+            modalHostToken = token;
+        }
+
+        function removeEvent(eventId, now) {
+            const next = [];
+            for (let index = 0; index < transients.length; index += 1) {
+                if (transients[index].id !== eventId) {
+                    next.push(transients[index]);
+                }
+            }
+            transients = next;
+            for (let index = 0; index < surfaces.length; index += 1) {
+                const record = surfaces[index];
+                const frames = [];
+                for (let frameIndex = 0; frameIndex < record.restoration.length; frameIndex += 1) {
+                    if (record.restoration[frameIndex].eventId !== eventId) {
+                        frames.push(record.restoration[frameIndex]);
+                    }
+                }
+                record.restoration = frames;
+                if (record.owner.eventId === eventId) {
+                    restoreNext(record, now);
+                }
+            }
+        }
+
+        function removeTargetFromEvents(token) {
+            const now = currentTime();
+            const emptyEvents = [];
+            for (let index = 0; index < transients.length; index += 1) {
+                const event = transients[index];
+                event.targets = event.targets.filter(candidate => candidate !== token);
+                event.visibleTokens = event.visibleTokens.filter(candidate => candidate !== token);
+                if (event.targets.length === 0) {
+                    emptyEvents.push(event.id);
+                }
+            }
+            for (let index = 0; index < emptyEvents.length; index += 1) {
+                removeEvent(emptyEvents[index], now);
+            }
+        }
+
+        function requestTransient(kind, sourceToken, sourceGeneration, sourceRevision,
+                                  initiatingSurfaceToken, broadcast) {
+            const now = currentTime();
+            expireDue(now);
+            if (!isTransient(kind) || !isSourceToken(sourceToken) || !isSourceVersion(
+                        sourceGeneration, sourceRevision)) {
+                return false;
+            }
+
+            let event = null;
+            for (let index = 0; index < transients.length; index += 1) {
+                if (eventMatches(transients[index], kind, sourceToken, sourceGeneration)) {
+                    event = transients[index];
+                    break;
+                }
+            }
+            if (event !== null) {
+                if (sourceRevision <= event.sourceRevision) {
+                    schedule(now);
+                    return false;
+                }
+                event.sourceRevision = sourceRevision;
+                event.freshUntil = now + freshnessFor(kind);
+                event.holdUntil = -1;
+                event.visibleTokens = [];
+                for (let index = 0; index < surfaces.length; index += 1) {
+                    const record = surfaces[index];
+                    if (record.owner.eventId === event.id) {
+                        record.owner.revision += 1;
+                        record.owner.sourceRevision = sourceRevision;
+                        record.owner.presentationVisible = false;
+                    }
+                }
+                projectEvent(event, now);
+                publish();
+                schedule(now);
+                return true;
+            }
+
+            let targets = [];
+            if (broadcast) {
+                for (let index = 0; index < surfaces.length; index += 1) {
+                    targets.push(surfaces[index].token);
+                }
+            } else {
+                const token = routedToken(initiatingSurfaceToken, null);
+                if (token !== null) {
+                    targets.push(token);
+                }
+            }
+            if (targets.length === 0) {
+                return false;
+            }
+
+            nextAdmission += 1;
+            event = {
+                "admission": nextAdmission,
+                "freshUntil": now + freshnessFor(kind),
                 "holdDuration": holdFor(kind),
+                "holdUntil": -1,
+                "id": nextAdmission,
                 "kind": kind,
                 "rank": rankFor(kind),
                 "sourceGeneration": sourceGeneration,
                 "sourceRevision": sourceRevision,
                 "sourceToken": sourceToken,
-                "surfaceGeneration": surfaceGeneration
+                "targets": targets,
+                "visibleTokens": []
             };
-        }
-
-        function invalidateTransient(sourceToken, sourceGeneration) {
-            if (!isSourceToken(sourceToken) || !isSourceVersion(sourceGeneration, 1)) {
-                return false;
-            }
-
-            const now = currentTime();
-            expireDue(now);
-            let removed = false;
-            const nextPending = [];
-            for (let index = 0; index < pending.length; index += 1) {
-                if (matchesInvalidation(pending[index], sourceToken, sourceGeneration)) {
-                    removed = true;
-                } else {
-                    nextPending.push(pending[index]);
+            if (transients.length >= root.maximumPendingTransients) {
+                let eviction = 0;
+                for (let index = 1; index < transients.length; index += 1) {
+                    if (transients[index].rank < transients[eviction].rank || (
+                                transients[index].rank === transients[eviction].rank
+                                && transients[index].admission < transients[eviction].admission)) {
+                        eviction = index;
+                    }
                 }
-            }
-            pending = nextPending;
-
-            const nextRestoration = [];
-            for (let index = 0; index < restoration.length; index += 1) {
-                if (matchesInvalidation(restoration[index], sourceToken, sourceGeneration)) {
-                    removed = true;
-                } else {
-                    nextRestoration.push(restoration[index]);
-                }
-            }
-            restoration = nextRestoration;
-
-            if (isTransient(ownerKind) && ownerSourceToken === sourceToken && ownerSourceGeneration
-                    === sourceGeneration) {
-                removed = true;
-                restoreNext(now);
-            }
-
-            schedule(now);
-            return removed;
-        }
-
-        function requestTransient(kind, sourceToken, sourceGeneration, sourceRevision,
-                                  initiatingSurfaceToken) {
-            const now = currentTime();
-            expireDue(now);
-
-            if (!isTransient(kind) || !matchingSurface(initiatingSurfaceToken) || !isSourceToken(
-                        sourceToken) || !isSourceVersion(sourceGeneration, sourceRevision)) {
-                schedule(now);
-                return false;
-            }
-
-            const freshUntil = now + freshnessFor(kind);
-            if (ownerKind === kind && ownerSourceToken === sourceToken && ownerSourceGeneration
-                    === sourceGeneration) {
-                if (sourceRevision <= ownerSourceRevision) {
-                    schedule(now);
+                if (event.rank < transients[eviction].rank) {
                     return false;
                 }
-                revision += 1;
-                ownerSourceRevision = sourceRevision;
-                ownerFreshUntil = freshUntil;
-                ownerHoldDuration = holdFor(kind);
-                ownerHoldUntil = -1;
-                presentationVisible = false;
-                schedule(now);
-                return true;
+                removeEvent(transients[eviction].id, now);
             }
-
-            for (let index = restoration.length - 1; index >= 0; index -= 1) {
-                if (matchesSource(restoration[index], kind, sourceToken, sourceGeneration)) {
-                    if (sourceRevision <= restoration[index].sourceRevision) {
-                        schedule(now);
-                        return false;
-                    }
-                    const frames = restoration.slice();
-                    frames[index] = transientRecord(kind, sourceToken, sourceGeneration,
-                                                    sourceRevision, restoration[index].admission,
-                                                    freshUntil);
-                    restoration = frames;
-                    schedule(now);
-                    return true;
-                }
-            }
-
-            for (let index = 0; index < pending.length; index += 1) {
-                if (matchesSource(pending[index], kind, sourceToken, sourceGeneration)) {
-                    if (sourceRevision <= pending[index].sourceRevision) {
-                        schedule(now);
-                        return false;
-                    }
-                    const records = pending.slice();
-                    records[index] = transientRecord(kind, sourceToken, sourceGeneration,
-                                                     sourceRevision, pending[index].admission,
-                                                     freshUntil);
-                    pending = records;
-                    schedule(now);
-                    return true;
-                }
-            }
-
-            nextAdmission += 1;
-            const record = transientRecord(kind, sourceToken, sourceGeneration, sourceRevision,
-                                           nextAdmission, freshUntil);
-
-            if (record.rank > ownerRank) {
-                captureCurrent(now);
-                enterOwner(kind, sourceToken, record, now);
-                schedule(now);
-                return true;
-            }
-
-            const accepted = queueTransient(record);
-            schedule(now);
-            return accepted;
-        }
-
-        function restoreNext(now) {
-            let frames = restoration.slice();
-            while (frames.length > 0 && !isRelevantFrame(frames[frames.length - 1], now)) {
-                frames.pop();
-            }
-            restoration = frames;
-
-            const predecessor = frames.length === 0 ? null : frames[frames.length - 1];
-            const pendingIndex = nextPendingIndex(now);
-            const pendingRecord = pendingIndex < 0 ? null : pending[pendingIndex];
-            const baselineKind = baselineExpanded ? root.ownerExpanded : root.ownerIdle;
-            const baselineRank = rankFor(baselineKind);
-            const predecessorRank = predecessor === null ? -1 : predecessor.rank;
-            const pendingRank = pendingRecord === null ? -1 : pendingRecord.rank;
-
-            if (predecessor !== null && predecessorRank >= pendingRank && predecessorRank
-                    >= baselineRank) {
-                frames.pop();
-                restoration = frames;
-                enterOwner(predecessor.kind, predecessor.sourceToken, predecessor, now);
-                return;
-            }
-
-            if (pendingRecord !== null && pendingRank > baselineRank) {
-                const records = pending.slice();
-                records.splice(pendingIndex, 1);
-                pending = records;
-                enterOwner(pendingRecord.kind, pendingRecord.sourceToken, pendingRecord, now);
-                return;
-            }
-
-            restoration = [];
-            enterOwner(baselineKind, null, null, now);
-        }
-
-        function schedule(now) {
-            if (surfaceToken === null) {
-                scheduler.stop();
-                return;
-            }
-
-            let deadline = -1;
-            if (isTransient(ownerKind)) {
-                deadline = ownerFreshUntil;
-                if (presentationVisible) {
-                    deadline = Math.min(deadline, ownerHoldUntil);
-                }
-            }
-
-            for (let index = 0; index < pending.length; index += 1) {
-                if (deadline < 0 || pending[index].freshUntil < deadline) {
-                    deadline = pending[index].freshUntil;
-                }
-            }
-            for (let index = 0; index < restoration.length; index += 1) {
-                if (isTransient(restoration[index].kind) && (deadline < 0
-                                                             || restoration[index].freshUntil
-                                                             < deadline)) {
-                    deadline = restoration[index].freshUntil;
-                }
-            }
-
-            if (deadline < 0) {
-                scheduler.stop();
-                return;
-            }
-
-            scheduleSerial += 1;
-            armedScheduleSerial = scheduleSerial;
-            scheduledSurfaceGeneration = surfaceGeneration;
-            scheduledOwnerEpoch = ownerEpoch;
-            scheduledRevision = revision;
-            scheduler.interval = Math.max(1, Math.min(2147483647, Math.ceil(deadline - now)));
-            scheduler.restart();
-        }
-
-        function schedulerTriggered(generation, epoch, contentRevision, serial) {
-            if (generation !== surfaceGeneration || epoch !== ownerEpoch || contentRevision
-                    !== revision || serial !== armedScheduleSerial) {
-                return;
-            }
-
-            const now = currentTime();
-            expireDue(now);
-            schedule(now);
-        }
-
-        function setBaselineIntent(generation, value, explicitIntent) {
-            const now = currentTime();
-            expireDue(now);
-
-            if (typeof value !== "boolean" || generation !== surfaceGeneration || surfaceToken
-                    === null) {
-                schedule(now);
-                return false;
-            }
-
-            const wasExpanded = baselineExpanded;
-            const wasExplicit = explicitExpandedIntent;
-            if (explicitIntent) {
-                explicitExpandedIntent = value;
-            } else {
-                hoverIntent = value;
-            }
-
-            if (!wasExpanded && baselineExpanded && ownerRank < rankFor(root.ownerExpanded)) {
-                captureCurrent(now);
-                enterOwner(root.ownerExpanded, null, null, now);
-            } else if (wasExpanded && !baselineExpanded && ownerKind === root.ownerExpanded) {
-                restoreNext(now);
-            } else if (explicitIntent && value && ownerKind === root.ownerExpanded) {
-                focusTarget = root.focusExpandedDashboard;
-                if (presentationVisible) {
-                    focusRequestSerial += 1;
-                } else {
-                    focusPending = true;
-                }
-            } else if (explicitIntent && wasExplicit && !value && ownerKind
-                       === root.ownerExpanded) {
-                focusPending = false;
-                focusTarget = root.focusNone;
-            }
-
+            transients.push(event);
+            projectEvent(event, now);
+            publish();
             schedule(now);
             return true;
         }
 
-        function setExplicitExpanded(generation, expanded) {
-            return setBaselineIntent(generation, expanded, true);
+        function resetToIdle(initiatingSurfaceToken) {
+            const record = recordForToken(initiatingSurfaceToken);
+            if (record === null || modalHostToken === record.token) {
+                return false;
+            }
+            forceIdle(record);
+            publish();
+            schedule(currentTime());
+            return true;
         }
 
-        function setHover(generation, hovered) {
-            return setBaselineIntent(generation, hovered, false);
+        function restoreNext(record, now) {
+            let predecessor = null;
+            while (record.restoration.length > 0) {
+                const candidate = record.restoration[record.restoration.length - 1];
+                record.restoration = record.restoration.slice(0, -1);
+                if (isRelevantFrame(candidate, record, now)) {
+                    predecessor = candidate;
+                    break;
+                }
+            }
+            let pendingEvent = null;
+            for (let index = 0; index < transients.length; index += 1) {
+                const candidate = transients[index];
+                if (candidate.freshUntil <= now || candidate.targets.indexOf(record.token) < 0
+                        || record.owner.eventId === candidate.id) {
+                    continue;
+                }
+                if (pendingEvent === null || candidate.rank > pendingEvent.rank || (candidate.rank
+                                                                                    === pendingEvent.rank
+                                                                                    && candidate.admission
+                                                                                    < pendingEvent.admission)) {
+                    pendingEvent = candidate;
+                }
+            }
+            const baseline = baselineKind(record);
+            const predecessorRank = predecessor === null ? -1 : predecessor.rank;
+            const pendingRank = pendingEvent === null ? -1 : pendingEvent.rank;
+            const baselineRank = rankFor(baseline);
+            if (predecessor !== null && predecessorRank >= pendingRank && predecessorRank
+                    >= baselineRank) {
+                record.owner = predecessor;
+                record.owner.revision += 1;
+                record.owner.presentationVisible = false;
+                record.owner.focusPending = isInteractiveKind(record.owner.kind) || (
+                            record.owner.kind === root.ownerExpanded && record.explicitExpanded);
+                record.owner.focusTarget = record.owner.focusPending ? focusFor(record.owner.kind) :
+                                                                       root.focusNone;
+                return;
+            }
+            if (pendingEvent !== null && pendingRank > baselineRank) {
+                enterOwner(record, pendingEvent.kind, pendingEvent, 0, 0);
+                return;
+            }
+            record.restoration = [];
+            record.owner = baselineOwner(baseline === root.ownerExpanded);
+            if (baseline === root.ownerExpanded && record.explicitExpanded) {
+                record.owner.focusPending = true;
+            }
+        }
+
+        function routedToken(initiatingSurfaceToken, excludedToken) {
+            const initiated = recordForToken(initiatingSurfaceToken);
+            if (initiated !== null && initiated.token !== excludedToken) {
+                return initiated.token;
+            }
+            if (root.surfaceRouter !== null && root.surfaceRouter !== undefined
+                    && typeof root.surfaceRouter.routeSurfaceToken === "function") {
+                const routed = root.surfaceRouter.routeSurfaceToken(excludedToken);
+                if (recordForToken(routed) !== null && routed !== excludedToken) {
+                    return routed;
+                }
+            }
+            for (let index = 0; index < surfaces.length; index += 1) {
+                if (surfaces[index].token !== excludedToken) {
+                    return surfaces[index].token;
+                }
+            }
+            return null;
+        }
+
+        function schedule(now) {
+            let deadline = -1;
+            for (let index = 0; index < transients.length; index += 1) {
+                const event = transients[index];
+                const candidate = event.holdUntil >= 0 ? Math.min(event.freshUntil,
+                                                                  event.holdUntil) :
+                                                         event.freshUntil;
+                if (deadline < 0 || candidate < deadline) {
+                    deadline = candidate;
+                }
+            }
+            if (deadline < 0) {
+                scheduler.stop();
+                return;
+            }
+            scheduler.interval = Math.max(1, Math.min(2147483647, Math.ceil(deadline - now)));
+            scheduler.restart();
+        }
+
+        function setBaselineIntent(token, generation, value, explicitIntent) {
+            const now = currentTime();
+            expireDue(now);
+            const record = recordForToken(token);
+            if (record === null || record.generation !== generation || typeof value !== "boolean") {
+                return false;
+            }
+            const wasExpanded = record.hover || record.explicitExpanded;
+            if (explicitIntent) {
+                record.explicitExpanded = value;
+            } else {
+                record.hover = value;
+            }
+            const expanded = record.hover || record.explicitExpanded;
+            if (!wasExpanded && expanded && record.owner.rank < rankFor(root.ownerExpanded)) {
+                captureCurrent(record);
+                enterOwner(record, root.ownerExpanded, null, 0, 0);
+                record.owner.focusPending = record.explicitExpanded;
+                record.owner.focusTarget = record.explicitExpanded ? root.focusExpandedDashboard :
+                                                                     root.focusNone;
+            } else if (wasExpanded && !expanded && record.owner.kind === root.ownerExpanded) {
+                restoreNext(record, now);
+            } else if (explicitIntent && value && record.owner.kind === root.ownerExpanded) {
+                record.owner.focusTarget = root.focusExpandedDashboard;
+                if (record.owner.presentationVisible) {
+                    record.focusRequestSerial += 1;
+                } else {
+                    record.owner.focusPending = true;
+                }
+            } else if (explicitIntent && !value && record.owner.kind === root.ownerExpanded) {
+                record.owner.focusPending = false;
+                record.owner.focusTarget = root.focusNone;
+            }
+            publish();
+            schedule(now);
+            return true;
+        }
+
+        function surfaceSnapshot(token) {
+            const ignored = serial;
+            const record = recordForToken(token);
+            if (record === null) {
+                return Object.freeze({
+                                         "explicitExpandedIntent": false,
+                                         "focusRequestSerial": 0,
+                                         "focusTarget": root.focusNone,
+                                         "generation": 0,
+                                         "hoverIntent": false,
+                                         "ownerEpoch": 0,
+                                         "ownerKind": root.ownerNone,
+                                         "ownerName": "none",
+                                         "ownerSourceGeneration": 0,
+                                         "ownerSourceRevision": 0,
+                                         "ownerSourceToken": null,
+                                         "presentationVisible": false,
+                                         "restorationDepth": 0,
+                                         "revision": 0
+                                     });
+            }
+            return Object.freeze({
+                                     "explicitExpandedIntent": record.explicitExpanded,
+                                     "focusRequestSerial": record.focusRequestSerial,
+                                     "focusTarget": record.owner.focusTarget,
+                                     "generation": record.generation,
+                                     "hoverIntent": record.hover,
+                                     "ownerEpoch": record.owner.epoch,
+                                     "ownerKind": record.owner.kind,
+                                     "ownerName": ownerName(record.owner.kind),
+                                     "ownerSourceGeneration": record.owner.sourceGeneration,
+                                     "ownerSourceRevision": record.owner.sourceRevision,
+                                     "ownerSourceToken": record.owner.sourceToken,
+                                     "presentationVisible": record.owner.presentationVisible,
+                                     "restorationDepth": record.restoration.length,
+                                     "revision": record.owner.revision
+                                 });
         }
 
         function syncPolkitModal(isActive, flowPresent, flowGeneration) {
@@ -1064,33 +972,42 @@ Scope {
                     !Number.isInteger(flowGeneration) || flowGeneration < 0) {
                 return false;
             }
-
-            const now = currentTime();
-            expireDue(now);
-            const wasPresent = modalPresent;
+            const wasPresent = modalIsActive || modalFlowPresent;
             const snapshotChanged = modalIsActive !== isActive || modalFlowPresent !== flowPresent
                   || modalFlowGeneration !== flowGeneration;
-
             modalIsActive = isActive;
             modalFlowPresent = flowPresent;
             modalFlowGeneration = flowGeneration;
-
-            if (!wasPresent && modalPresent) {
-                if (surfaceToken !== null) {
-                    captureCurrent(now);
-                    enterOwner(root.ownerPolkitModal, null, null, now);
+            const present = modalIsActive || modalFlowPresent;
+            if (!wasPresent && present) {
+                rehomeModal(null, true);
+            } else if (wasPresent && present && snapshotChanged) {
+                const record = recordForToken(modalHostToken);
+                if (record !== null && record.owner.kind === root.ownerPolkitModal) {
+                    record.owner.revision += 1;
+                    record.owner.presentationVisible = false;
+                    record.owner.focusPending = true;
                 }
-            } else if (wasPresent && modalPresent && snapshotChanged && ownerKind
-                       === root.ownerPolkitModal) {
-                revision += 1;
-                presentationVisible = false;
-                focusPending = true;
-            } else if (wasPresent && !modalPresent && ownerKind === root.ownerPolkitModal) {
-                restoreNext(now);
+            } else if (wasPresent && !present) {
+                const record = recordForToken(modalHostToken);
+                modalHostToken = null;
+                if (record !== null && record.owner.kind === root.ownerPolkitModal) {
+                    restoreNext(record, currentTime());
+                }
             }
-
-            schedule(now);
+            publish();
+            schedule(currentTime());
             return true;
+        }
+
+        function transferInteractiveAfterLoss(kind, epoch, excludedToken) {
+            const token = routedToken(null, excludedToken);
+            const target = recordForToken(token);
+            if (target === null) {
+                return;
+            }
+            captureCurrent(target);
+            enterOwner(target, kind, null, epoch, 1);
         }
     }
 
@@ -1102,9 +1019,11 @@ Scope {
         id: scheduler
 
         repeat: false
-        onTriggered: reducer.schedulerTriggered(reducer.scheduledSurfaceGeneration,
-                                                reducer.scheduledOwnerEpoch,
-                                                reducer.scheduledRevision,
-                                                reducer.armedScheduleSerial)
+        onTriggered: {
+            const now = state.currentTime();
+            state.expireDue(now);
+            state.publish();
+            state.schedule(now);
+        }
     }
 }

--- a/qml/IslandSurface.qml
+++ b/qml/IslandSurface.qml
@@ -7,7 +7,9 @@ PanelWindow {
     id: surface
 
     required property var coordinator
+    required property var hostSurfaceToken
     required property int hostSurfaceGeneration
+    required property var surfaceHost
 
     // Normalized idle data sources. Null keeps the matching block collapsed,
     // so harnesses can mount the surface without the full adapter set.
@@ -38,11 +40,27 @@ PanelWindow {
     property Component dashboardNotificationsContent: null
     property Component dashboardNavigationContent: null
 
-    readonly property int ownerKind: coordinator.ownerKind
-    readonly property real ownerEpoch: coordinator.ownerEpoch
-    readonly property real ownerRevision: coordinator.revision
-    readonly property int focusTarget: coordinator.focusTarget
-    readonly property real focusRequestSerial: coordinator.focusRequestSerial
+    property var surfaceState: ({
+                                    "focusRequestSerial": 0,
+                                    "focusTarget": coordinator.focusNone,
+                                    "ownerEpoch": 0,
+                                    "ownerKind": coordinator.ownerNone,
+                                    "ownerName": "none",
+                                    "ownerSourceGeneration": 0,
+                                    "ownerSourceRevision": 0,
+                                    "ownerSourceToken": null,
+                                    "presentationVisible": false,
+                                    "revision": 0
+                                })
+
+    function refreshSurfaceState() {
+        surfaceState = coordinator.surfaceSnapshot(hostSurfaceToken);
+    }
+    readonly property int ownerKind: surfaceState.ownerKind
+    readonly property real ownerEpoch: surfaceState.ownerEpoch
+    readonly property real ownerRevision: surfaceState.revision
+    readonly property int focusTarget: surfaceState.focusTarget
+    readonly property real focusRequestSerial: surfaceState.focusRequestSerial
     readonly property bool expanded: ownerKind === coordinator.ownerExpanded
     readonly property bool launcher: ownerKind === coordinator.ownerLauncher
     readonly property bool session: ownerKind === coordinator.ownerSession
@@ -292,9 +310,9 @@ PanelWindow {
                 !== "function") {
             return null;
         }
-        const resolved = source.resolveTransient(coordinator.ownerSourceToken,
-                                                 coordinator.ownerSourceGeneration,
-                                                 coordinator.ownerSourceRevision);
+        const resolved = source.resolveTransient(surfaceState.ownerSourceToken,
+                                                 surfaceState.ownerSourceGeneration,
+                                                 surfaceState.ownerSourceRevision);
         return resolved !== null && typeof resolved === "object" && !Array.isArray(resolved)
                 ? resolved : null;
     }
@@ -328,7 +346,7 @@ PanelWindow {
             return;
         }
 
-        coordinator.acknowledgeVisible(generation, epoch, contentRevision);
+        coordinator.acknowledgeVisible(hostSurfaceToken, generation, epoch, contentRevision);
     }
 
     function cancelDashboard() {
@@ -339,8 +357,10 @@ PanelWindow {
         // Explicit close/cancel also suppresses the current hover sample. The
         // HoverHandler will report true again only after a real pointer exit
         // and re-entry, so Close is never an inert control.
-        const explicitAccepted = coordinator.setExplicitExpanded(hostSurfaceGeneration, false);
-        const hoverAccepted = coordinator.setHover(hostSurfaceGeneration, false);
+        const explicitAccepted = coordinator.setExplicitExpanded(hostSurfaceToken,
+                                                                 hostSurfaceGeneration, false);
+        const hoverAccepted = coordinator.setHover(hostSurfaceToken, hostSurfaceGeneration, false);
+        refreshSurfaceState();
         return explicitAccepted && hoverAccepted;
     }
 
@@ -369,6 +389,9 @@ PanelWindow {
         const epoch = ownerEpoch;
         const serial = focusRequestSerial;
         Qt.callLater(function () {
+            if (surface === null) {
+                return;
+            }
             if (generation !== surface.hostSurfaceGeneration || epoch !== surface.ownerEpoch
                     || serial !== surface.focusRequestSerial) {
                 return;
@@ -415,7 +438,9 @@ PanelWindow {
         const epoch = ownerEpoch;
         const contentRevision = ownerRevision;
         Qt.callLater(function () {
-            surface.acknowledgePresentation(generation, epoch, contentRevision);
+            if (surface !== null) {
+                surface.acknowledgePresentation(generation, epoch, contentRevision);
+            }
         });
     }
 
@@ -423,11 +448,16 @@ PanelWindow {
         if (shellMenuOpen && !hovered) {
             return true;
         }
-        return coordinator.setHover(hostSurfaceGeneration, hovered);
+        const accepted = coordinator.setHover(hostSurfaceToken, hostSurfaceGeneration, hovered);
+        refreshSurfaceState();
+        return accepted;
     }
 
     function requestDeliberateExpansion() {
-        return coordinator.setExplicitExpanded(hostSurfaceGeneration, true);
+        const accepted = coordinator.setExplicitExpanded(hostSurfaceToken, hostSurfaceGeneration,
+                                                         true);
+        refreshSurfaceState();
+        return accepted;
     }
 
     function beginShellMenu() {
@@ -452,7 +482,7 @@ PanelWindow {
 
     function completeShellMenuAction() {
         cancelShellMenu();
-        return coordinator.resetToIdle(coordinator.surfaceToken);
+        return coordinator.resetToIdle(hostSurfaceToken);
     }
 
     function handleWindowActivation(active) {
@@ -471,7 +501,7 @@ PanelWindow {
             return false;
         }
         shellWindowWasActive = false;
-        return coordinator.resetToIdle(coordinator.surfaceToken);
+        return coordinator.resetToIdle(hostSurfaceToken);
     }
 
     function safeLogicalSize(preferredSize, screenSize) {
@@ -514,6 +544,7 @@ PanelWindow {
     }
 
     Component.onCompleted: {
+        refreshSurfaceState();
         previousOwnerKind = ownerKind;
         syncDashboardReveal();
         queuePresentationAcknowledgement();
@@ -534,6 +565,7 @@ PanelWindow {
             reportHover(true);
         }
     }
+    onHostSurfaceTokenChanged: refreshSurfaceState()
 
     Connections {
         target: surface.backingWindow
@@ -547,25 +579,17 @@ PanelWindow {
     Connections {
         target: surface.coordinator
 
-        function onFocusRequestSerialChanged() {
-            surface.queueOwnerFocus();
-        }
-
-        function onPresentationVisibleChanged() {
-            if (surface.coordinator.presentationVisible) {
-                Qt.callLater(surface.queueOwnerFocus);
-            }
-        }
-
-        function onOwnerEpochChanged() {
-            surface.focusedOwnerEpoch = 0;
-            surface.queuePresentationAcknowledgement();
-        }
-
-        function onRevisionChanged() {
-            surface.queuePresentationAcknowledgement();
+        function onStateSerialChanged() {
+            Qt.callLater(surface.refreshSurfaceState);
         }
     }
+
+    onFocusRequestSerialChanged: queueOwnerFocus()
+    onOwnerEpochChanged: {
+        focusedOwnerEpoch = 0;
+        queuePresentationAcknowledgement();
+    }
+    onOwnerRevisionChanged: queuePresentationAcknowledgement()
 
     Connections {
         target: surface.applicationModel
@@ -577,7 +601,7 @@ PanelWindow {
             }
             surface.launcherRequestId = 0;
             surface.launcherRequestOwnerEpoch = 0;
-            surface.coordinator.resetToIdle(surface.coordinator.surfaceToken);
+            surface.coordinator.resetToIdle(surface.hostSurfaceToken);
         }
 
         function onLaunchRejected(requestId, category) {
@@ -702,7 +726,7 @@ PanelWindow {
         sourceComponent: Component {
             TransientView {
                 active: transientLoader.visible
-                kind: surface.coordinator.ownerName
+                kind: surface.surfaceState.ownerName
                 ownerEpoch: surface.ownerEpoch
                 ownerRevision: surface.ownerRevision
                 presentation: surface.transientPresentation

--- a/qml/IslandSurfaceHost.qml
+++ b/qml/IslandSurfaceHost.qml
@@ -1,5 +1,6 @@
 pragma ComponentBehavior: Bound
 
+import Nagi.Platform 1.0
 import Quickshell
 import QtQuick
 
@@ -8,7 +9,6 @@ Scope {
 
     required property var coordinator
 
-    // Normalized idle data sources relayed to the island surface.
     property var virtualDesktops: null
     property var clock: null
     property var weather: null
@@ -16,6 +16,7 @@ Scope {
     property var sessionService: null
     property var polkitController: null
     property var notificationService: null
+    property var connectivityAdapter: null
     property var applicationModel: null
     property var trayAdapter: null
     property var audioAdapter: null
@@ -23,289 +24,473 @@ Scope {
     property var brightnessTransientSource: null
     property var volumeTransientSource: null
     property var notificationTransientSource: null
-    property bool reducedMotion: false
     property Component dashboardMediaContent: null
     property Component dashboardClockContent: null
     property Component dashboardQuickControlsContent: null
     property Component dashboardAudioContent: null
     property Component dashboardNotificationsContent: null
     property Component dashboardNavigationContent: null
+    property string settingsFailure: ""
 
-    readonly property int surfaceGeneration: ownership.surfaceGeneration
-    readonly property var surfaceToken: ownership.surfaceToken
-    readonly property var menuParentWindow: ownership.liveSurface
-    readonly property int surfaceWidth: ownership.liveSurface === null ? 0 :
-                                                                         ownership.liveSurface.width
+    signal systemSettingsRequested(var initiatingSurfaceToken)
+    property bool reducedMotion: false
 
-    readonly property int surfaceHeight: ownership.liveSurface === null ? 0 :
-                                                                          ownership.liveSurface.height
+    readonly property int revision: displays.revision + registryRevision
+    readonly property int liveSurfaceCount: registry.length
+    readonly property int enabledDisplayCount: displays.enabledDisplayCount
+    readonly property var rememberedDisplays: displays.rememberedDisplays
+    readonly property var surfaceToken: routeFallbackToken(null)
+    readonly property int surfaceGeneration: generationForToken(surfaceToken)
+    readonly property var menuParentWindow: fallbackSurface
+    readonly property var fallbackSurface: surfaceForToken(surfaceToken)
+    readonly property int surfaceWidth: fallbackSurface === null ? 0 : fallbackSurface.width
+    readonly property int surfaceHeight: fallbackSurface === null ? 0 : fallbackSurface.height
+    readonly property int surfaceScreenWidth: fallbackSurface === null || fallbackSurface.screen
+                                              === null ? 0 : fallbackSurface.screen.width
+    readonly property int surfaceLeftMargin: fallbackSurface === null ? 0 :
+                                                                        fallbackSurface.margins.left
+    readonly property int surfaceTopMargin: fallbackSurface === null ? 0 :
+                                                                       fallbackSurface.margins.top
+    readonly property int surfacePreferredWidth: fallbackSurface === null ? 0 :
+                                                                            fallbackSurface.preferredWidth
+    readonly property int surfacePreferredHeight: fallbackSurface === null ? 0 :
+                                                                             fallbackSurface.preferredHeight
+    readonly property bool backgroundCoversSurface: fallbackSurface !== null
+                                                    && fallbackSurface.backgroundCoversSurface
+    readonly property real backgroundRadius: fallbackSurface === null ? 0 :
+                                                                        fallbackSurface.backgroundRadius
+    readonly property bool surfaceFocusable: fallbackSurface !== null && fallbackSurface.focusable
+    readonly property bool dashboardFocused: fallbackSurface !== null
+                                             && fallbackSurface.dashboardFocused
+    readonly property int loadedDashboardRegionCount: fallbackSurface === null ? 0 :
+                                                                                 fallbackSurface.loadedDashboardRegionCount
+    readonly property bool interactiveExitRunning: fallbackSurface !== null
+                                                   && fallbackSurface.interactiveExitRunning
+    readonly property int interactiveExitDuration: fallbackSurface === null ? 0 :
+                                                                              fallbackSurface.interactiveExitDuration
+    readonly property real interactiveExitOffset: fallbackSurface === null ? 0 :
+                                                                             fallbackSurface.interactiveExitOffset
+    readonly property real interactiveExitLoaderX: fallbackSurface === null ? 0 :
+                                                                              fallbackSurface.interactiveExitLoaderX
+    readonly property real interactiveExitMappedX: fallbackSurface === null ? 0 :
+                                                                              fallbackSurface.interactiveExitMappedX
+    readonly property bool interactiveExitLoaderEnabled: fallbackSurface !== null
+                                                         && fallbackSurface.interactiveExitLoaderEnabled
+    readonly property var interactiveExitItem: fallbackSurface === null ? null :
+                                                                          fallbackSurface.interactiveExitItem
+    readonly property bool launcherLoaded: fallbackSurface !== null
+                                           && fallbackSurface.launcherLoaded
+    readonly property bool launcherFocused: fallbackSurface !== null
+                                            && fallbackSurface.launcherFocused
+    readonly property int launcherResultCount: fallbackSurface === null ? 0 :
+                                                                          fallbackSurface.launcherResultCount
+    readonly property bool launcherResultScrollVisible: fallbackSurface !== null
+                                                        && fallbackSurface.launcherResultScrollVisible
+    readonly property string launcherSelectedId: fallbackSurface === null ? "" :
+                                                                            fallbackSurface.launcherSelectedId
+    readonly property bool sessionLoaded: fallbackSurface !== null && fallbackSurface.sessionLoaded
+    readonly property bool sessionFocused: fallbackSurface !== null
+                                           && fallbackSurface.sessionFocused
+    readonly property bool trayLoaded: fallbackSurface !== null && fallbackSurface.trayLoaded
+    readonly property bool trayFocused: fallbackSurface !== null && fallbackSurface.trayFocused
+    readonly property bool audioLoaded: fallbackSurface !== null && fallbackSurface.audioLoaded
+    readonly property bool audioFocused: fallbackSurface !== null && fallbackSurface.audioFocused
+    readonly property bool polkitLoaded: fallbackSurface !== null && fallbackSurface.polkitLoaded
+    readonly property bool polkitFocused: fallbackSurface !== null && fallbackSurface.polkitFocused
+    readonly property bool polkitResponseFocused: fallbackSurface !== null
+                                                  && fallbackSurface.polkitResponseFocused
+    readonly property int polkitIdentityCount: fallbackSurface === null ? 0 :
+                                                                          fallbackSurface.polkitIdentityCount
+    readonly property bool polkitResponseFieldVisible: fallbackSurface !== null
+                                                       && fallbackSurface.polkitResponseFieldVisible
+    readonly property bool historyLoaded: fallbackSurface !== null && fallbackSurface.historyLoaded
+    readonly property bool historyFocused: fallbackSurface !== null
+                                           && fallbackSurface.historyFocused
+    readonly property int historyRowCount: fallbackSurface === null ? 0 :
+                                                                      fallbackSurface.historyRowCount
+    readonly property bool historyEmptyStateVisible: fallbackSurface !== null
+                                                     && fallbackSurface.historyEmptyStateVisible
+    readonly property int geometryAnimationDuration: fallbackSurface === null ? 0 :
+                                                                                fallbackSurface.geometryAnimationDuration
+    readonly property bool geometryAnimationRunning: fallbackSurface !== null
+                                                     && fallbackSurface.geometryAnimationRunning
+    readonly property bool transientCommitted: fallbackSurface !== null
+                                               && fallbackSurface.transientCommitted
+    readonly property bool transientEntryAnimationRunning: fallbackSurface !== null
+                                                           && fallbackSurface.transientEntryAnimationRunning
+    readonly property string transientPrimaryText: fallbackSurface === null ? "" :
+                                                                              fallbackSurface.transientPrimaryText
+    readonly property string transientDetailText: fallbackSurface === null ? "" :
+                                                                             fallbackSurface.transientDetailText
+    readonly property string lastFailure: failureText
 
-    // Requested layer-shell geometry is observable on Wayland even though the
-    // compositor does not publish a trustworthy global QWindow position.
-    readonly property int surfaceScreenWidth: ownership.liveSurface === null
-                                              || ownership.liveSurface.screen === null ? 0 :
-                                                                                         ownership.liveSurface.screen.width
-    readonly property int surfaceLeftMargin: ownership.liveSurface === null ? 0 :
-                                                                              ownership.liveSurface.margins.left
-    readonly property int surfaceTopMargin: ownership.liveSurface === null ? 0 :
-                                                                             ownership.liveSurface.margins.top
+    property var registry: []
+    property var entries: []
+    property int registryRevision: 0
+    property int nextSurfaceGeneration: 0
+    property string failureText: ""
 
-    readonly property int surfacePreferredWidth: ownership.liveSurface === null ? 0 :
-                                                                                  ownership.liveSurface.preferredWidth
-    readonly property int surfacePreferredHeight: ownership.liveSurface === null ? 0 :
-                                                                                   ownership.liveSurface.preferredHeight
-    readonly property bool backgroundCoversSurface: ownership.liveSurface !== null
-                                                    && ownership.liveSurface.backgroundCoversSurface
-    readonly property real backgroundRadius: ownership.liveSurface === null ? 0 :
-                                                                              ownership.liveSurface.backgroundRadius
+    function activeDisplays() {
+        const ignored = revision;
+        return displays.activeDisplays();
+    }
 
-    readonly property bool surfaceFocusable: ownership.liveSurface !== null
-                                             && ownership.liveSurface.focusable
-    readonly property bool dashboardFocused: ownership.liveSurface !== null
-                                             && ownership.liveSurface.dashboardFocused
-    readonly property int loadedDashboardRegionCount: ownership.liveSurface === null ? 0 :
-                                                                                       ownership.liveSurface.loadedDashboardRegionCount
-    readonly property bool interactiveExitRunning: ownership.liveSurface !== null
-                                                   && ownership.liveSurface.interactiveExitRunning
-    readonly property int interactiveExitDuration: ownership.liveSurface === null ? 0 :
-                                                                                    ownership.liveSurface.interactiveExitDuration
-    readonly property real interactiveExitOffset: ownership.liveSurface === null ? 0 :
-                                                                                   ownership.liveSurface.interactiveExitOffset
-    readonly property real interactiveExitLoaderX: ownership.liveSurface === null ? 0 :
-                                                                                    ownership.liveSurface.interactiveExitLoaderX
-    readonly property real interactiveExitMappedX: ownership.liveSurface === null ? 0 :
-                                                                                    ownership.liveSurface.interactiveExitMappedX
-    readonly property bool interactiveExitLoaderEnabled: ownership.liveSurface !== null
-                                                         && ownership.liveSurface.interactiveExitLoaderEnabled
-    readonly property var interactiveExitItem: ownership.liveSurface === null ? null :
-                                                                                ownership.liveSurface.interactiveExitItem
-    readonly property bool launcherLoaded: ownership.liveSurface !== null
-                                           && ownership.liveSurface.launcherLoaded
-    readonly property bool launcherFocused: ownership.liveSurface !== null
-                                            && ownership.liveSurface.launcherFocused
-    readonly property int launcherResultCount: ownership.liveSurface === null ? 0 :
-                                                                                ownership.liveSurface.launcherResultCount
-    readonly property bool launcherResultScrollVisible: ownership.liveSurface !== null
-                                                        && ownership.liveSurface.launcherResultScrollVisible
-    readonly property string launcherSelectedId: ownership.liveSurface === null ? "" :
-                                                                                  ownership.liveSurface.launcherSelectedId
-    readonly property bool sessionLoaded: ownership.liveSurface !== null
-                                          && ownership.liveSurface.sessionLoaded
-    readonly property bool sessionFocused: ownership.liveSurface !== null
-                                           && ownership.liveSurface.sessionFocused
-    readonly property bool trayLoaded: ownership.liveSurface !== null
-                                       && ownership.liveSurface.trayLoaded
-    readonly property bool trayFocused: ownership.liveSurface !== null
-                                        && ownership.liveSurface.trayFocused
-    readonly property bool audioLoaded: ownership.liveSurface !== null
-                                        && ownership.liveSurface.audioLoaded
-    readonly property bool audioFocused: ownership.liveSurface !== null
-                                         && ownership.liveSurface.audioFocused
-    readonly property bool polkitLoaded: ownership.liveSurface !== null
-                                         && ownership.liveSurface.polkitLoaded
-    readonly property bool polkitFocused: ownership.liveSurface !== null
-                                          && ownership.liveSurface.polkitFocused
-    readonly property bool polkitResponseFocused: ownership.liveSurface !== null
-                                                  && ownership.liveSurface.polkitResponseFocused
-    readonly property int polkitIdentityCount: ownership.liveSurface === null ? 0 :
-                                                                                ownership.liveSurface.polkitIdentityCount
-    readonly property bool polkitResponseFieldVisible: ownership.liveSurface !== null
-                                                       && ownership.liveSurface.polkitResponseFieldVisible
-    readonly property bool historyLoaded: ownership.liveSurface !== null
-                                          && ownership.liveSurface.historyLoaded
-    readonly property bool historyFocused: ownership.liveSurface !== null
-                                           && ownership.liveSurface.historyFocused
-    readonly property int historyRowCount: ownership.liveSurface === null ? 0 :
-                                                                            ownership.liveSurface.historyRowCount
-    readonly property bool historyEmptyStateVisible: ownership.liveSurface !== null
-                                                     && ownership.liveSurface.historyEmptyStateVisible
-    readonly property int geometryAnimationDuration: ownership.liveSurface === null ? 0 :
-                                                                                      ownership.liveSurface.geometryAnimationDuration
-    readonly property bool geometryAnimationRunning: ownership.liveSurface !== null
-                                                     && ownership.liveSurface.geometryAnimationRunning
-    readonly property bool transientCommitted: ownership.liveSurface !== null
-                                               && ownership.liveSurface.transientCommitted
-    readonly property bool transientEntryAnimationRunning: ownership.liveSurface !== null
-                                                           && ownership.liveSurface.transientEntryAnimationRunning
-    readonly property string transientPrimaryText: ownership.liveSurface === null ? "" :
-                                                                                    ownership.liveSurface.transientPrimaryText
-    readonly property string transientDetailText: ownership.liveSurface === null ? "" :
-                                                                                   ownership.liveSurface.transientDetailText
+    function beginShellMenu(token) {
+        const surface = surfaceForToken(token);
+        return surface !== null && surface.beginShellMenu();
+    }
 
     function cancelDashboard() {
-        return ownership.liveSurface !== null && ownership.liveSurface.cancelDashboard();
+        return fallbackSurface !== null && fallbackSurface.cancelDashboard();
     }
 
     function requestDeliberateExpansion() {
-        return ownership.liveSurface !== null && ownership.liveSurface.requestDeliberateExpansion();
+        return fallbackSurface !== null && fallbackSurface.requestDeliberateExpansion();
+    }
+    function completeShellMenuAction(token) {
+        const surface = surfaceForToken(token);
+        return surface !== null && surface.completeShellMenuAction();
     }
 
-    function beginShellMenu() {
-        return ownership.liveSurface !== null && ownership.liveSurface.beginShellMenu();
+    function confirmForget(identity) {
+        failureText
+                = "Disconnected displays cannot be remembered without a stable platform identity.";
+        return false;
     }
 
-    function finishShellMenuOpen(result) {
-        return ownership.liveSurface !== null && ownership.liveSurface.finishShellMenuOpen(result);
-    }
-
-    function completeShellMenuAction() {
-        return ownership.liveSurface !== null && ownership.liveSurface.completeShellMenuAction();
-    }
-
-    QtObject {
-        id: ownership
-
-        // QsWindow can report provisional screens while the layer-shell surface settles.
-        readonly property int surfaceSettleDelay: 50
-        property var liveSurface: null
-        property var ownerScreen: null
-        property var pendingSurface: null
-        property bool replacementPending: false
-        property var replacementScreen: null
-        property int surfaceGeneration: 0
-        property var surfaceToken: null
-
-        function completeSurfaceReplacement() {
-            surfaceLoader.active = true;
+    function entryForScreen(screen) {
+        for (let index = 0; index < entries.length; index += 1) {
+            if (entries[index].targetScreen === screen) {
+                return entries[index];
+            }
         }
+        return null;
+    }
 
-        function isConnected(screen) {
-            for (let index = 0; index < Quickshell.screens.length; index += 1) {
-                if (Quickshell.screens[index] === screen) {
-                    return true;
+    function finishShellMenuOpen(token, result) {
+        const surface = surfaceForToken(token);
+        return surface !== null && surface.finishShellMenuOpen(result);
+    }
+
+    function generationForToken(token) {
+        const record = registryRecordForToken(token);
+        return record === null ? 0 : record.generation;
+    }
+
+    function isConnected(screen) {
+        for (let index = 0; index < Quickshell.screens.length; index += 1) {
+            if (Quickshell.screens[index] === screen) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function reconcileScreens() {
+        displays.syncScreens();
+        const kept = [];
+        for (let index = 0; index < entries.length; index += 1) {
+            const entry = entries[index];
+            if (isConnected(entry.targetScreen)) {
+                kept.push(entry);
+            } else {
+                entry.destroy();
+            }
+        }
+        entries = kept;
+
+        for (let index = 0; index < Quickshell.screens.length; index += 1) {
+            const screen = Quickshell.screens[index];
+            if (entryForScreen(screen) === null) {
+                const entry = surfaceEntryComponent.createObject(host, {
+                                                                     "targetScreen": screen
+                                                                 });
+                if (entry !== null) {
+                    const next = entries.slice();
+                    next.push(entry);
+                    entries = next;
+                }
+            }
+        }
+        registryRevision += 1;
+    }
+
+    function registerSurface(entry, surface) {
+        nextSurfaceGeneration += 1;
+        entry.surfaceGeneration = nextSurfaceGeneration;
+        entry.surfaceToken = {};
+        entry.liveSurface = surface;
+        const next = registry.slice();
+        next.push({
+                      "entry": entry,
+                      "generation": entry.surfaceGeneration,
+                      "screen": entry.targetScreen,
+                      "surface": surface,
+                      "token": entry.surfaceToken
+                  });
+        registry = next;
+        registryRevision += 1;
+        coordinator.attachSurface(entry.surfaceToken, entry.surfaceGeneration);
+    }
+
+    function registryRecordForToken(token) {
+        if (token === null || token === undefined) {
+            return null;
+        }
+        for (let index = 0; index < registry.length; index += 1) {
+            if (registry[index].token === token) {
+                return registry[index];
+            }
+        }
+        return null;
+    }
+
+    function routeFallbackToken(excludedToken) {
+        const fallback = displays.fallbackScreen;
+        for (let index = 0; index < registry.length; index += 1) {
+            if (registry[index].token !== excludedToken && registry[index].screen === fallback) {
+                return registry[index].token;
+            }
+        }
+        for (let index = 0; index < registry.length; index += 1) {
+            if (registry[index].token !== excludedToken) {
+                return registry[index].token;
+            }
+        }
+        return null;
+    }
+
+    function routeSurfaceToken(excludedToken) {
+        for (let index = 0; index < registry.length; index += 1) {
+            const record = registry[index];
+            if (record.token !== excludedToken && PointerRouter.isPointerOnWindowScreen(
+                        record.surface.backingWindow)) {
+                return record.token;
+            }
+        }
+        return routeFallbackToken(excludedToken);
+    }
+
+    function setEnabled(screen, enabled) {
+        failureText = "";
+        const entry = entryForScreen(screen);
+        if (entry === null) {
+            failureText = "The display is no longer connected.";
+            return false;
+        }
+        if (!enabled && entry.surfaceToken !== null && !coordinator.prepareSurfaceDisable(
+                    entry.surfaceToken)) {
+            failureText = coordinator.modalHostToken === entry.surfaceToken
+                    ? "Authentication must finish before this island can be disabled." :
+                      "The active task could not be transferred safely.";
+            return false;
+        }
+        if (!displays.requestEnabled(screen, enabled)) {
+            failureText = "At least one island must remain enabled.";
+            return false;
+        }
+        registryRevision += 1;
+        return true;
+    }
+
+    function setFallback(screen) {
+        failureText = "";
+        if (!displays.requestFallback(screen)) {
+            failureText = "The fallback must be an active enabled display.";
+            return false;
+        }
+        registryRevision += 1;
+        return true;
+    }
+
+    function surfaceForToken(token) {
+        const record = registryRecordForToken(token);
+        return record === null ? null : record.surface;
+    }
+
+    function unregisterSurface(entry, surface) {
+        const next = [];
+        let removed = null;
+        for (let index = 0; index < registry.length; index += 1) {
+            if (registry[index].entry === entry && registry[index].surface === surface) {
+                removed = registry[index];
+            } else {
+                next.push(registry[index]);
+            }
+        }
+        registry = next;
+        registryRevision += 1;
+        if (removed !== null) {
+            coordinator.detachSurface(removed.token, removed.generation);
+        }
+        if (entry.liveSurface === surface) {
+            entry.liveSurface = null;
+            entry.surfaceToken = null;
+            entry.surfaceGeneration = 0;
+        }
+    }
+
+    function windowForToken(token) {
+        const record = registryRecordForToken(token);
+        return record === null || record.surface === null ? null : record.surface.backingWindow;
+    }
+
+    DisplayManager {
+        id: displays
+
+        onChangeRejected: reason => host.failureText = reason
+    }
+
+    Component {
+        id: surfaceEntryComponent
+
+        Scope {
+            id: entry
+
+            required property var targetScreen
+            property var liveSurface: null
+            property var surfaceToken: null
+            property int surfaceGeneration: 0
+            readonly property bool enabled: displays.isEnabled(targetScreen)
+
+            Component {
+                id: dashboardMedia
+
+                DashboardMedia {
+                    media: host.media
                 }
             }
 
-            return false;
+            Component {
+                id: dashboardClock
+
+                DashboardClock {
+                    clock: host.clock
+                }
+            }
+
+            Component {
+                id: dashboardQuickControls
+
+                DashboardQuickControls {
+                    centerStatusInMainLane: host.media === null || !host.media.available
+                    connectivity: host.connectivityAdapter
+                    applicationModel: host.applicationModel
+                    tray: host.trayAdapter
+                    menuParentWindow: entry.liveSurface
+                    onExternalActionDispatched: host.completeShellMenuAction(entry.surfaceToken)
+                    onShellMenuOpening: host.beginShellMenu(entry.surfaceToken)
+                    onShellMenuOpenResult: result => host.finishShellMenuOpen(entry.surfaceToken,
+                                                                              result)
+                }
+            }
+
+            Component {
+                id: dashboardAudio
+
+                DashboardAudio {
+                    audio: host.audioAdapter
+                    onDeviceSelectionRequested: host.coordinator.openAudio(entry.surfaceToken)
+                }
+            }
+
+            Component {
+                id: dashboardNotifications
+
+                DashboardNotifications {
+                    service: host.notificationService
+                }
+            }
+
+            Component {
+                id: dashboardNavigation
+
+                DashboardNavigation {
+                    coordinator: host.coordinator
+                    surfaceToken: entry.surfaceToken
+                    settingsFailure: host.settingsFailure
+                    onSystemSettingsRequested: host.systemSettingsRequested(entry.surfaceToken)
+                }
+            }
+
+            LazyLoader {
+                id: surfaceLoader
+
+                active: entry.enabled
+
+                IslandSurface {
+                    id: island
+
+                    screen: entry.targetScreen
+                    coordinator: host.coordinator
+                    hostSurfaceToken: entry.surfaceToken
+                    hostSurfaceGeneration: entry.surfaceGeneration
+                    surfaceHost: host
+                    virtualDesktops: host.virtualDesktops
+                    clock: host.clock
+                    weather: host.weather
+                    media: host.media
+                    sessionService: host.sessionService
+                    polkitController: host.polkitController
+                    notificationService: host.notificationService
+                    applicationModel: host.applicationModel
+                    trayAdapter: host.trayAdapter
+                    audioAdapter: host.audioAdapter
+                    workspaceTransientSource: host.workspaceTransientSource
+                    brightnessTransientSource: host.brightnessTransientSource
+                    volumeTransientSource: host.volumeTransientSource
+                    notificationTransientSource: host.notificationTransientSource
+                    reducedMotion: host.reducedMotion
+                    dashboardMediaContent: host.dashboardMediaContent !== null
+                                           ? host.dashboardMediaContent : host.media !== null
+                                             && host.media.available ? dashboardMedia : null
+                    dashboardClockContent: host.dashboardClockContent !== null
+                                           ? host.dashboardClockContent : dashboardClock
+                    dashboardQuickControlsContent: host.dashboardQuickControlsContent !== null
+                                                   ? host.dashboardQuickControlsContent :
+                                                     dashboardQuickControls
+                    dashboardAudioContent: host.dashboardAudioContent !== null
+                                           ? host.dashboardAudioContent : dashboardAudio
+                    dashboardNotificationsContent: host.dashboardNotificationsContent !== null
+                                                   ? host.dashboardNotificationsContent :
+                                                     dashboardNotifications
+                    dashboardNavigationContent: host.dashboardNavigationContent !== null
+                                                ? host.dashboardNavigationContent :
+                                                  dashboardNavigation
+
+                    Component.onCompleted: host.registerSurface(entry, island)
+                    Component.onDestruction: host.unregisterSurface(entry, island)
+                    onScreenChanged: {
+                        if (screen !== entry.targetScreen && !host.isConnected(
+                                entry.targetScreen)) {
+                            surfaceLoader.active = false;
+                        }
+                    }
+                }
+            }
         }
-
-        function queueSurfaceRegistration(surface) {
-            const targetScreen = replacementScreen;
-            replacementScreen = null;
-
-            if (targetScreen !== null && isConnected(targetScreen)) {
-                surface.screen = targetScreen;
-            }
-
-            liveSurface = surface;
-            pendingSurface = surface;
-            surfaceSettleTimer.restart();
-        }
-
-        function reconcileOwner() {
-            if (ownerScreen === null || isConnected(ownerScreen)) {
-                return;
-            }
-
-            const rehomedScreen = liveSurface === null ? null : liveSurface.screen;
-            if (rehomedScreen !== null && isConnected(rehomedScreen)) {
-                replacementScreen = rehomedScreen;
-                replaceSurface();
-            }
-        }
-
-        function replaceSurface() {
-            if (replacementPending) {
-                return;
-            }
-
-            replacementPending = true;
-            if (surfaceToken !== null) {
-                host.coordinator.detachSurface(surfaceToken, surfaceGeneration);
-            }
-            surfaceToken = null;
-            surfaceLoader.active = false;
-            Qt.callLater(completeSurfaceReplacement);
-        }
-
-        function settleSurfaceRegistration() {
-            if (pendingSurface === null) {
-                return;
-            }
-
-            ownerScreen = pendingSurface.screen;
-            pendingSurface = null;
-            surfaceGeneration += 1;
-            surfaceToken = {};
-            replacementPending = false;
-            host.coordinator.attachSurface(surfaceToken, surfaceGeneration);
-        }
-
-        function unregisterSurface(surface) {
-            if (liveSurface !== surface) {
-                return;
-            }
-
-            if (pendingSurface === surface) {
-                pendingSurface = null;
-                surfaceSettleTimer.stop();
-            }
-
-            liveSurface = null;
-            if (surfaceToken !== null) {
-                host.coordinator.detachSurface(surfaceToken, surfaceGeneration);
-            }
-            surfaceToken = null;
-            ownerScreen = null;
-        }
-    }
-
-    Timer {
-        id: surfaceSettleTimer
-
-        interval: ownership.surfaceSettleDelay
-        onTriggered: ownership.settleSurfaceRegistration()
     }
 
     Connections {
         target: Quickshell
 
         function onScreensChanged() {
-            ownership.reconcileOwner();
+            host.reconcileScreens();
         }
     }
 
-    LazyLoader {
-        id: surfaceLoader
-
-        active: true
-
-        IslandSurface {
-            id: island
-
-            coordinator: host.coordinator
-            hostSurfaceGeneration: host.surfaceGeneration
-            virtualDesktops: host.virtualDesktops
-            clock: host.clock
-            weather: host.weather
-            media: host.media
-            sessionService: host.sessionService
-            polkitController: host.polkitController
-            notificationService: host.notificationService
-            applicationModel: host.applicationModel
-            trayAdapter: host.trayAdapter
-            audioAdapter: host.audioAdapter
-            workspaceTransientSource: host.workspaceTransientSource
-            brightnessTransientSource: host.brightnessTransientSource
-            volumeTransientSource: host.volumeTransientSource
-            notificationTransientSource: host.notificationTransientSource
-            reducedMotion: host.reducedMotion
-            dashboardMediaContent: host.dashboardMediaContent
-            dashboardClockContent: host.dashboardClockContent
-            dashboardQuickControlsContent: host.dashboardQuickControlsContent
-            dashboardAudioContent: host.dashboardAudioContent
-            dashboardNotificationsContent: host.dashboardNotificationsContent
-            dashboardNavigationContent: host.dashboardNavigationContent
-
-            Component.onCompleted: ownership.queueSurfaceRegistration(island)
-            Component.onDestruction: ownership.unregisterSurface(island)
-            onScreenChanged: {
-                if (ownership.pendingSurface === island) {
-                    surfaceSettleTimer.restart();
-                } else {
-                    ownership.reconcileOwner();
-                }
-            }
+    Component.onCompleted: {
+        coordinator.surfaceRouter = host;
+        reconcileScreens();
+    }
+    Component.onDestruction: {
+        if (coordinator.surfaceRouter === host) {
+            coordinator.surfaceRouter = null;
+        }
+        const doomed = entries.slice();
+        entries = [];
+        for (let index = 0; index < doomed.length; index += 1) {
+            doomed[index].destroy();
         }
     }
 }

--- a/qml/TransientCoordinatorBridge.qml
+++ b/qml/TransientCoordinatorBridge.qml
@@ -1,13 +1,12 @@
 import Quickshell
 import QtQuick
 
-// Routes normalized producer identities into the one owner reducer. It owns no
-// payload, queue, timer, or backend action.
+// Routes normalized producer identities into the process-wide owner reducer.
+// It owns no payload, queue, timer, or backend action.
 Scope {
     id: bridge
 
     required property var coordinator
-    required property var surfaceToken
     property var workspaceSource: null
     property var brightnessSource: null
     property var audioSource: null
@@ -46,8 +45,7 @@ Scope {
         ignoreUnknownSignals: true
 
         function onConfirmedOutputChanged(sourceToken, sourceGeneration, revision) {
-            bridge.coordinator.requestVolume(sourceToken, sourceGeneration, revision,
-                                             bridge.surfaceToken);
+            bridge.coordinator.requestVolume(sourceToken, sourceGeneration, revision, null);
         }
 
         function onConfirmedOutputInvalidated(sourceToken, sourceGeneration) {
@@ -60,8 +58,7 @@ Scope {
         ignoreUnknownSignals: true
 
         function onTransientRequested(sourceToken, sourceGeneration, revision) {
-            bridge.coordinator.requestNotification(sourceToken, sourceGeneration, revision,
-                                                   bridge.surfaceToken);
+            bridge.coordinator.requestNotification(sourceToken, sourceGeneration, revision, null);
         }
 
         function onTransientInvalidated(sourceToken, sourceGeneration) {

--- a/shell.qml
+++ b/shell.qml
@@ -9,7 +9,7 @@ ShellRoot {
     property int systemSettingsRequestId: 0
     property string systemSettingsFailure: ""
 
-    function launchSystemSettings() {
+    function launchSystemSettings(initiatingSurfaceToken) {
         systemSettingsFailure = "";
         const requestId = applicationModel.dispatchLaunch("systemsettings.desktop");
         if (requestId === 0) {
@@ -19,7 +19,9 @@ ShellRoot {
             return false;
         }
         systemSettingsRequestId = requestId;
-        islandState.resetToIdle(islandHost.surfaceToken);
+        if (initiatingSurfaceToken !== null && initiatingSurfaceToken !== undefined) {
+            islandState.resetToIdle(initiatingSurfaceToken);
+        }
         return true;
     }
 
@@ -51,7 +53,7 @@ ShellRoot {
         helperPath: Quickshell.shellPath("build/global-shortcut/nagi-global-shortcut")
         onSystemSettingsRequested: {
             if (!islandState.modalPresent) {
-                launchSystemSettings();
+                launchSystemSettings(islandHost.routeSurfaceToken(null));
             }
         }
     }
@@ -66,8 +68,7 @@ ShellRoot {
     MediaAdapter {
         id: mediaAdapter
         enabled: UserConfig.snapshot.media.enabled
-        detailsVisible: islandState.ownerKind === islandState.ownerExpanded
-                        && islandState.presentationVisible
+        detailsVisible: islandState.anyExpanded
     }
 
     AudioAdapter {
@@ -97,7 +98,7 @@ ShellRoot {
 
     OnboardingWindow {
         settingsFailure: systemSettingsFailure
-        onSystemSettingsRequested: launchSystemSettings()
+        onSystemSettingsRequested: launchSystemSettings(islandHost.routeSurfaceToken(null))
     }
 
     NotificationService {
@@ -106,65 +107,6 @@ ShellRoot {
 
     TrayAdapter {
         id: trayAdapter
-    }
-
-    Component {
-        id: dashboardMedia
-
-        DashboardMedia {
-            media: mediaAdapter
-        }
-    }
-
-    Component {
-        id: dashboardClock
-
-        DashboardClock {
-            clock: clockState
-        }
-    }
-
-    Component {
-        id: dashboardQuickControls
-
-        DashboardQuickControls {
-            centerStatusInMainLane: !mediaAdapter.available
-            connectivity: connectivityAdapter
-            applicationModel: applicationModel
-            tray: trayAdapter
-            menuParentWindow: islandHost.menuParentWindow
-            onExternalActionDispatched: islandHost.completeShellMenuAction()
-            onShellMenuOpening: islandHost.beginShellMenu()
-            onShellMenuOpenResult: result => islandHost.finishShellMenuOpen(result)
-        }
-    }
-
-    Component {
-        id: dashboardAudio
-
-        DashboardAudio {
-            audio: audioAdapter
-            onDeviceSelectionRequested: islandState.openAudio(islandHost.surfaceToken)
-        }
-    }
-
-    Component {
-        id: dashboardNotifications
-
-        DashboardNotifications {
-            service: notificationService
-        }
-    }
-
-    Component {
-        id: dashboardNavigation
-
-        DashboardNavigation {
-            coordinator: islandState
-            surfaceToken: islandHost.surfaceToken
-            settingsFailure: systemSettingsFailure
-            onSystemSettingsRequested: launchSystemSettings()
-        }
     }
 
     Connections {
@@ -206,6 +148,7 @@ ShellRoot {
         clock: clockState
         weather: weather
         media: mediaAdapter
+        connectivityAdapter: connectivityAdapter
         sessionService: session
         notificationService: notificationService
         applicationModel: applicationModel
@@ -216,17 +159,12 @@ ShellRoot {
         volumeTransientSource: audioAdapter
         notificationTransientSource: notificationService
         reducedMotion: motion.active
-        dashboardMediaContent: mediaAdapter.available ? dashboardMedia : null
-        dashboardClockContent: dashboardClock
-        dashboardQuickControlsContent: dashboardQuickControls
-        dashboardAudioContent: dashboardAudio
-        dashboardNotificationsContent: dashboardNotifications
-        dashboardNavigationContent: dashboardNavigation
+        settingsFailure: systemSettingsFailure
+        onSystemSettingsRequested: token => launchSystemSettings(token)
     }
 
     TransientCoordinatorBridge {
         coordinator: islandState
-        surfaceToken: islandHost.surfaceToken
         workspaceSource: virtualDesktops
         brightnessSource: brightness
         audioSource: audioAdapter

--- a/src/platform/plugin.cpp
+++ b/src/platform/plugin.cpp
@@ -1,0 +1,38 @@
+#include "pointer_router.h"
+
+#include <QCoreApplication>
+#include <QQmlEngine>
+#include <QQmlEngineExtensionPlugin>
+#include <qqml.h>
+
+namespace nagi::platform {
+namespace {
+
+PointerRouter *pointerRouterInstance()
+{
+    static auto *router = new PointerRouter;
+    return router;
+}
+
+} // namespace
+
+class PlatformPlugin final : public QQmlExtensionPlugin {
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QQmlExtensionInterface/1.0")
+
+public:
+    void registerTypes(const char *uri) override
+    {
+        Q_ASSERT(QByteArrayView(uri) == QByteArrayView("Nagi.Platform"));
+        qmlRegisterSingletonType<PointerRouter>(
+            uri, 1, 0, "PointerRouter", [](QQmlEngine *, QJSEngine *) -> QObject * {
+                PointerRouter *router = pointerRouterInstance();
+                QQmlEngine::setObjectOwnership(router, QQmlEngine::CppOwnership);
+                return router;
+            });
+    }
+};
+
+} // namespace nagi::platform
+
+#include "plugin.moc"

--- a/src/platform/pointer_router.cpp
+++ b/src/platform/pointer_router.cpp
@@ -1,0 +1,30 @@
+#include "pointer_router.h"
+
+#include <QCursor>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QWindow>
+
+namespace nagi::platform {
+
+PointerRouter::PointerRouter(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool PointerRouter::available() const
+{
+    return qobject_cast<QGuiApplication *>(QCoreApplication::instance()) != nullptr;
+}
+
+bool PointerRouter::isPointerOnWindowScreen(QObject *windowObject) const
+{
+    const auto *window = qobject_cast<QWindow *>(windowObject);
+    if (window == nullptr || window->screen() == nullptr || !available()) {
+        return false;
+    }
+
+    return QGuiApplication::screenAt(QCursor::pos()) == window->screen();
+}
+
+} // namespace nagi::platform

--- a/src/platform/pointer_router.h
+++ b/src/platform/pointer_router.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QObject>
+
+namespace nagi::platform {
+
+class PointerRouter final : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool available READ available CONSTANT)
+
+public:
+    explicit PointerRouter(QObject *parent = nullptr);
+
+    [[nodiscard]] bool available() const;
+    Q_INVOKABLE [[nodiscard]] bool isPointerOnWindowScreen(QObject *windowObject) const;
+};
+
+} // namespace nagi::platform

--- a/src/platform/qmldir
+++ b/src/platform/qmldir
@@ -1,0 +1,2 @@
+module Nagi.Platform
+plugin nagiplatformplugin

--- a/tests/coordinator/shell.qml
+++ b/tests/coordinator/shell.qml
@@ -6,157 +6,9 @@ ShellRoot {
     id: test
 
     property real nowMs: 0
-    property var token: null
-    property int generation: 0
-    property bool fakePolkitActive: true
-    property bool fakePolkitFlowPresent: true
-    property int fakePolkitFlowGeneration: 77
-
-    function attachFreshSurface() {
-        if (token !== null) {
-            require(coordinator.detachSurface(token, generation), "current surface detaches");
-        }
-        token = {};
-        generation += 1;
-        require(coordinator.attachSurface(token, generation), "fresh surface attaches");
-        require(coordinator.ownerName === "idle", "fresh surface starts idle");
-    }
-
-    function exerciseFreshness(request, owner, freshness) {
-        require(request(), owner + " freshness request enters");
-        require(coordinator.ownerName === owner, owner + " owns before freshness boundary");
-        nowMs += freshness - 1;
-        require(coordinator.setHover(generation, false), owner + " pre-boundary dispatch succeeds");
-        require(coordinator.ownerName === owner, owner + " remains fresh before boundary");
-        nowMs += 1;
-        require(coordinator.setHover(generation, false), owner
-                + " freshness boundary dispatch succeeds");
-        require(coordinator.ownerName === "idle", owner + " expires at freshness boundary");
-    }
-
-    function exerciseVisibleHold(request, owner, hold) {
-        require(request(), owner + " hold request enters");
-        require(coordinator.ownerName === owner, owner + " owns before acknowledgement");
-        require(coordinator.acknowledgeVisible(generation, coordinator.ownerEpoch,
-                                               coordinator.revision), owner
-                + " presentation is acknowledged");
-        nowMs += hold - 1;
-        require(coordinator.setHover(generation, false), owner
-                + " hold pre-boundary dispatch succeeds");
-        require(coordinator.ownerName === owner, owner + " remains visible before hold boundary");
-        nowMs += 1;
-        require(coordinator.setHover(generation, false), owner
-                + " hold boundary dispatch succeeds");
-        require(coordinator.ownerName === "idle", owner + " releases at hold boundary");
-    }
-
-    function syncFakePolkitSnapshot(target) {
-        return target.syncPolkitModal(fakePolkitActive, fakePolkitFlowPresent,
-                                      fakePolkitFlowGeneration);
-    }
-
-    function verifyReloadReattachment() {
-        const first = coordinatorFactory.createObject(test);
-        require(first !== null, "pre-reload coordinator is created");
-        const firstToken = {};
-        require(first.attachSurface(firstToken, 1), "pre-reload surface attaches");
-        require(first.setHover(1, true), "pre-reload predecessor enters");
-        require(syncFakePolkitSnapshot(first), "pre-reload Modal snapshot enters");
-        require(first.ownerName === "polkitModal", "pre-reload Modal owns the island");
-        first.destroy();
-
-        const replacement = coordinatorFactory.createObject(test);
-        require(replacement !== null, "replacement coordinator is created");
-        require(syncFakePolkitSnapshot(replacement),
-                "replacement coordinator reads the existing snapshot");
-        const replacementToken = {};
-        require(replacement.attachSurface(replacementToken, 1),
-                "replacement surface attaches after snapshot synchronization");
-        require(replacement.ownerName === "polkitModal" && replacement.restorationDepth === 0,
-                "reload reattaches Modal without old predecessor state");
-        require(replacement.acknowledgeVisible(1, replacement.ownerEpoch, replacement.revision),
-                "reattached Modal presentation is acknowledged");
-        require(replacement.focusTarget === replacement.focusPolkitModal
-                && replacement.focusRequestSerial === 1,
-                "reattached Modal retains a valid focus path");
-
-        fakePolkitActive = false;
-        fakePolkitFlowPresent = false;
-        fakePolkitFlowGeneration = 0;
-        require(syncFakePolkitSnapshot(replacement),
-                "registration loss publishes an absent authoritative snapshot");
-        require(replacement.ownerName === "idle",
-                "registration loss restores only the replacement baseline");
-        replacement.destroy();
-    }
-
-    function verifyExpandedIntents() {
-        attachFreshSurface();
-        require(!coordinator.setHover(generation + 1, true), "stale hover generation is rejected");
-        require(coordinator.setHover(generation, true), "current hover expands the baseline");
-        require(coordinator.ownerName === "expanded" && coordinator.focusTarget
-                === coordinator.focusNone, "hover expansion never requests keyboard focus");
-        const hoverFocusSerial = coordinator.focusRequestSerial;
-        require(coordinator.acknowledgeVisible(generation, coordinator.ownerEpoch,
-                                               coordinator.revision),
-                "hover dashboard presentation is acknowledged");
-        require(coordinator.focusRequestSerial === hoverFocusSerial,
-                "hover acknowledgement does not issue focus");
-
-        require(coordinator.setExplicitExpanded(generation, true),
-                "deliberate intent joins the expanded baseline");
-        require(coordinator.ownerName === "expanded" && coordinator.focusTarget
-                === coordinator.focusExpandedDashboard && coordinator.focusRequestSerial
-                === hoverFocusSerial + 1,
-                "visible deliberate expansion receives dashboard focus intent");
-        require(coordinator.setExplicitExpanded(generation, false),
-                "deliberate intent can clear independently");
-        require(coordinator.ownerName === "expanded" && coordinator.hoverIntent
-                && coordinator.focusTarget === coordinator.focusNone,
-                "current hover keeps Expanded visible without retaining focus");
-        require(coordinator.setHover(generation, false), "pointer exit clears hover intent");
-        require(coordinator.ownerName === "idle", "clearing both intents restores Idle");
-
-        const deliberateFocusSerial = coordinator.focusRequestSerial;
-        require(coordinator.openDashboard(null),
-                "surface-independent dashboard activation enters from Idle");
-        require(coordinator.focusRequestSerial === deliberateFocusSerial && coordinator.focusTarget
-                === coordinator.focusExpandedDashboard,
-                "focus waits for the deliberate dashboard presentation");
-        require(coordinator.acknowledgeVisible(generation, coordinator.ownerEpoch,
-                                               coordinator.revision),
-                "deliberate dashboard presentation is acknowledged");
-        require(coordinator.focusRequestSerial === deliberateFocusSerial + 1,
-                "matching visibility acknowledgement issues focus once");
-        require(coordinator.setExplicitExpanded(generation, false),
-                "keyboard cancellation clears deliberate intent");
-        require(coordinator.ownerName === "idle" && coordinator.focusTarget
-                === coordinator.focusNone, "keyboard cancellation restores Idle focus policy");
-    }
-
-    function verifyExternalReset() {
-        attachFreshSurface();
-        require(coordinator.setHover(generation, true)
-                && coordinator.setExplicitExpanded(generation, true),
-                "external-reset baseline expands with focus intent");
-        require(coordinator.openTray(token), "external-reset tray interaction opens");
-        require(coordinator.requestNotification("external-reset-notification", 1, 1, token),
-                "external-reset scenario retains pending transient work");
-        require(coordinator.resetToIdle(token), "matching external reset is accepted");
-        require(coordinator.ownerName === "idle" && !coordinator.hoverIntent
-                && !coordinator.explicitExpandedIntent && coordinator.pendingTransientCount === 0
-                && coordinator.restorationDepth === 0 && coordinator.focusTarget
-                === coordinator.focusNone,
-                "external reset clears every non-modal owner, intent, pending item, and predecessor");
-        require(!coordinator.resetToIdle({}), "foreign surface reset is rejected");
-
-        require(coordinator.syncPolkitModal(true, true, 90), "Modal opens for reset guard");
-        require(!coordinator.resetToIdle(token) && coordinator.ownerName === "polkitModal",
-                "external reset cannot abandon Modal ownership");
-        require(coordinator.syncPolkitModal(false, false, 0),
-                "Modal reset guard releases through its authoritative snapshot");
-        require(coordinator.ownerName === "idle", "Modal cleanup returns to Idle");
-    }
+    property var firstToken: null
+    property var secondToken: null
+    property var thirdToken: null
 
     function require(condition, message) {
         if (!condition) {
@@ -166,372 +18,202 @@ ShellRoot {
         }
     }
 
-    function run() {
-        attachFreshSurface();
-        require(coordinator.requestWorkspace("workspace", 1, 1, token),
-                "workspace request is accepted");
-        require(coordinator.ownerName === "workspace", "workspace owns idle");
-        require(coordinator.requestBrightness("brightness", 1, 1, token),
-                "brightness request is accepted");
-        require(coordinator.ownerName === "brightness",
-                "higher transient preempts lower transient");
-        require(coordinator.requestWorkspace("other-workspace", 1, 1, token),
-                "lower transient enters mailbox");
-        require(coordinator.ownerName === "brightness",
-                "lower transient cannot replace higher transient");
-        require(coordinator.setHover(generation, true), "expanded baseline is accepted");
-        require(coordinator.ownerName === "expanded", "expanded preempts transients");
-        require(coordinator.requestNotification("notification", 1, 1, token),
-                "notification is held while expanded");
-        require(coordinator.ownerName === "expanded", "transient cannot replace expanded");
-        require(coordinator.openLauncher(token), "local launcher intent is accepted");
-        require(coordinator.ownerName === "launcher", "launcher preempts expanded");
-        require(coordinator.openSession(token), "session intent is accepted");
-        const suspendedSessionEpoch = coordinator.ownerEpoch;
-        require(coordinator.ownerName === "session", "session preempts launcher");
-        require(coordinator.syncPolkitModal(true, true, 1), "Polkit snapshot is accepted");
-        require(coordinator.ownerName === "polkitModal", "Modal preempts session");
-        require(coordinator.restorationDepth <= coordinator.maximumRestorationDepth,
-                "restoration chain remains bounded");
-        require(coordinator.completeInteractive(suspendedSessionEpoch),
-                "matching completion invalidates a Modal-suspended session");
-        require(coordinator.ownerName === "polkitModal",
-                "suspended completion cannot close the current Modal");
-        require(!coordinator.completeInteractive(suspendedSessionEpoch),
-                "repeated suspended completion is stale");
-        require(coordinator.syncPolkitModal(false, false, 0), "Polkit cleanup is accepted");
-        require(coordinator.ownerName === "launcher",
-                "Modal cleanup skips the completed session and restores its predecessor");
-        require(coordinator.cancelInteractive(coordinator.ownerEpoch), "launcher cancels");
-        require(coordinator.ownerName === "expanded", "launcher restores expanded");
-
-        attachFreshSurface();
-        require(coordinator.setHover(generation, true), "expanded predecessor is set");
-        require(coordinator.openLauncher(token), "dashboard launcher intent opens");
-        const launcherEpoch = coordinator.ownerEpoch;
-        const launcherRevision = coordinator.revision;
-        require(coordinator.acknowledgeVisible(generation, launcherEpoch, launcherRevision),
-                "matching launcher presentation is acknowledged");
-        const firstFocus = coordinator.focusRequestSerial;
-        require(firstFocus > 0 && coordinator.focusTarget === coordinator.focusLauncherSearch,
-                "visible launcher requests search focus");
-        require(coordinator.openLauncher(null), "global launcher intent is idempotently accepted");
-        require(coordinator.ownerEpoch === launcherEpoch,
-                "repeated launcher preserves owner epoch");
-        require(coordinator.focusRequestSerial === firstFocus + 1,
-                "repeated visible launcher requests search focus again");
-        require(!coordinator.completeInteractive(launcherEpoch - 1),
-                "stale completion is rejected");
-        require(coordinator.cancelInteractive(launcherEpoch), "Escape cancels current launcher");
-        require(coordinator.ownerName === "expanded", "Escape restores the predecessor");
-        require(coordinator.openTray(null),
-                "global tray intent opens through the attached surface");
-        require(coordinator.openTray(token), "visible dashboard tray intent renews focus");
-        const trayEpoch = coordinator.ownerEpoch;
-        require(coordinator.ownerName === "tray", "tray owns the island as an Interactive task");
-        require(coordinator.acknowledgeVisible(generation, trayEpoch, coordinator.revision),
-                "matching tray presentation is acknowledged");
-        const trayFocus = coordinator.focusRequestSerial;
-        require(trayFocus > 0 && coordinator.focusTarget === coordinator.focusTray,
-                "visible tray requests item focus");
-        require(coordinator.openTray(token) && coordinator.ownerEpoch === trayEpoch
-                && coordinator.focusRequestSerial === trayFocus + 1,
-                "repeated tray intent preserves its epoch and renews focus");
-        require(!coordinator.openHistory(token),
-                "equal-rank history cannot replace active tray");
-        require(coordinator.cancelInteractive(trayEpoch),
-                "tray Back accepts its current owner epoch");
-        require(coordinator.ownerName === "expanded",
-                "tray Back atomically restores its dashboard predecessor");
-
-        require(coordinator.openAudio(null),
-                "global audio intent opens through the attached surface");
-        require(coordinator.openAudio(token), "visible dashboard audio intent renews focus");
-        const audioEpoch = coordinator.ownerEpoch;
-        require(coordinator.ownerName === "audio"
-                && coordinator.focusTarget === coordinator.focusAudio,
-                "audio mirrors tray ownership and focus rank");
-        require(coordinator.acknowledgeVisible(generation, audioEpoch, coordinator.revision),
-                "matching audio presentation is acknowledged");
-        const audioFocus = coordinator.focusRequestSerial;
-        require(coordinator.openAudio(token) && coordinator.ownerEpoch === audioEpoch
-                && coordinator.focusRequestSerial === audioFocus + 1,
-                "repeated audio intent preserves its epoch and renews focus");
-        require(!coordinator.openTray(token),
-                "equal-rank tray cannot replace active audio");
-        const audioRevisionBeforeModal = coordinator.revision;
-        require(coordinator.syncPolkitModal(true, true, 2),
-                "Modal can suspend the active audio task");
-        require(!coordinator.openAudio(token), "audio is rejected during Modal");
-        require(coordinator.syncPolkitModal(false, false, 0),
-                "Modal cleanup restores the audio task");
-        require(coordinator.ownerName === "audio" && coordinator.ownerEpoch === audioEpoch
-                && coordinator.revision > audioRevisionBeforeModal,
-                "audio restoration preserves epoch and advances revision");
-        require(coordinator.cancelInteractive(audioEpoch),
-                "audio Back accepts its restored owner epoch");
-        require(coordinator.ownerName === "expanded",
-                "audio Back atomically restores its dashboard predecessor");
-
-
-        require(coordinator.openHistory(null),
-                "global history intent opens through the attached surface");
-        require(coordinator.openHistory(token), "visible dashboard history intent renews focus");
-        const historyEpoch = coordinator.ownerEpoch;
-        require(coordinator.ownerName === "history",
-                "history owns the island as an Interactive task");
-        require(coordinator.acknowledgeVisible(generation, historyEpoch, coordinator.revision),
-                "matching history presentation is acknowledged");
-        const historyFocus = coordinator.focusRequestSerial;
-        require(historyFocus > 0 && coordinator.focusTarget === coordinator.focusNotificationHistory,
-                "visible history requests list focus");
-        require(coordinator.openHistory(token) && coordinator.ownerEpoch === historyEpoch
-                && coordinator.focusRequestSerial === historyFocus + 1,
-                "repeated history intent preserves its epoch and renews focus");
-        require(!coordinator.openLauncher(token),
-                "equal-rank launcher cannot replace active history");
-
-        require(coordinator.openSession(null), "global session intent preempts visible history");
-        const sessionEpoch = coordinator.ownerEpoch;
-        require(coordinator.acknowledgeVisible(generation, sessionEpoch, coordinator.revision),
-                "matching session presentation is acknowledged");
-        require(coordinator.focusTarget === coordinator.focusSessionActions,
-                "visible session interaction requests action-grid focus");
-        const sessionRevisionBeforeModal = coordinator.revision;
-        require(coordinator.syncPolkitModal(true, true, 2),
-                "Modal can suspend the active session task");
-        require(coordinator.syncPolkitModal(false, false, 0),
-                "Modal cleanup restores an unfinished session task");
-        require(coordinator.ownerName === "session" && coordinator.ownerEpoch === sessionEpoch
-                && coordinator.revision > sessionRevisionBeforeModal,
-                "restoration preserves the session task epoch with a fresh presentation revision");
-        require(coordinator.acknowledgeVisible(generation, sessionEpoch, coordinator.revision),
-                "restored session presentation is acknowledged");
-        require(!coordinator.cancelInteractive(sessionEpoch + 100),
-                "stale session cancellation is rejected");
-        require(coordinator.cancelInteractive(sessionEpoch),
-                "current session cancellation is accepted");
-        require(coordinator.ownerName === "history" && coordinator.ownerEpoch === historyEpoch,
-                "session cancellation restores the suspended history task");
-        require(coordinator.acknowledgeVisible(generation, historyEpoch, coordinator.revision),
-                "restored history presentation is acknowledged");
-        require(coordinator.cancelInteractive(historyEpoch),
-                "history Back accepts its current owner epoch");
-        require(coordinator.ownerName === "expanded",
-                "history Back atomically restores its dashboard predecessor");
-        require(coordinator.openLauncher(null), "shortcut launcher intent opens");
-        require(coordinator.ownerName === "launcher",
-                "global and local origins share launcher behavior");
-        require(coordinator.cancelInteractive(coordinator.ownerEpoch), "global launcher completes");
-        require(coordinator.ownerName === "expanded", "global launcher restores identically");
-
-        attachFreshSurface();
-        require(coordinator.syncPolkitModal(true, true, 10), "Modal enters from current snapshot");
-        const modalEpoch = coordinator.ownerEpoch;
-        const modalRevision = coordinator.revision;
-        require(coordinator.acknowledgeVisible(generation, modalEpoch, modalRevision),
-                "matching Modal presentation is acknowledged");
-        const modalFocus = coordinator.focusRequestSerial;
-        require(!coordinator.openLauncher(null), "launcher is rejected during Modal");
-        require(!coordinator.openHistory(token), "history is rejected during Modal");
-        require(!coordinator.openTray(token), "tray is rejected during Modal");
-        require(!coordinator.openAudio(token), "audio is rejected during Modal");
-        require(!coordinator.openSession(token), "session is rejected during Modal");
-        require(coordinator.ownerName === "polkitModal" && coordinator.focusRequestSerial
-                === modalFocus, "lower requests cannot steal Modal ownership or focus");
-        require(coordinator.requestNotification("held", 1, 1, null),
-                "fresh notification is held during Modal");
-        require(coordinator.pendingTransientCount === 1,
-                "held transient occupies one bounded slot");
-        require(coordinator.syncPolkitModal(true, true, 11),
-                "serialized flow replacement is accepted");
-        require(coordinator.ownerName === "polkitModal" && coordinator.ownerEpoch === modalEpoch
-                && coordinator.revision === modalRevision + 1,
-                "flow replacement updates Modal in place");
-        require(coordinator.syncPolkitModal(false, true, 11),
-                "inactive agent with flow stays Modal");
-        require(coordinator.ownerName === "polkitModal",
-                "flow presence prevents early restoration");
-        nowMs += 6000;
-        require(coordinator.syncPolkitModal(false, false, 0), "full cleanup releases Modal");
-        require(coordinator.ownerName === "idle",
-                "expired held work and rejected launcher do not replay");
-
-        require(coordinator.syncPolkitModal(true, true, 12), "another Modal enters");
-        const oldModalEpoch = coordinator.ownerEpoch;
-        require(coordinator.detachSurface(token, generation), "surface loss detaches Modal host");
-        token = {};
-        generation += 1;
-        require(coordinator.attachSurface(token, generation), "replacement surface attaches");
-        require(coordinator.ownerName === "polkitModal" && coordinator.ownerEpoch !== oldModalEpoch,
-                "existing flow reattaches as a new Modal owner");
-        require(coordinator.restorationDepth === 0, "surface loss drops old restoration state");
-        require(coordinator.syncPolkitModal(false, false, 0), "reattached Modal cleans up");
-        require(coordinator.ownerName === "idle", "reattached Modal restores new baseline only");
-
-        attachFreshSurface();
-        require(coordinator.requestNotification("timeout", 1, 1, token), "notification enters");
-        const notificationEpoch = coordinator.ownerEpoch;
-        require(coordinator.acknowledgeVisible(generation, notificationEpoch, coordinator.revision),
-                "notification presentation is acknowledged");
-        nowMs += 2999;
-        require(coordinator.setHover(generation, false), "dispatch processes elapsed time");
-        require(coordinator.ownerName === "notification", "hold remains before exact boundary");
-        nowMs += 1;
-        require(coordinator.setHover(generation, false), "exact hold boundary is processed");
-        require(coordinator.ownerName === "idle", "visible hold starts at acknowledgement");
-        require(!coordinator.acknowledgeVisible(generation, notificationEpoch, 1),
-                "stale visible acknowledgement is ignored");
-
-        require(coordinator.requestVolume("visible-coalescing", 1, 1, token),
-                "visible value event enters");
-        const coalescedEpoch = coordinator.ownerEpoch;
-        const supersededRevision = coordinator.revision;
-        require(coordinator.requestVolume("visible-coalescing", 1, 2, token),
-                "superseding value event coalesces in place");
-        require(coordinator.ownerEpoch === coalescedEpoch && coordinator.revision
-                === supersededRevision + 1,
-                "coalescing preserves owner and advances content revision");
-        require(coordinator.ownerSourceGeneration === 1 && coordinator.ownerSourceRevision === 2,
-                "coalescing exposes the exact latest source version");
-        require(!coordinator.requestVolume("visible-coalescing", 1, 2, token),
-                "duplicate source revision cannot restart the visible hold");
-        require(!coordinator.requestVolume("visible-coalescing", 1, 1, token),
-                "older source revision is rejected");
-        require(coordinator.requestVolume("visible-coalescing", 2, 1, token),
-                "a new source generation receives an independent pending slot");
-        require(coordinator.pendingTransientCount === 1,
-                "generation-scoped coalescing does not merge distinct sources");
-        require(coordinator.invalidateTransient("visible-coalescing", 2)
-                && coordinator.pendingTransientCount === 0,
-                "source invalidation removes matching pending work");
-        require(!coordinator.acknowledgeVisible(generation, coalescedEpoch, supersededRevision),
-                "superseded presentation acknowledgement is rejected");
-        require(coordinator.acknowledgeVisible(generation, coalescedEpoch, coordinator.revision),
-                "current coalesced presentation is acknowledged");
-        nowMs += 1800;
-        require(coordinator.setHover(generation, false), "coalesced hold boundary is processed");
-        require(coordinator.ownerName === "idle", "coalesced value releases once");
-
-        require(!coordinator.requestNotification("x".repeat(129), 1, 1, token),
-                "oversized source token is rejected");
-        require(!coordinator.requestNotification({}, 1, 1, token),
-                "object source token is rejected");
-        require(!coordinator.requestNotification("bounded-version",
-                                                 coordinator.maximumSourceVersion + 1, 1, token),
-                "oversized source generation is rejected");
-        require(!coordinator.requestNotification("bounded-version", 1,
-                                                 coordinator.maximumSourceVersion + 1, token),
-                "oversized source revision is rejected");
-        require(!coordinator.invalidateTransient("bounded-version",
-                                                 coordinator.maximumSourceVersion + 1),
-                "oversized invalidation generation is rejected");
-
-        exerciseVisibleHold(() => coordinator.requestVolume("volume-hold", 1, 1, token), "volume",
-        1800);
-        exerciseVisibleHold(() => coordinator.requestBrightness("brightness-hold", 1, 1, token),
-        "brightness", 1800);
-        exerciseVisibleHold(() => coordinator.requestWorkspace("workspace-hold", 1, 1, token),
-        "workspace", 1200);
-
-        require(coordinator.requestWorkspace("freshness", 1, 1, token),
-                "workspace enters without acknowledgement");
-        nowMs += 2000;
-        require(coordinator.setHover(generation, false), "freshness boundary is processed");
-        require(coordinator.ownerName === "idle",
-                "freshness expires even before visibility acknowledgement");
-
-        exerciseFreshness(() => coordinator.requestBrightness("brightness-freshness", 1, 1, token),
-        "brightness", 3000);
-        exerciseFreshness(() => coordinator.requestVolume("volume-freshness", 1, 1, token), "volume",
-        3000);
-        exerciseFreshness(() => coordinator.requestNotification("notification-freshness", 1, 1,
-                                                                token), "notification", 6000);
-
-        require(coordinator.requestNotification("remaining-hold", 1, 1, token),
-                "notification enters for hold resumption");
-        require(coordinator.acknowledgeVisible(generation, coordinator.ownerEpoch,
-                                               coordinator.revision),
-                "notification hold starts after visibility");
-        nowMs += 500;
-        require(coordinator.setHover(generation, true), "Expanded preempts visible notification");
-        require(coordinator.ownerName === "expanded", "Expanded owns during preemption");
-        require(coordinator.setHover(generation, false), "Expanded releases notification");
-        require(coordinator.ownerName === "notification", "fresh predecessor is restored");
-        require(coordinator.acknowledgeVisible(generation, coordinator.ownerEpoch,
-                                               coordinator.revision),
-                "restored notification is acknowledged");
-        nowMs += 2499;
-        require(coordinator.setHover(generation, false),
-                "remaining hold pre-boundary is processed");
-        require(coordinator.ownerName === "notification",
-                "restored notification keeps only its remaining hold");
-        nowMs += 1;
-        require(coordinator.setHover(generation, false), "remaining hold boundary is processed");
-        require(coordinator.ownerName === "idle",
-                "remaining hold does not restart from full duration");
-        require(coordinator.requestVolume("invalidation", 7, 1, token),
-                "value source enters for invalidation");
-        require(coordinator.requestNotification("invalidation-notification", 8, 1, token),
-                "higher transient suspends the value source");
-        require(coordinator.ownerName === "notification" && coordinator.restorationDepth === 1,
-                "strict transient preemption captures one predecessor");
-        require(!coordinator.invalidateTransient("invalidation", 6),
-                "stale source generation cannot remove a live predecessor");
-        require(coordinator.invalidateTransient("invalidation-notification", 8),
-                "current source invalidation is accepted");
-        require(coordinator.ownerName === "volume" && coordinator.ownerSourceGeneration === 7,
-                "current invalidation atomically restores the relevant predecessor");
-        require(coordinator.invalidateTransient("invalidation", 7) && coordinator.ownerName
-                === "idle", "restored source invalidation removes it without stale content");
-
-        require(coordinator.syncPolkitModal(true, true, 20), "Modal opens for mailbox test");
-        require(coordinator.requestWorkspace("pending-invalidation", 9, 1, null),
-                "Modal admits a pending source for invalidation");
-        require(coordinator.invalidateTransient("pending-invalidation", 9)
-                && coordinator.pendingTransientCount === 0,
-                "source invalidation removes matching Modal-held work");
-        for (let index = 1; index <= 8; index += 1) {
-            require(coordinator.requestNotification("notification-" + index, 1, 1, null),
-                    "mailbox accepts bounded notification " + index);
-        }
-        require(coordinator.pendingTransientCount === 8, "mailbox reaches its fixed capacity");
-        require(coordinator.requestNotification("notification-4", 1, 2, null),
-                "coalesced update is accepted");
-        require(coordinator.pendingTransientCount === 8, "coalescing retains admission slot");
-        require(!coordinator.requestWorkspace("overflow-low", 1, 1, null),
-                "lower-rank overflow is rejected");
-        require(coordinator.pendingTransientCount === 8, "rejected overflow does not grow mailbox");
-        require(coordinator.requestNotification("notification-9", 1, 1, null),
-                "equal-rank overflow evicts oldest lowest-rank slot");
-        require(coordinator.pendingTransientCount === 8, "accepted overflow remains bounded");
-        require(coordinator.syncPolkitModal(false, false, 0), "mailbox Modal releases");
-        require(coordinator.ownerName === "notification" && coordinator.ownerSourceToken
-                === "notification-2",
-                "highest-rank oldest remaining transient is selected deterministically");
-
-
-        verifyExpandedIntents();
-        verifyExternalReset();
-
-        verifyReloadReattachment();
-
-        console.log("island state coordinator tests passed");
-        Qt.exit(0);
+    function snapshot(token) {
+        const ignored = coordinator.stateSerial;
+        return coordinator.surfaceSnapshot(token);
     }
 
-    Component {
-        id: coordinatorFactory
+    function attachSurfaces() {
+        firstToken = {};
+        secondToken = {};
+        thirdToken = {};
+        require(coordinator.attachSurface(firstToken, 1), "first surface attaches");
+        require(coordinator.attachSurface(secondToken, 2), "second surface attaches");
+        require(coordinator.attachSurface(thirdToken, 3), "third surface attaches");
+        require(coordinator.surfaceCount === 3, "one coordinator owns three records");
+        require(snapshot(firstToken).ownerName === "idle"
+                && snapshot(secondToken).ownerName === "idle"
+                && snapshot(thirdToken).ownerName === "idle", "every surface starts Idle");
+    }
 
-        IslandStateCoordinator {}
+    function verifyLocalBaselines() {
+        require(coordinator.setHover(firstToken, 1, true), "first hover enters");
+        require(snapshot(firstToken).ownerName === "expanded", "first surface expands");
+        require(snapshot(secondToken).ownerName === "idle", "second surface remains Idle");
+        require(!coordinator.setHover(firstToken, 2, false), "stale generation is rejected");
+        require(coordinator.setHover(firstToken, 1, false), "first hover clears");
+    }
+
+    function verifyInteractiveTransfer() {
+        router.preferredToken = secondToken;
+        require(coordinator.openLauncher(null), "global launcher routes to preferred surface");
+        const firstEpoch = snapshot(secondToken).ownerEpoch;
+        require(snapshot(secondToken).ownerName === "launcher"
+                && coordinator.interactiveHostToken === secondToken,
+                "launcher has one global host");
+        require(coordinator.openLauncher(firstToken), "local activation transfers launcher");
+        require(snapshot(firstToken).ownerName === "launcher"
+                && snapshot(secondToken).ownerName === "idle"
+                && coordinator.interactiveHostToken === firstToken,
+                "transfer is atomic and leaves previous host Idle");
+        require(snapshot(firstToken).ownerEpoch !== firstEpoch, "transfer receives a fresh epoch");
+
+        require(coordinator.openSession(thirdToken), "different island transfers Interactive task");
+        const sessionEpoch = snapshot(thirdToken).ownerEpoch;
+        require(snapshot(firstToken).ownerName === "idle"
+                && snapshot(thirdToken).ownerName === "session",
+                "only the transferred Session task survives");
+        require(!coordinator.openLauncher(firstToken)
+                && snapshot(thirdToken).ownerName === "session",
+                "lower-rank Interactive activation cannot preempt Session");
+        require(coordinator.cancelInteractive(sessionEpoch), "current Interactive task cancels");
+        require(snapshot(thirdToken).ownerName === "idle", "cancellation restores local baseline");
+    }
+
+    function verifyDisableAndLoss() {
+        require(coordinator.openAudio(firstToken), "Audio opens on first surface");
+        const audioEpoch = snapshot(firstToken).ownerEpoch;
+        router.preferredToken = secondToken;
+        require(coordinator.prepareSurfaceDisable(firstToken), "safe Interactive host transfers");
+        require(snapshot(firstToken).ownerName === "idle"
+                && snapshot(secondToken).ownerName === "audio"
+                && snapshot(secondToken).ownerEpoch === audioEpoch,
+                "voluntary disable preserves one safe task owner");
+
+        require(coordinator.syncPolkitModal(true, true, 41), "Modal flow enters");
+        require(coordinator.interactiveHostToken === null,
+                "Modal admission leaves no competing Interactive focus owner");
+        const modalToken = coordinator.modalHostToken;
+        require(modalToken !== null && !coordinator.prepareSurfaceDisable(modalToken),
+                "voluntary disable is rejected for Modal host");
+        router.preferredToken = thirdToken;
+        const modalSnapshot = snapshot(modalToken);
+        require(coordinator.detachSurface(modalToken, modalSnapshot.generation),
+                "involuntary Modal host loss detaches");
+        require(coordinator.modalHostToken === thirdToken
+                && snapshot(thirdToken).ownerName === "polkitModal"
+                && snapshot(thirdToken).restorationDepth === 0,
+                "Modal rehomes once without predecessor state");
+        require(coordinator.syncPolkitModal(false, false, 0), "Modal flow releases");
+        require(snapshot(thirdToken).ownerName === "idle", "rehomed Modal releases to Idle");
+        secondToken = {};
+        require(coordinator.attachSurface(secondToken, 4),
+                "reconnected display receives a fresh session token");
+    }
+
+    function verifyTransientProjection() {
+        require(coordinator.requestNotification("notification", 1, 1, null),
+                "notification enters one global event slot");
+        require(coordinator.pendingTransientCount === 1, "broadcast consumes one slot");
+        require(snapshot(secondToken).ownerName === "notification"
+                && snapshot(thirdToken).ownerName === "notification",
+                "notification projects to every eligible island");
+        const secondRevision = snapshot(secondToken).revision;
+        require(coordinator.requestNotification("notification", 1, 2, null),
+                "notification coalesces globally");
+        require(coordinator.pendingTransientCount === 1
+                && snapshot(secondToken).revision === secondRevision + 1
+                && snapshot(thirdToken).ownerSourceRevision === 2,
+                "coalescence updates every projection atomically");
+        require(coordinator.invalidateTransient("notification", 1),
+                "notification invalidates once");
+        require(snapshot(secondToken).ownerName === "idle"
+                && snapshot(thirdToken).ownerName === "idle"
+                && coordinator.pendingTransientCount === 0,
+                "invalidation removes every projection atomically");
+
+        require(coordinator.setHover(secondToken, 4, true), "second surface expands");
+        require(coordinator.requestVolume("output", 1, 1, null), "volume event broadcasts");
+        require(snapshot(secondToken).ownerName === "expanded"
+                && snapshot(thirdToken).ownerName === "volume",
+                "lower transient respects each surface priority");
+        require(coordinator.invalidateTransient("output", 1), "volume event invalidates");
+        require(coordinator.setHover(secondToken, 4, false), "second surface returns Idle");
+
+        require(coordinator.requestWorkspace("workspace", 1, 1, thirdToken),
+                "workspace event targets action surface");
+        require(snapshot(thirdToken).ownerName === "workspace"
+                && snapshot(secondToken).ownerName === "idle",
+                "workspace never mirrors");
+        require(coordinator.invalidateTransient("workspace", 1), "workspace invalidates");
+        require(coordinator.requestBrightness("brightness", 1, 1, secondToken),
+                "brightness targets initiating surface");
+        require(snapshot(secondToken).ownerName === "brightness"
+                && snapshot(thirdToken).ownerName === "idle",
+                "brightness never guesses another display");
+        require(coordinator.invalidateTransient("brightness", 1), "brightness invalidates");
+    }
+
+    function verifyTimingAndBounds() {
+        require(coordinator.requestVolume("timed", 2, 1, null), "timed volume enters");
+        const first = snapshot(firstToken);
+        const second = snapshot(secondToken);
+        const third = snapshot(thirdToken);
+        require(coordinator.acknowledgeVisible(firstToken, first.generation, first.ownerEpoch,
+                                               first.revision), "first projection acknowledges");
+        require(coordinator.acknowledgeVisible(secondToken, second.generation, second.ownerEpoch,
+                                               second.revision), "second projection acknowledges");
+        require(coordinator.acknowledgeVisible(thirdToken, third.generation, third.ownerEpoch,
+                                               third.revision), "third projection acknowledges");
+        nowMs += 1799;
+        require(coordinator.setHover(secondToken, 4, false), "pre-boundary dispatch runs");
+        require(snapshot(secondToken).ownerName === "volume", "global hold remains before boundary");
+        nowMs += 1;
+        require(coordinator.setHover(secondToken, 4, false), "hold boundary dispatch runs");
+        require(snapshot(secondToken).ownerName === "idle"
+                && snapshot(thirdToken).ownerName === "idle",
+                "global hold expires atomically");
+
+        for (let index = 0; index < 8; index += 1) {
+            require(coordinator.requestWorkspace("bounded-" + index, 1, 1, secondToken),
+                    "bounded event " + index + " enters");
+        }
+        require(coordinator.pendingTransientCount === 8, "mailbox remains bounded at eight");
+        require(coordinator.requestNotification("higher", 3, 1, null),
+                "higher event evicts one bounded candidate");
+        require(coordinator.pendingTransientCount === 8, "eviction preserves global bound");
+    }
+
+    QtObject {
+        id: router
+
+        property var preferredToken: null
+
+        function routeSurfaceToken(excludedToken) {
+            if (preferredToken !== null && preferredToken !== excludedToken
+                    && test.snapshot(preferredToken).generation > 0) {
+                return preferredToken;
+            }
+            const candidates = [test.firstToken, test.secondToken, test.thirdToken];
+            for (let index = 0; index < candidates.length; index += 1) {
+                if (candidates[index] !== excludedToken
+                        && test.snapshot(candidates[index]).generation > 0) {
+                    return candidates[index];
+                }
+            }
+            return null;
+        }
     }
 
     IslandStateCoordinator {
         id: coordinator
 
         monotonicNow: () => test.nowMs
+        surfaceRouter: router
     }
 
-
-    Component.onCompleted: Qt.callLater(test.run)
+    Timer {
+        interval: 1
+        running: true
+        onTriggered: {
+            attachSurfaces();
+            verifyLocalBaselines();
+            verifyInteractiveTransfer();
+            verifyDisableAndLoss();
+            verifyTransientProjection();
+            verifyTimingAndBounds();
+            console.log("coordinator multi-surface tests passed");
+            Qt.exit(0);
+        }
+    }
 }

--- a/tests/displays/shell.qml
+++ b/tests/displays/shell.qml
@@ -1,0 +1,173 @@
+import Quickshell
+import QtQuick
+import "qml"
+
+ShellRoot {
+    id: test
+
+    readonly property int expectedOutputs: parseInt(Quickshell.env("NAGI_TEST_OUTPUTS") ?? "2")
+    property int step: 0
+    property int attempts: 0
+    property var disabledScreen: null
+    property var replacementToken: null
+
+    function require(condition, message) {
+        if (!condition) {
+            console.error("FAIL: " + message);
+            Qt.exit(1);
+            throw new Error(message);
+        }
+    }
+
+    function awaitState(condition, message) {
+        if (condition) {
+            attempts = 0;
+            return true;
+        }
+        attempts += 1;
+        if (attempts > 500) {
+            require(false, message);
+        }
+        retry.restart();
+        return false;
+    }
+
+    function tokenForScreen(screen) {
+        for (let index = 0; index < host.registry.length; index += 1) {
+            if (host.registry[index].screen === screen) {
+                return host.registry[index].token;
+            }
+        }
+        return null;
+    }
+
+    function run() {
+        if (step === 0) {
+            if (!awaitState(host.liveSurfaceCount === expectedOutputs
+                            && coordinator.surfaceCount === expectedOutputs,
+                            "one live island did not settle on every connected output")) {
+                return;
+            }
+            const rows = host.activeDisplays();
+            require(rows.length === expectedOutputs && host.enabledDisplayCount === expectedOutputs,
+                    "new installations enable every connected display");
+            require(host.rememberedDisplays.length === 0,
+                    "unreliable ShellScreen identities never create remembered rows");
+            for (let index = 0; index < rows.length; index += 1) {
+                require(rows[index].enabled && !rows[index].reliable,
+                        "active display row is enabled and session-only");
+            }
+            require(displaysPage.displayController === host,
+                    "Displays page consumes the shared display controller");
+            const pointerToken = host.routeSurfaceToken(null);
+            require(pointerToken !== null && coordinator.openDashboard(null)
+                    && coordinator.surfaceSnapshot(pointerToken).ownerName === "expanded",
+                    "global action routes through the native pointer-screen bridge");
+            require(coordinator.resetToIdle(pointerToken),
+                    "pointer-routed dashboard returns to its initiating surface Idle");
+            if (expectedOutputs === 1) {
+                require(!host.setEnabled(rows[0].screen, false)
+                        && host.liveSurfaceCount === 1,
+                        "configuration rejects disabling the final island");
+                console.warn("display orchestration single-output tests passed");
+                Qt.exit(0);
+                return;
+            }
+
+            const first = rows[0];
+            const second = rows[1];
+            require(host.setFallback(second.screen), "active enabled fallback is accepted");
+            require(host.routeFallbackToken(null) === tokenForScreen(second.screen),
+                    "configured fallback resolves to its live surface");
+            require(host.routeSurfaceToken(null) === pointerToken
+                    && pointerToken !== host.routeFallbackToken(null),
+                    "pointer screen wins over a different configured fallback");
+            require(!host.setFallback(null), "disconnected fallback is rejected");
+
+            const firstToken = tokenForScreen(first.screen);
+            require(coordinator.openLauncher(firstToken), "Interactive task opens on first island");
+            disabledScreen = first.screen;
+            require(host.setEnabled(first.screen, false),
+                    "disabling an Interactive host transfers it safely");
+            step = 1;
+            retry.restart();
+            return;
+        }
+
+        if (step === 1) {
+            if (!awaitState(host.liveSurfaceCount === expectedOutputs - 1
+                            && coordinator.surfaceCount === expectedOutputs - 1,
+                            "disabled island did not destroy independently")) {
+                return;
+            }
+            require(coordinator.interactiveHostToken === host.routeFallbackToken(null),
+                    "one Interactive owner survives on the fallback island");
+            require(host.setEnabled(disabledScreen, true), "disabled island re-enables");
+            step = 2;
+            retry.restart();
+            return;
+        }
+
+        if (step === 2) {
+            if (!awaitState(host.liveSurfaceCount === expectedOutputs
+                            && tokenForScreen(disabledScreen) !== null,
+                            "re-enabled island did not receive a fresh surface")) {
+                return;
+            }
+            replacementToken = tokenForScreen(disabledScreen);
+            require(coordinator.surfaceSnapshot(replacementToken).ownerName === "idle",
+                    "replacement generation starts with local Idle state");
+            const interactive = coordinator.surfaceSnapshot(coordinator.interactiveHostToken);
+            require(coordinator.cancelInteractive(interactive.ownerEpoch),
+                    "transferred Interactive task completes before global feedback");
+            require(coordinator.requestNotification("broadcast", 1, 1, null),
+                    "notification enters the global mailbox");
+            for (let index = 0; index < host.registry.length; index += 1) {
+                require(coordinator.surfaceSnapshot(host.registry[index].token).ownerName
+                        === "notification", "notification mirrors to every eligible island");
+            }
+            require(coordinator.pendingTransientCount === 1,
+                    "mirrored notification consumes one global slot");
+            require(coordinator.invalidateTransient("broadcast", 1),
+                    "mirrored notification invalidates atomically");
+
+            coordinator.syncPolkitModal(true, true, 9);
+            const modalRecord = host.registryRecordForToken(coordinator.modalHostToken);
+            require(modalRecord !== null && !host.setEnabled(modalRecord.screen, false),
+                    "Modal host cannot be voluntarily disabled");
+            coordinator.syncPolkitModal(false, false, 0);
+            console.warn("display orchestration " + expectedOutputs + "-output tests passed");
+            Qt.exit(0);
+        }
+    }
+
+    IslandStateCoordinator {
+        id: coordinator
+    }
+
+    IslandSurfaceHost {
+        id: host
+
+        coordinator: coordinator
+    }
+
+    DisplaysPage {
+        id: displaysPage
+
+        visible: false
+        displayController: host
+    }
+
+    Timer {
+        id: retry
+
+        interval: 10
+        onTriggered: test.run()
+    }
+
+    Timer {
+        interval: 1
+        running: true
+        onTriggered: test.run()
+    }
+}

--- a/tests/surface-state/shell.qml
+++ b/tests/surface-state/shell.qml
@@ -243,7 +243,7 @@ ShellRoot {
                     "surface keeps the outer radius override while standard panels default to md");
             initialSurfaceToken = host.surfaceToken;
             initialSurfaceGeneration = host.surfaceGeneration;
-            require(mountedRegionCount === 6,
+            require(mountedRegionCount === host.liveSurfaceCount * 6,
                     "all dashboard regions mount before expansion starts");
             startGeometrySampling("expanding", function () {
                 return coordinator.setHover(host.surfaceGeneration, true);
@@ -617,7 +617,7 @@ ShellRoot {
                             "final transient cleanup did not restore Idle")) {
                 return;
             }
-            require(mountedRegionCount === 6,
+            require(mountedRegionCount === host.liveSurfaceCount * 6,
                     "dashboard regions stay mounted across Interactive interruptions");
             require(!coordinator.setHover(host.surfaceGeneration + 1, true),
                     "stale surface intent cannot reopen the dashboard");
@@ -635,15 +635,20 @@ ShellRoot {
         } else if (step === 21) {
             if (!awaitState(coordinator.ownerName === "polkitModal"
                             && coordinator.presentationVisible && host.surfaceFocusable
-                            && host.polkitLoaded && host.polkitFocused,
+                            && host.polkitLoaded && host.polkitFocused
+                            && Math.abs(host.surfaceWidth - host.surfacePreferredWidth) <= 1
+                            && Math.abs(host.surfaceHeight - host.surfacePreferredHeight) <= 1,
                             "Polkit presentation did not load, acknowledge, and focus")) {
                 return;
             }
             require(host.surfacePreferredWidth > 0 && host.surfacePreferredHeight > 0
-                    && host.surfaceWidth <= host.surfacePreferredWidth
-                    && host.surfaceHeight <= host.surfacePreferredHeight
+                    && host.surfaceWidth <= host.surfacePreferredWidth + 1
+                    && host.surfaceHeight <= host.surfacePreferredHeight + 1
                     && host.geometryAnimationDuration === 0,
-                    "Polkit Modal uses content-sized reduced-motion geometry");
+                    "Polkit geometry actual=" + host.surfaceWidth + "x" + host.surfaceHeight
+                    + " preferred=" + host.surfacePreferredWidth + "x"
+                    + host.surfacePreferredHeight + " duration="
+                    + host.geometryAnimationDuration);
             require(host.polkitIdentityCount === 2 && host.polkitResponseFieldVisible,
                     "normalized identities and the live prompt reach the Modal view");
             require(!coordinator.openLauncher(host.surfaceToken)
@@ -700,7 +705,11 @@ ShellRoot {
         } else if (step === 26) {
             if (!awaitState(coordinator.ownerName === "expanded" && coordinator.presentationVisible
                             && host.dashboardFocused && !host.polkitLoaded,
-                            "Modal completion did not restore its focused predecessor")) {
+                            "Modal completion state owner=" + coordinator.ownerName + " visible="
+                            + coordinator.presentationVisible + " focused=" + host.dashboardFocused
+                            + " polkitLoaded=" + host.polkitLoaded + " target="
+                            + coordinator.focusTarget + " serial="
+                            + coordinator.focusRequestSerial)) {
                 return;
             }
             require(host.cancelDashboard(), "restored predecessor remains cancellable");
@@ -1133,14 +1142,90 @@ ShellRoot {
     }
 
     IslandStateCoordinator {
-        id: coordinator
+        id: coordinatorCore
     }
 
+    QtObject {
+        id: coordinator
+
+        readonly property var snapshot: coordinatorCore.surfaceSnapshot(host.surfaceToken)
+        readonly property string ownerName: snapshot.ownerName
+        readonly property bool presentationVisible: snapshot.presentationVisible
+        readonly property real ownerEpoch: snapshot.ownerEpoch
+        readonly property real revision: snapshot.revision
+        readonly property int focusTarget: snapshot.focusTarget
+        readonly property real focusRequestSerial: snapshot.focusRequestSerial
+        readonly property bool hoverIntent: snapshot.hoverIntent
+        readonly property bool explicitExpandedIntent: snapshot.explicitExpandedIntent
+        readonly property int focusNone: coordinatorCore.focusNone
+        readonly property int focusExpandedDashboard: coordinatorCore.focusExpandedDashboard
+        readonly property int focusLauncherSearch: coordinatorCore.focusLauncherSearch
+        readonly property int focusSessionActions: coordinatorCore.focusSessionActions
+        readonly property int focusNotificationHistory: coordinatorCore.focusNotificationHistory
+        readonly property int focusTray: coordinatorCore.focusTray
+        readonly property int focusAudio: coordinatorCore.focusAudio
+
+        function refreshFallback(result) {
+            if (host.fallbackSurface !== null) {
+                host.fallbackSurface.refreshSurfaceState();
+            }
+            return result;
+        }
+
+        function cancelInteractive(epoch) {
+            return refreshFallback(coordinatorCore.cancelInteractive(epoch));
+        }
+        function invalidateTransient(token, generation) {
+            return refreshFallback(coordinatorCore.invalidateTransient(token, generation));
+        }
+        function openAudio(token) {
+            return coordinatorCore.openAudio(token);
+        }
+        function openHistory(token) {
+            return coordinatorCore.openHistory(token);
+        }
+        function openLauncher(token) {
+            return coordinatorCore.openLauncher(token);
+        }
+        function openSession(token) {
+            return coordinatorCore.openSession(token);
+        }
+        function openTray(token) {
+            return coordinatorCore.openTray(token);
+        }
+        function requestNotification(token, generation, sourceRevision, initiatingToken) {
+            return coordinatorCore.requestNotification(token, generation, sourceRevision,
+                                                       initiatingToken);
+        }
+        function requestVolume(token, generation, sourceRevision, initiatingToken) {
+            return coordinatorCore.requestVolume(token, generation, sourceRevision,
+                                                 initiatingToken);
+        }
+        function requestWorkspace(token, generation, sourceRevision, initiatingToken) {
+            return coordinatorCore.requestWorkspace(token, generation, sourceRevision,
+                                                    initiatingToken);
+        }
+        function setExplicitExpanded(generation, value) {
+            const accepted = coordinatorCore.setExplicitExpanded(host.surfaceToken, generation,
+                                                                 value);
+            host.fallbackSurface.refreshSurfaceState();
+            return accepted;
+        }
+        function setHover(generation, value) {
+            const accepted = coordinatorCore.setHover(host.surfaceToken, generation, value);
+            host.fallbackSurface.refreshSurfaceState();
+            return accepted;
+        }
+        function syncPolkitModal(active, flowPresent, flowGeneration) {
+            return refreshFallback(coordinatorCore.syncPolkitModal(active, flowPresent,
+                                                                   flowGeneration));
+        }
+    }
 
     IslandSurfaceHost {
         id: host
 
-        coordinator: coordinator
+        coordinator: coordinatorCore
         dashboardMediaContent: mediaRegion
         dashboardClockContent: clockRegion
         dashboardQuickControlsContent: quickControlsRegion

--- a/tests/transients/shell.qml
+++ b/tests/transients/shell.qml
@@ -16,6 +16,10 @@ ShellRoot {
         }
     }
 
+    function snapshot() {
+        return coordinator.surfaceSnapshot(surfaceToken);
+    }
+
     function requireWorkspaceGeometry(view, label) {
         require(view.implicitWidth >= Theme.size.islandTransientCompactMinimumWidth
                 && view.implicitWidth <= Theme.size.islandTransientCompactWidth, label
@@ -98,90 +102,93 @@ ShellRoot {
         surfaceToken = {};
         require(coordinator.attachSurface(surfaceToken, 1), "transient surface attaches");
         workspace.confirmedWorkspaceChanged("workspace-current", 1, 1);
-        require(coordinator.ownerName === "workspace" && coordinator.ownerSourceRevision === 1,
-                "confirmed workspace change routes once to the fallback surface");
-        const workspaceEpoch = coordinator.ownerEpoch;
+        require(snapshot().ownerName === "workspace"
+                && snapshot().ownerSourceRevision === 1,
+                "confirmed workspace change routes to its action surface");
+        const workspaceEpoch = snapshot().ownerEpoch;
         for (let revision = 2; revision <= 20; revision += 1) {
             workspace.confirmedWorkspaceChanged("workspace-current", 1, revision);
         }
-        require(coordinator.ownerName === "workspace" && coordinator.ownerEpoch === workspaceEpoch
-                && coordinator.ownerSourceRevision === 20 && coordinator.pendingTransientCount === 0,
-                "workspace burst coalesces in place without queue growth");
+        require(snapshot().ownerName === "workspace" && snapshot().ownerEpoch === workspaceEpoch
+                && snapshot().ownerSourceRevision === 20
+                && coordinator.pendingTransientCount === 1,
+                "workspace burst coalesces in one global event record");
 
-        brightness.confirmedBrightnessChanged("1:display0", 1, 1, null);
-        require(coordinator.ownerName === "brightness" && coordinator.restorationDepth === 1,
-                "external brightness preempts workspace through fallback routing");
+        brightness.confirmedBrightnessChanged("1:display0", 1, 1, surfaceToken);
+        require(snapshot().ownerName === "brightness" && snapshot().restorationDepth === 1,
+                "targeted brightness preempts workspace");
         workspace.confirmedWorkspaceInvalidated("workspace-current", 1);
-        require(coordinator.restorationDepth === 0,
-                "workspace generation loss removes its suspended feedback");
-        const brightnessEpoch = coordinator.ownerEpoch;
+        require(snapshot().restorationDepth === 0 && coordinator.pendingTransientCount === 1,
+                "workspace invalidation removes its suspended event globally");
+        const brightnessEpoch = snapshot().ownerEpoch;
         brightness.confirmedBrightnessChanged("1:display0", 1, 2, surfaceToken);
-        require(coordinator.ownerEpoch === brightnessEpoch && coordinator.ownerSourceRevision === 2
-                && coordinator.pendingTransientCount === 0,
-                "local brightness confirmation coalesces without a parallel routing path");
+        require(snapshot().ownerEpoch === brightnessEpoch
+                && snapshot().ownerSourceRevision === 2
+                && coordinator.pendingTransientCount === 1,
+                "local brightness confirmation coalesces without another slot");
         brightness.confirmedBrightnessInvalidated("1:display0", 1);
-        require(coordinator.ownerName === "idle",
-                "brightness display removal invalidates visible feedback");
+        require(snapshot().ownerName === "idle", "brightness invalidation restores Idle");
 
         audio.confirmedOutputChanged("audio-output-1", 1, 1);
-        require(coordinator.ownerName === "volume" && coordinator.ownerSourceRevision === 1,
-                "confirmed output change enters the volume owner");
-        const volumeEpoch = coordinator.ownerEpoch;
+        require(snapshot().ownerName === "volume" && snapshot().ownerSourceRevision === 1,
+                "confirmed output change enters one volume event");
+        const volumeEpoch = snapshot().ownerEpoch;
         for (let revision = 2; revision <= 20; revision += 1) {
             audio.confirmedOutputChanged("audio-output-1", 1, revision);
         }
-        require(coordinator.ownerName === "volume" && coordinator.ownerEpoch === volumeEpoch
-                && coordinator.ownerSourceRevision === 20 && coordinator.pendingTransientCount === 0,
-                "rapid visible output confirmations coalesce in place without queue growth");
+        require(snapshot().ownerName === "volume" && snapshot().ownerEpoch === volumeEpoch
+                && snapshot().ownerSourceRevision === 20
+                && coordinator.pendingTransientCount === 1,
+                "rapid output confirmations coalesce in one event record");
 
         audio.confirmedInputChanged("audio-input-1", 1, 1);
-        require(coordinator.ownerSourceToken === "audio-output-1"
-                && coordinator.ownerSourceRevision === 20,
-                "default-input confirmation cannot create an output-volume transient");
+        require(snapshot().ownerSourceToken === "audio-output-1"
+                && snapshot().ownerSourceRevision === 20,
+                "input confirmation cannot create an output-volume event");
 
         notifications.transientRequested("notification-1", 1, 1);
-        require(coordinator.ownerName === "notification" && coordinator.restorationDepth === 1,
-                "notification priority preempts and suspends confirmed volume");
+        require(snapshot().ownerName === "notification" && snapshot().restorationDepth === 1
+                && coordinator.pendingTransientCount === 2,
+                "notification priority preempts volume without per-display duplication");
         audio.confirmedOutputChanged("audio-output-1", 1, 21);
-        require(coordinator.restorationDepth === 1 && coordinator.pendingTransientCount === 0,
-                "suspended volume source coalesces to one latest revision");
+        require(snapshot().restorationDepth === 1
+                && coordinator.pendingTransientCount === 2,
+                "suspended volume source coalesces in its existing event");
         audio.confirmedOutputInvalidated("audio-output-1", 1);
-        require(coordinator.ownerName === "notification" && coordinator.restorationDepth === 0,
-                "endpoint removal invalidates the suspended volume without stale restoration");
+        require(snapshot().ownerName === "notification" && snapshot().restorationDepth === 0
+                && coordinator.pendingTransientCount === 1,
+                "endpoint removal invalidates suspended volume globally");
 
         notifications.transientRequested("notification-2", 1, 1);
-        require(coordinator.pendingTransientCount === 1,
-                "independent notification occupies one shared mailbox slot");
-        const notificationEpoch = coordinator.ownerEpoch;
+        require(coordinator.pendingTransientCount === 2,
+                "independent notification occupies one additional global slot");
+        const notificationEpoch = snapshot().ownerEpoch;
         notifications.transientRequested("notification-1", 1, 2);
-        require(coordinator.ownerEpoch === notificationEpoch && coordinator.ownerSourceRevision
-                === 2 && coordinator.pendingTransientCount === 1,
-                "same-notification replacement coalesces without disturbing independent work");
+        require(snapshot().ownerEpoch === notificationEpoch
+                && snapshot().ownerSourceRevision === 2
+                && coordinator.pendingTransientCount === 2,
+                "same-notification replacement updates without slot growth");
         notifications.transientInvalidated("notification-1", 1);
-        require(coordinator.ownerName === "notification" && coordinator.ownerSourceToken
-                === "notification-2" && coordinator.pendingTransientCount === 0,
-                "notification invalidation restores the next eligible source atomically");
+        require(snapshot().ownerName === "notification" && snapshot().ownerSourceToken
+                === "notification-2" && coordinator.pendingTransientCount === 1,
+                "invalidation restores the next eligible notification atomically");
         notifications.transientInvalidated("notification-2", 1);
-        require(coordinator.ownerName === "idle", "last notification invalidation restores Idle");
+        require(snapshot().ownerName === "idle" && coordinator.pendingTransientCount === 0,
+                "last notification invalidation restores Idle");
 
-        require(coordinator.setHover(1, true), "expanded baseline enters for pending test");
+        require(coordinator.setHover(surfaceToken, 1, true),
+                "expanded baseline enters for pending test");
         for (let revision = 1; revision <= 20; revision += 1) {
             audio.confirmedOutputChanged("audio-output-2", 2, revision);
         }
-        require(coordinator.ownerName === "expanded" && coordinator.pendingTransientCount === 1,
-                "blocked output burst keeps one replaceable pending transient");
+        require(snapshot().ownerName === "expanded" && coordinator.pendingTransientCount === 1,
+                "blocked output burst keeps one replaceable global event");
         audio.confirmedOutputInvalidated("audio-output-2", 2);
         require(coordinator.pendingTransientCount === 0,
-                "endpoint disappearance drops pending audio before presentation");
-        require(coordinator.setHover(1, false) && coordinator.ownerName === "idle",
-                "expired pending audio cannot replay after Expanded");
-
-        audio.confirmedOutputChanged("audio-output-3", 3, 1);
-        require(coordinator.ownerName === "volume" && coordinator.ownerSourceToken
-                === "audio-output-3", "replacement endpoint presents only its fresh generation");
-        audio.confirmedOutputInvalidated("audio-output-3", 3);
-        require(coordinator.ownerName === "idle",
-                "unavailable output cannot leave a stale volume owner");
+                "endpoint disappearance drops blocked audio before presentation");
+        require(coordinator.setHover(surfaceToken, 1, false)
+                && snapshot().ownerName === "idle",
+                "invalidated audio cannot replay after Expanded");
 
         console.warn("transient integration tests passed");
         Qt.exit(0);
@@ -225,7 +232,6 @@ ShellRoot {
 
     TransientCoordinatorBridge {
         coordinator: coordinator
-        surfaceToken: test.surfaceToken
         workspaceSource: workspace
         brightnessSource: brightness
         audioSource: audio


### PR DESCRIPTION
Create one island per enabled display while keeping services,
Interactive and Modal ownership, and transient admission process-wide.
Route global actions through the pointer screen, then the fallback.

BREAKING CHANGE: multi-monitor sessions now create an island on every
connected display instead of one startup-primary island.

Closes #71