### PR TITLE
feat(weather): extend forecasts and configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ help:
 		'make test-transients  Test workspace, brightness, audio, and notification routing' \
 		'make test-surface-state  Exercise the actual island surface in isolated virtual KWin' \
 		'make test-display-orchestration  Test live multi-island display routing and visibility' \
-		'make test-weather    Test compact clock and weather adapter state' \
+		'make test-weather    Test bounded location lookup, forecasts, cache, and scheduling' \
 		'make test-media      Test the MPRIS media adapter state' \
 		'make test-audio      Test the PipeWire audio adapter state' \
 		'make test-audio-live Probe the live PipeWire graph without changing it' \
@@ -519,7 +519,7 @@ test-transients: check-quickshell | $(BUILD_DIR)
 test-weather: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(WEATHER_TEST_DIR)/qml
 	cp tests/weather/shell.qml $(WEATHER_TEST_DIR)/shell.qml
-	cp qml/WeatherAdapter.qml qml/CompactClock.qml $(WEATHER_TEST_DIR)/qml/
+	cp qml/WeatherAdapter.qml qml/WeatherLocationSearchAdapter.qml qml/CompactClock.qml $(WEATHER_TEST_DIR)/qml/
 	$(QS) -p $(WEATHER_TEST_DIR) --no-duplicate
 
 test-media: check-quickshell | $(BUILD_DIR)
@@ -598,7 +598,7 @@ test-launcher: check-quickshell | $(BUILD_DIR)
 test-surface-state: check-quickshell platform-plugin | $(BUILD_DIR)
 	mkdir -p $(SURFACE_STATE_TEST_DIR)/qml $(SURFACE_STATE_TEST_DIR)/assets/icons/nagi
 	cp tests/surface-state/shell.qml $(SURFACE_STATE_TEST_DIR)/shell.qml
-	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/DashboardMedia.qml qml/DashboardClock.qml qml/DashboardQuickControls.qml qml/DashboardAudio.qml qml/DashboardVolumeControl.qml qml/DashboardNotifications.qml qml/DashboardNavigation.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/AudioSelectionView.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IconResolver.qml qml/IslandIcon.qml qml/SubviewFrame.qml qml/TrayView.qml qml/IslandStateCoordinator.qml qml/DisplayManager.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(SURFACE_STATE_TEST_DIR)/qml/
+	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/DashboardMedia.qml qml/DashboardClock.qml qml/DashboardQuickControls.qml qml/DashboardAudio.qml qml/DashboardVolumeControl.qml qml/DashboardNotifications.qml qml/DashboardNavigation.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/AudioSelectionView.qml qml/WeatherView.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IconResolver.qml qml/IslandIcon.qml qml/SubviewFrame.qml qml/TrayView.qml qml/IslandStateCoordinator.qml qml/DisplayManager.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(SURFACE_STATE_TEST_DIR)/qml/
 	cp assets/icons/nagi/*.svg $(SURFACE_STATE_TEST_DIR)/assets/icons/nagi/
 	$(KWIN_VIRTUAL_RUNNER) $(KWIN_TEST_ARGS) -- env QML_IMPORT_PATH='$(abspath $(BUILD_DIR)/qml)' $(QS) -p $(SURFACE_STATE_TEST_DIR) --no-duplicate
 
@@ -606,7 +606,7 @@ test-display-orchestration: check-quickshell platform-plugin | $(BUILD_DIR)
 	rm -rf $(DISPLAY_TEST_DIR)
 	mkdir -p $(DISPLAY_TEST_DIR)/qml $(DISPLAY_TEST_DIR)/assets/icons/nagi
 	cp tests/displays/shell.qml $(DISPLAY_TEST_DIR)/shell.qml
-	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/DashboardMedia.qml qml/DashboardClock.qml qml/DashboardQuickControls.qml qml/DashboardAudio.qml qml/DashboardVolumeControl.qml qml/DashboardNotifications.qml qml/DashboardNavigation.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/AudioSelectionView.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IconResolver.qml qml/IslandIcon.qml qml/SubviewFrame.qml qml/TrayView.qml qml/IslandStateCoordinator.qml qml/DisplayManager.qml qml/DisplaysPage.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(DISPLAY_TEST_DIR)/qml/
+	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/DashboardMedia.qml qml/DashboardClock.qml qml/DashboardQuickControls.qml qml/DashboardAudio.qml qml/DashboardVolumeControl.qml qml/DashboardNotifications.qml qml/DashboardNavigation.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/AudioSelectionView.qml qml/WeatherView.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IconResolver.qml qml/IslandIcon.qml qml/SubviewFrame.qml qml/TrayView.qml qml/IslandStateCoordinator.qml qml/DisplayManager.qml qml/DisplaysPage.qml qml/IslandSurfaceHost.qml qml/IslandSurface.qml $(DISPLAY_TEST_DIR)/qml/
 	cp assets/icons/nagi/*.svg $(DISPLAY_TEST_DIR)/assets/icons/nagi/
 	@set -eu; \
 	for outputs in 1 2 3; do \
@@ -677,7 +677,7 @@ test-onboarding: check-quickshell | $(BUILD_DIR)
 test-ui-primitives: check-quickshell | $(BUILD_DIR)
 	mkdir -p $(UI_PRIMITIVES_TEST_DIR)/qml $(UI_PRIMITIVES_TEST_DIR)/assets/icons/nagi
 	cp tests/ui/shell.qml $(UI_PRIMITIVES_TEST_DIR)/shell.qml
-	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/AudioSelectionView.qml qml/IslandStateCoordinator.qml qml/IslandSurface.qml qml/IconResolver.qml qml/IslandIcon.qml qml/SubviewFrame.qml qml/TrayView.qml $(UI_PRIMITIVES_TEST_DIR)/qml/
+	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IdleIsland.qml qml/IdleMediaText.qml qml/WeatherGlyph.qml qml/WeatherView.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/IslandIconButton.qml qml/IslandProgressBar.qml qml/TransientView.qml qml/DashboardRegion.qml qml/ExpandedDashboard.qml qml/LauncherView.qml qml/NotificationHistoryView.qml qml/SessionView.qml qml/PolkitView.qml qml/AudioSelectionView.qml qml/IslandStateCoordinator.qml qml/IslandSurface.qml qml/IconResolver.qml qml/IslandIcon.qml qml/SubviewFrame.qml qml/TrayView.qml $(UI_PRIMITIVES_TEST_DIR)/qml/
 	cp assets/icons/nagi/*.svg $(UI_PRIMITIVES_TEST_DIR)/assets/icons/nagi/
 	$(KWIN_VIRTUAL_RUNNER) $(KWIN_TEST_ARGS) -- $(QS) -p $(UI_PRIMITIVES_TEST_DIR) --no-duplicate
 
@@ -728,7 +728,7 @@ test-control-center: check-quickshell | $(BUILD_DIR)
 	rm -rf $(CONTROL_CENTER_TEST_DIR)
 	mkdir -p $(CONTROL_CENTER_TEST_DIR)/qml
 	cp tests/control-center/shell.qml $(CONTROL_CENTER_TEST_DIR)/shell.qml
-	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/ControlCenterSettingRow.qml qml/SettingToggleRow.qml qml/SettingSliderRow.qml qml/SettingChoiceRow.qml qml/SettingColorRow.qml qml/SettingActionRow.qml qml/SettingsResetActions.qml qml/IslandPage.qml qml/AppearancePage.qml qml/ClockDatePage.qml qml/MediaPage.qml qml/NotificationsPage.qml qml/DisplaysPage.qml qml/AboutPage.qml qml/ControlCenterWindow.qml $(CONTROL_CENTER_TEST_DIR)/qml/
+	cp $(THEME_QML_SOURCES) qml/IslandPanel.qml qml/IslandText.qml qml/IslandFocusRing.qml qml/IslandButton.qml qml/ControlCenterSettingRow.qml qml/SettingToggleRow.qml qml/SettingSliderRow.qml qml/SettingChoiceRow.qml qml/SettingColorRow.qml qml/SettingActionRow.qml qml/SettingsResetActions.qml qml/IslandPage.qml qml/AppearancePage.qml qml/ClockDatePage.qml qml/MediaPage.qml qml/WeatherPage.qml qml/NotificationsPage.qml qml/DisplaysPage.qml qml/AboutPage.qml qml/ControlCenterWindow.qml $(CONTROL_CENTER_TEST_DIR)/qml/
 	@$(KWIN_VIRTUAL_RUNNER) $(KWIN_TEST_ARGS) -- env NAGI_SKIP_DEFAULT_CONFIG_CREATION=1 NAGI_CONTROL_CENTER_CAPTURE='$(abspath $(CONTROL_CENTER_TEST_DIR))/about.png' NAGI_APPEARANCE_CAPTURE='$(abspath $(CONTROL_CENTER_TEST_DIR))/appearance.png' NAGI_ISLAND_CAPTURE='$(abspath $(CONTROL_CENTER_TEST_DIR))/island.png' QT_ACCESSIBILITY=1 $(QS) -p $(abspath $(CONTROL_CENTER_TEST_DIR)) --no-duplicate
 	@$(KWIN_VIRTUAL_RUNNER) --scale 1 --outputs 1 --width '$(KWIN_TEST_WIDTH)' --height '$(KWIN_TEST_HEIGHT)' -- bash $(CURDIR)/tests/control-center/run-activation.sh
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ weather · media       connectivity · audio      tray · audio · session
 - **Adaptive geometry.** Content determines the island size. Compact height/padding and expanded screen fractions stay inside tested bounds; empty regions collapse, focused collections grow only as needed, and screen bounds cap the result. Horizontal and vertical overflow scroll independently and keep keyboard focus visible.
 - **Useful Idle state.** Mandatory Clock plus optional Workspace, Weather, and Media stay in one fixed order inside a metrics-derived 44 to 48 px bar. Disabled or unavailable groups and separators collapse completely.
 - **Current dashboard.** Media and a centered clock/date lead into large Wi-Fi and Bluetooth quick settings, active or attention tray applications, pinned launchers, two-column output/input audio, recent notifications, and the right navigation rail.
-- **Focused tools.** Launcher, notification history, tray, audio-device selection, and six session actions replace dashboard content inside the same island. History keeps a 480 px reading lane within a 512 px surface and shows up to five rows before scrolling. The tray subview lists every item in a scrollable grid, while the dashboard mirrors at most four active or attention items.
+- **Focused tools.** Launcher, notification history, tray, audio-device selection, detailed Weather, and six session actions replace dashboard content inside the same island. Weather shows the shared current conditions, next 12 returned hours, and five returned days in a bounded scrolling view. History keeps a 480 px reading lane within a 512 px surface and shows up to five rows before scrolling. The tray subview lists every item in a scrollable grid, while the dashboard mirrors at most four active or attention items.
 - **Native desktop integration.** KWin virtual desktops, PowerDevil brightness, PipeWire audio, MPRIS media, D-Bus connectivity and session actions, desktop entries, KGlobalAccel, StatusNotifier items, notifications, KDE appearance, and the Plasma wallpaper palette feed normalized adapters.
 - **Bounded live appearance.** Nagi Dark, OLED, Light, System, and reduced Custom inputs publish one contrast-checked semantic snapshot across every island and Nagi window. Nagi, System, Wallpaper, and Custom accents share one derivation path; optional blur keeps a readable plain-surface fallback.
 - **Semantic icons.** Nagi icons, KDE action icons, and untinted application icons share one resolver/rendering path with a neutral fallback and adapt contrast to the current semantic surface; muted input has its own slashed-microphone shape.
@@ -63,7 +63,7 @@ weather · media       connectivity · audio      tray · audio · session
 |---|---|---|
 | **Idle** | Show compact, display-only status | Workspace, clock, optional weather and media |
 | **Expanded** | Expose frequent controls and recent context | Media, connectivity, audio, pinned apps, notifications |
-| **Interactive** | Complete one focused task | Launcher, History, Tray, Audio, Session |
+| **Interactive** | Complete one focused task | Launcher, History, Tray, Audio, Weather, Session |
 | **Transient** | Replace Idle with short-lived feedback | Notification, volume, brightness, workspace |
 | **Modal** | Hold a normalized authentication presentation | Dormant Polkit UI seam only |
 
@@ -108,7 +108,7 @@ Run the checkout in the foreground. `make launch` builds the native helpers and 
 make launch
 ```
 
-Hover the island to open the dashboard. On first launch, an independent onboarding window explains the private versioned settings, Control Center, and KDE shortcut management. Close it with its visible action, `Escape`, or the window manager; Nagi records that dismissal under `${XDG_STATE_HOME:-$HOME/.local/state}/nagi-shell/`, and a missing or unwritable record simply means onboarding appears again later. Dashboard Settings opens the normal resizable Control Center in the same Nagi process. Its complete Island, Appearance, Clock & Date, Media, Notifications, Displays, and About pages unload while closed; setting changes publish immediately through the shared settings snapshot. While Nagi runs, it acts as the session's freedesktop notification server. Use Back or `Escape` to leave a focused island subview. Run `make stop` from another terminal to stop the checkout synchronously.
+Hover the island to open the dashboard. On first launch, an independent onboarding window explains the private versioned settings, Control Center, and KDE shortcut management. Close it with its visible action, `Escape`, or the window manager; Nagi records that dismissal under `${XDG_STATE_HOME:-$HOME/.local/state}/nagi-shell/`, and a missing or unwritable record simply means onboarding appears again later. Dashboard Settings opens the normal resizable Control Center in the same Nagi process. Its complete Island, Appearance, Clock & Date, Media, Weather, Notifications, Displays, and About pages unload while closed; setting changes publish immediately through the shared settings snapshot. While Nagi runs, it acts as the session's freedesktop notification server.
 
 For startup diagnostics, use `make diagnose`, then inspect the checkout with `make instances` and `make logs`.
 
@@ -117,7 +117,7 @@ For startup diagnostics, use `make diagnose`, then inspect the checkout with `ma
 Nagi owns one canonical file at `${XDG_CONFIG_HOME:-$HOME/.config}/nagi-shell/settings.conf`. Schema version `2` is a file-format version, not the product's internal V2 program name. New files use the private canonical template in `packaging/settings.conf`; valid legacy `theme.conf` values migrate once, byte-for-byte backup to `settings.conf.bak`, then the old file stops being active.
 
 > [!WARNING]
-> Weather remains opt-in. Enabling migrated coordinates means direct requests reveal your IP address and four-decimal coordinates to MET Norway. Nagi never uses IP geolocation. Future location search is an explicit user action owned by the Weather page.
+> Weather is opt-in. Manual search sends the submitted city or postal text and your IP address to Open-Meteo; if it is unavailable, Nagi may send the same submitted search to the configured Nominatim endpoint. Confirmed forecasts send your IP address and four-decimal coordinates to MET Norway. Nagi stores no search history, uses no IP geolocation or automatic location tracking, and saves only the confirmed local label and coordinates. Accept this disclosure before searching or enabling Weather.
 
 ```ini
 [settings]
@@ -208,7 +208,7 @@ Everything below stays on this machine; Nagi has no telemetry or sync.
 
 **Notification history.** Memory-only: no history file or database exists, and history is lost entirely when the process exits. It keeps at most 50 records for at most 24 hours, newest first, with the four most recent mirrored on the dashboard. Transient notifications never enter history. Expired notifications remain as text-only records until evicted; dismissed, action-consumed, and sender-closed records are removed immediately. A separate safety cap of 50 tracked protocol notifications expires the lowest-ranked item deterministically under pressure, even critical or never-expiring ones. Notification actions remain disabled on current supported Quickshell versions.
 
-**Weather cache.** One record per configured location lives in Quickshell's per-shell cache directory as `weather.json`, written atomically and reused at startup. Refreshes follow provider cache headers with bounded backoff, and content older than six hours is discarded automatically. Clearing the configured location also clears its cache.
+**Weather cache.** One private record for the confirmed label-and-coordinate identity lives in Quickshell's per-shell cache directory as `weather.json`, written atomically and reused at startup. It holds one bounded MET Norway compact response for process-wide current, 12-hour, and five-day projections; it never duplicates the human-readable label. Refreshes honor provider expiry and conditional requests before the selected `15m`, `30m`, `1h`, or `3h` preference, with a ten-minute minimum gap, manual-refresh cooldown, Retry-After, and bounded backoff. Expired valid data is marked stale with age for at most six hours, then discarded. Disabling Weather or changing/clearing the confirmed location aborts work and clears the prior cache.
 
 **Onboarding record.** First-launch dismissal persists under `${XDG_STATE_HOME:-$HOME/.local/state}/nagi-shell/`.
 
@@ -254,9 +254,9 @@ Brightness uses PowerDevil 6.7's `org.kde.ScreenBrightness` interface exclusivel
 
 ## Privacy
 
-Nagi has no telemetry. Desktop metadata, application history, pins, notifications, media state, audio devices, and wallpaper analysis stay local. Adapters bound untrusted text and keep raw D-Bus payloads, hardware identity, wallpaper paths, and backend errors out of the presentation.
+Nagi has no telemetry. Desktop metadata, application history, pins, notifications, media state, audio devices, and wallpaper analysis stay local. Adapters bound untrusted text and keep raw D-Bus payloads, hardware identity, wallpaper paths, network payloads, coordinates, location labels, submitted searches, and backend errors out of presentation diagnostics and logs.
 
-Weather is opt-in. It sends coordinates truncated to two decimal places and the user's IP address to MET Norway, then stores a bounded local cache. No location label leaves the machine. Use the linked Nominatim web page to look up coordinates manually; Nagi does not contact Nominatim. Weather data comes from [MET Norway Locationforecast](https://api.met.no/weatherapi/locationforecast/2.0/documentation), transformed into compact Nagi Shell condition categories and licensed under [CC BY 4.0](https://api.met.no/doc/License). MET Norway provides no delivery SLA.
+Weather is opt-in and performs no automatic location lookup. The Weather page repeats the disclosure before its explicit city/postal search. Search uses the keyless [Open-Meteo geocoding API](https://open-meteo.com/en/docs/geocoding-api), based on GeoNames and licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/), while Nagi remains non-commercial. Service failure may use the switchable [Nominatim](https://nominatim.org/) fallback at no more than one request per second; its data is © OpenStreetMap contributors under [ODbL](https://www.openstreetmap.org/copyright). Forecasts use only [MET Norway Locationforecast](https://api.met.no/weatherapi/locationforecast/2.0/documentation), transformed into bounded Nagi condition categories and calculated feels-like values, under [NLOD 2.0 / CC BY 4.0](https://api.met.no/doc/License). MET Norway provides no delivery SLA.
 
 Polkit credentials never enter the production shell because the backend is dormant. Synthetic presentation tests still enforce explicit submission and secret cleanup.
 

--- a/qml/ControlCenterWindow.qml
+++ b/qml/ControlCenterWindow.qml
@@ -12,6 +12,8 @@ FloatingWindow {
     required property var clock
     required property var media
     required property var notificationService
+    required property var weather
+    required property var locationSearch
     required property var capabilities
     property bool reducedMotion: false
     property string version: "0.1.0"
@@ -38,6 +40,10 @@ FloatingWindow {
                                                                  "name": "Media"
                                                              },
                                                              {
+                                                                 "id": "weather",
+                                                                 "name": "Weather"
+                                                             },
+                                                             {
                                                                  "id": "notifications",
                                                                  "name": "Notifications"
                                                              },
@@ -58,6 +64,8 @@ FloatingWindow {
     readonly property string activeRouteName: routeName(currentPageId)
     readonly property string diagnosticText: currentPageId === "about" && pageLoader.item !== null
                                              ? pageLoader.item.diagnosticText : ""
+    readonly property bool weatherLookupAllowed: currentPageId === "weather" && pageLoader.item
+                                                 !== null && pageLoader.item.lookupAllowed === true
     readonly property var backingWindow: contentItem.Window.window
 
     title: "Nagi Control Center"
@@ -74,8 +82,8 @@ FloatingWindow {
 
     function routeAvailable(routeId) {
         return routeId === "island" || routeId === "appearance" || routeId === "clock-date"
-                || routeId === "media" || routeId === "notifications" || routeId === "displays"
-                || routeId === "about";
+                || routeId === "media" || routeId === "weather" || routeId === "notifications"
+                || routeId === "displays" || routeId === "about";
     }
 
     function routeName(routeId) {
@@ -425,12 +433,15 @@ FloatingWindow {
                                                                                === "media"
                                                                                ? mediaPageComponent :
                                                                                  root.currentPageId
-                                                                                 === "notifications"
-                                                                                 ? notificationsPageComponent :
+                                                                                 === "weather"
+                                                                                 ? weatherPageComponent :
                                                                                    root.currentPageId
-                                                                                   === "displays"
-                                                                                   ? displaysPageComponent :
-                                                                                     aboutPageComponent
+                                                                                   === "notifications"
+                                                                                   ? notificationsPageComponent :
+                                                                                     root.currentPageId
+                                                                                     === "displays"
+                                                                                     ? displaysPageComponent :
+                                                                                       aboutPageComponent
                         onLoaded: Qt.callLater(root.focusCurrentContext)
                     }
                 }
@@ -471,6 +482,17 @@ FloatingWindow {
         MediaPage {
             settingsModel: root.settingsModel
             media: root.media
+            reducedMotion: root.reducedMotion
+        }
+    }
+
+    Component {
+        id: weatherPageComponent
+
+        WeatherPage {
+            settingsModel: root.settingsModel
+            weather: root.weather
+            locationSearch: root.locationSearch
             reducedMotion: root.reducedMotion
         }
     }

--- a/qml/IdleIsland.qml
+++ b/qml/IdleIsland.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtQuick.Controls
 
 // Compact Idle composition: workspace, time, optional weather, optional
 // active media, in that order.
@@ -33,6 +34,8 @@ Item {
     property bool showWorkspace: true
     property bool showWeather: true
     property bool showMedia: true
+
+    signal weatherRequested
 
     readonly property int contentPadding: Theme.size.islandCompactPadding
     readonly property int contentGap: Theme.size.islandCompactPadding
@@ -294,7 +297,7 @@ Item {
             visible: clockGroup.visible && (weatherGroup.visible || mediaText.visible)
         }
 
-        Item {
+        AbstractButton {
             id: weatherGroup
 
             x: idle.offsetAfter([workspaceIndicator, workspaceSeparator, clockGroup,
@@ -304,6 +307,12 @@ Item {
             implicitWidth: weatherGlyph.implicitWidth + idle.weatherGap
                            + weatherLabels.implicitWidth
             implicitHeight: Math.max(weatherGlyph.implicitHeight, weatherLabels.implicitHeight)
+            focusPolicy: Qt.NoFocus
+            hoverEnabled: true
+            Accessible.role: Accessible.Button
+            Accessible.name: "Open detailed weather for " + idle.temperatureText + ", "
+                             + idle.weatherCaptionText
+            onClicked: idle.weatherRequested()
 
             WeatherGlyph {
                 id: weatherGlyph
@@ -341,6 +350,13 @@ Item {
                     size: "caption"
                     font.weight: Theme.type.weightRegular
                 }
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.NoButton
+                cursorShape: Qt.PointingHandCursor
+                enabled: weatherGroup.enabled
             }
         }
 

--- a/qml/IslandStateCoordinator.qml
+++ b/qml/IslandStateCoordinator.qml
@@ -21,6 +21,7 @@ Scope {
     readonly property int ownerHistory: 10
     readonly property int ownerTray: 11
     readonly property int ownerAudio: 12
+    readonly property int ownerWeather: 13
 
     readonly property int focusNone: 0
     readonly property int focusLauncherSearch: 1
@@ -30,6 +31,7 @@ Scope {
     readonly property int focusNotificationHistory: 5
     readonly property int focusTray: 6
     readonly property int focusAudio: 7
+    readonly property int focusWeather: 8
 
     readonly property int stateSerial: state.serial
     readonly property int surfaceCount: state.surfaces.length
@@ -72,6 +74,10 @@ Scope {
 
     function openAudio(initiatingSurfaceToken) {
         return state.openInteractive(root.ownerAudio, initiatingSurfaceToken);
+    }
+
+    function openWeather(initiatingSurfaceToken) {
+        return state.openInteractive(root.ownerWeather, initiatingSurfaceToken);
     }
 
     function openDashboard(initiatingSurfaceToken) {
@@ -372,6 +378,9 @@ Scope {
             if (kind === root.ownerAudio) {
                 return root.focusAudio;
             }
+            if (kind === root.ownerWeather) {
+                return root.focusWeather;
+            }
             if (kind === root.ownerSession) {
                 return root.focusSessionActions;
             }
@@ -426,7 +435,7 @@ Scope {
 
         function isInteractiveKind(kind) {
             return kind === root.ownerLauncher || kind === root.ownerHistory || kind === root.ownerTray || kind
-                    === root.ownerAudio || kind === root.ownerSession;
+                    === root.ownerAudio || kind === root.ownerWeather || kind === root.ownerSession;
         }
 
         function isRelevantFrame(frame, record, now) {
@@ -540,6 +549,8 @@ Scope {
                 return "tray";
             if (kind === root.ownerAudio)
                 return "audio";
+            if (kind === root.ownerWeather)
+                return "weather";
             if (kind === root.ownerPolkitModal)
                 return "polkitModal";
             return "none";
@@ -619,7 +630,7 @@ Scope {
             if (kind === root.ownerExpanded)
                 return 5;
             if (kind === root.ownerLauncher || kind === root.ownerHistory || kind === root.ownerTray
-                    || kind === root.ownerAudio)
+                    || kind === root.ownerAudio || kind === root.ownerWeather)
                 return 6;
             if (kind === root.ownerSession)
                 return 7;

--- a/qml/IslandSurface.qml
+++ b/qml/IslandSurface.qml
@@ -68,6 +68,7 @@ PanelWindow {
     readonly property bool history: ownerKind === coordinator.ownerHistory
     readonly property bool tray: ownerKind === coordinator.ownerTray
     readonly property bool audio: ownerKind === coordinator.ownerAudio
+    readonly property bool weatherDetails: ownerKind === coordinator.ownerWeather
     readonly property bool polkitControllerReady: polkitController !== null && polkitController
                                                   !== undefined && polkitController.available
                                                   === true
@@ -83,10 +84,10 @@ PanelWindow {
                                            === coordinator.ownerVolume || ownerKind
                                            === coordinator.ownerNotification
     readonly property bool notificationTransient: ownerKind === coordinator.ownerNotification
-    readonly property bool largeContent: expanded || launcher || history || tray || audio || session
-                                         || polkit
-    readonly property bool interactiveOwner: launcher || history || tray || audio || session
-                                             || polkit
+    readonly property bool largeContent: expanded || launcher || history || tray || audio
+                                         || weatherDetails || session || polkit
+    readonly property bool interactiveOwner: launcher || history || tray || audio || weatherDetails
+                                             || session || polkit
     property int previousOwnerKind: -1
     property int exitingOwnerKind: -1
     property var exitingLoader: null
@@ -112,9 +113,10 @@ PanelWindow {
     readonly property Item interactiveContent: launcher ? launcherLoader.item : history
                                                           ? historyLoader.item : tray
                                                             ? trayLoader.item : audio
-                                                              ? audioLoader.item : session
-                                                                ? sessionLoader.item : polkit
-                                                                  ? polkitLoader.item : null
+                                                              ? audioLoader.item : weatherDetails
+                                                                ? weatherLoader.item : session
+                                                                  ? sessionLoader.item : polkit
+                                                                    ? polkitLoader.item : null
     readonly property real interactivePreferredWidth: interactiveContent === null
                                                       ? Theme.size.islandIdleWidth :
                                                         interactiveContent.implicitWidth
@@ -192,6 +194,9 @@ PanelWindow {
     readonly property bool trayFocused: trayLoader.item !== null && trayLoader.item.activeFocus
     readonly property bool audioLoaded: audioLoader.item !== null
     readonly property bool audioFocused: audioLoader.item !== null && audioLoader.item.activeFocus
+    readonly property bool weatherLoaded: weatherLoader.item !== null
+    readonly property bool weatherFocused: weatherLoader.item !== null
+                                           && weatherLoader.item.activeFocus
     readonly property bool polkitLoaded: polkitLoader.item !== null
     readonly property bool polkitFocused: polkitLoader.item !== null
                                           && polkitLoader.item.activeFocus
@@ -223,7 +228,8 @@ PanelWindow {
     function isInteractiveKind(kind) {
         return kind === coordinator.ownerLauncher || kind === coordinator.ownerHistory || kind
                 === coordinator.ownerTray || kind === coordinator.ownerAudio || kind
-                === coordinator.ownerSession || kind === coordinator.ownerPolkitModal;
+                === coordinator.ownerWeather || kind === coordinator.ownerSession || kind
+                === coordinator.ownerPolkitModal;
     }
 
     function loaderForKind(kind) {
@@ -238,6 +244,9 @@ PanelWindow {
         }
         if (kind === coordinator.ownerAudio) {
             return audioLoader;
+        }
+        if (kind === coordinator.ownerWeather) {
+            return weatherLoader;
         }
         if (kind === coordinator.ownerSession) {
             return sessionLoader;
@@ -339,12 +348,14 @@ PanelWindow {
               && trayLoader.item.visible;
         const audioVisible = ownerKind === coordinator.ownerAudio && audioLoader.item !== null
               && audioLoader.item.visible;
+        const weatherVisible = ownerKind === coordinator.ownerWeather && weatherLoader.item
+              !== null && weatherLoader.item.visible;
         const polkitVisible = polkit && polkitLoader.item !== null && polkitLoader.item.visible;
         const transientVisible = transientOwner && transientLoader.item !== null
               && transientLoader.item.visible && transientLoader.item.committed;
         if (!idleVisible && !dashboardVisible && !launcherVisible && !historyVisible &&
-                !trayVisible && !audioVisible && !sessionVisible && !polkitVisible &&
-                !transientVisible) {
+                !trayVisible && !audioVisible && !weatherVisible && !sessionVisible &&
+                !polkitVisible && !transientVisible) {
             return;
         }
 
@@ -421,6 +432,9 @@ PanelWindow {
             } else if (surface.focusTarget === surface.coordinator.focusAudio && surface.audio
                        && audioLoader.item !== null) {
                 target = audioLoader.item;
+            } else if (surface.focusTarget === surface.coordinator.focusWeather
+                       && surface.weatherDetails && weatherLoader.item !== null) {
+                target = weatherLoader.item;
             } else if (surface.focusTarget === surface.coordinator.focusPolkitModal
                        && surface.polkit && polkitLoader.item !== null) {
                 target = polkitLoader.item;
@@ -651,6 +665,9 @@ PanelWindow {
                                                                            === coordinator.focusTray)
                                                                        || (audio && focusTarget
                                                                            === coordinator.focusAudio)
+                                                                       || (weatherDetails
+                                                                           && focusTarget
+                                                                           === coordinator.focusWeather)
                                                                        || (session && focusTarget
                                                                            === coordinator.focusSessionActions)
                                                                        || (polkit && focusTarget
@@ -769,6 +786,7 @@ PanelWindow {
         showWorkspace: UserConfig.snapshot.island.showWorkspace
         showWeather: UserConfig.snapshot.island.showWeather
         showMedia: UserConfig.snapshot.media.compactVisible
+        onWeatherRequested: surface.coordinator.openWeather(surface.hostSurfaceToken)
     }
 
     ExpandedDashboard {
@@ -946,6 +964,34 @@ PanelWindow {
             AudioSelectionView {
                 active: audioLoader.visible
                 adapter: surface.audioAdapter
+                ownerEpoch: surface.ownerEpoch
+                reducedMotion: surface.reducedMotion
+                onCancelled: epoch => surface.coordinator.cancelInteractive(epoch)
+            }
+        }
+
+        onLoaded: {
+            surface.queuePresentationAcknowledgement();
+            surface.queueOwnerFocus();
+        }
+    }
+
+    Loader {
+        id: weatherLoader
+
+        anchors.fill: parent
+        active: (surface.weatherDetails || surface.exitingOwnerKind
+                 === surface.coordinator.ownerWeather) && surface.weather !== null
+        visible: active
+        enabled: surface.weatherDetails
+        transform: Translate {
+            x: weatherLoader === surface.exitingLoader ? surface.interactiveExitOffset : 0
+        }
+
+        sourceComponent: Component {
+            WeatherView {
+                active: weatherLoader.visible
+                adapter: surface.weather
                 ownerEpoch: surface.ownerEpoch
                 reducedMotion: surface.reducedMotion
                 onCancelled: epoch => surface.coordinator.cancelInteractive(epoch)

--- a/qml/IslandSurfaceHost.qml
+++ b/qml/IslandSurfaceHost.qml
@@ -97,6 +97,9 @@ Scope {
     readonly property bool trayFocused: fallbackSurface !== null && fallbackSurface.trayFocused
     readonly property bool audioLoaded: fallbackSurface !== null && fallbackSurface.audioLoaded
     readonly property bool audioFocused: fallbackSurface !== null && fallbackSurface.audioFocused
+    readonly property bool weatherLoaded: fallbackSurface !== null && fallbackSurface.weatherLoaded
+    readonly property bool weatherFocused: fallbackSurface !== null
+                                           && fallbackSurface.weatherFocused
     readonly property bool polkitLoaded: fallbackSurface !== null && fallbackSurface.polkitLoaded
     readonly property bool polkitFocused: fallbackSurface !== null && fallbackSurface.polkitFocused
     readonly property bool polkitResponseFocused: fallbackSurface !== null

--- a/qml/WeatherAdapter.qml
+++ b/qml/WeatherAdapter.qml
@@ -4,36 +4,25 @@ import Quickshell
 import Quickshell.Io
 import QtQuick
 
-// MET Norway Locationforecast 2.0 compact weather state (ADR-0003 boundary).
+// MET Norway Locationforecast 2.0 compact weather state (ADRs 0003 and 0016).
 //
-// Platform adapter owning the request, validation, bounded cache, one-shot
-// scheduling, backoff, and symbol normalization behind the optional Idle
-// weather state. Presentation consumes only the typed state below; provider
-// codes, URLs, coordinates, payloads, and cache contents never leave this
-// file, and no request-related value is ever logged.
-//
-// Privacy model: weather is opt-in through explicit local coordinates.
-// Missing or invalid coordinates perform no request and keep no cache.
-// Requests carry two-decimal truncated coordinates and the public identifying
-// User-Agent only; the optional label never leaves the machine.
+// This process-wide adapter owns the only forecast request, validation,
+// bounded cache, schedule, backoff, unit conversion, and immutable model.
+// Presentation consumes normalized values only. Provider codes, URLs,
+// coordinates, payloads, and cache contents never leave this file or logs.
 Scope {
     id: root
 
-    // Project version reported in the provider User-Agent. Bump with releases.
     property string version: "0.1.0"
     property bool enabled: false
-
-    // Opt-in location. Invalid or missing values keep weather unavailable
-    // without any request. Altitude is optional whole metres; the label is
-    // local-only and is never sent, persisted, or logged.
     property real latitude: Number.NaN
     property real longitude: Number.NaN
-    property var altitude: null
     property string label: ""
+    property string temperatureUnit: "auto"
+    property string windUnit: "auto"
+    property string refreshPreset: "1h"
 
     // Verification seams following the coordinator's injected-clock pattern.
-    // Production leaves them unset and uses the wall clock, Math.random, the
-    // built-in XMLHttpRequest transport, and the per-shell cache directory.
     property var wallNow: null
     property var randomSource: null
     property var transport: null
@@ -41,45 +30,49 @@ Scope {
     property string cacheDirectory: ""
     property string cacheFileName: "weather.json"
 
-    // ---- normalized state -------------------------------------------------
-
-    // True while a valid current timestep is exposed, including the bounded
-    // stale window before the six-hour cutoff.
-    readonly property bool available: root.enabled && engine.available
-    // True while available content comes from an expired cache record.
+    // Current compatibility properties remain shallow for compact Idle.
+    readonly property bool available: root.enabled && engine.model !== null
     readonly property bool stale: engine.stale
-    readonly property real temperatureC: engine.snapshot === null ? Number.NaN :
-                                                                    engine.snapshot.temperatureC
-    readonly property string condition: engine.snapshot === null ? "unknown" :
-                                                                   engine.snapshot.condition
+    readonly property real temperatureC: engine.model === null ? Number.NaN :
+                                                                 engine.model.current.temperatureC
 
-    readonly property string dayPhase: engine.snapshot === null ? "day" : engine.snapshot.dayPhase
-    readonly property date forecastTime: engine.snapshot === null ? new Date(Number.NaN) : new Date(
-                                                                        engine.snapshot.forecastEpoch)
+    readonly property string condition: engine.model === null ? "unknown" :
+                                                                engine.model.current.condition
+    readonly property string dayPhase: engine.model === null ? "day" : engine.model.current.dayPhase
+    readonly property date forecastTime: engine.model === null ? new Date(Number.NaN) : new Date(
+                                                                     engine.model.current.forecastEpoch)
     readonly property date fetchedAt: Number.isFinite(engine.fetchedAt) ? new Date(
                                                                               engine.fetchedAt) :
                                                                           new Date(Number.NaN)
-    // Bounded failure kinds: "none", "unconfigured", "transient", "throttled",
-    // "permanent", "stale". It reports the most recent failure and never
-    // carries provider payloads.
     readonly property string failure: engine.failure
 
-    // Scheduling visibility for verification: epoch milliseconds of the next
-    // allowed network request (0 when none is scheduled) and the number of
-    // requests started since instantiation.
+    // One frozen generation contains local location, normalized current
+    // conditions, up to the exact requested 12 hourly and five daily entries,
+    // converted presentation values, and no provider-specific fields.
+    readonly property var model: engine.model
+    readonly property int modelGeneration: engine.modelGeneration
+    readonly property var current: engine.model === null ? null : engine.model.current
+    readonly property var hourly: engine.model === null ? emptyModel : engine.model.hourly
+    readonly property var daily: engine.model === null ? emptyModel : engine.model.daily
+    readonly property real lastUpdatedAgeMs: Number.isFinite(engine.fetchedAt) ? Math.max(0,
+                                                                                          engine.currentTime(
+                                                                                              ) - engine.fetchedAt) :
+                                                                                 Number.NaN
+    readonly property bool refreshInFlight: engine.inFlight
+    readonly property bool manualRefreshAvailable: {
+        const revision = engine.manualAvailabilityRevision;
+        return revision >= 0 && engine.canManualRefresh();
+    }
+    readonly property real nextManualRefreshAt: engine.nextManualRefreshAt()
     readonly property real nextRequestAt: engine.nextRequestAt
     readonly property int requestCount: engine.requestCount
     readonly property bool locationConfigured: engine.locationKey !== ""
     readonly property int maximumResponseCharacters: 1048576
-    readonly property int cacheSchemaVersion: 1
+    readonly property int cacheSchemaVersion: 2
+    readonly property var emptyModel: Object.freeze([])
 
-    // Emitted after every completed cache write, including clears. Verification
-    // uses it to sequence cross-instance cache scenarios deterministically.
     signal cacheSaved
 
-    // Deadline handlers. The internal one-shot timers invoke these; exposing
-    // them lets verification fire exact deadlines deterministically. Each is
-    // idempotent and guarded.
     function refreshDeadlineReached() {
         engine.runRefresh();
     }
@@ -92,12 +85,23 @@ Scope {
         engine.requestTimeoutReached();
     }
 
+    function manualRefresh() {
+        return engine.manualRefresh();
+    }
+
+    function manualRefreshDeadlineReached() {
+        engine.armManualAvailability();
+    }
+
     Component.onCompleted: applyLocation()
     onLatitudeChanged: engine.scheduleLocationSync()
     onLongitudeChanged: engine.scheduleLocationSync()
-    onAltitudeChanged: engine.scheduleLocationSync()
+    onLabelChanged: engine.scheduleLocationSync()
     onVersionChanged: engine.scheduleLocationSync()
     onEnabledChanged: engine.scheduleLocationSync()
+    onTemperatureUnitChanged: engine.rebuildModel()
+    onWindUnitChanged: engine.rebuildModel()
+    onRefreshPresetChanged: engine.rearmSuccessfulSchedule()
 
     FileView {
         id: cacheFileView
@@ -125,6 +129,13 @@ Scope {
     }
 
     Timer {
+        id: manualRefreshTimer
+
+        repeat: false
+        onTriggered: root.manualRefreshDeadlineReached()
+    }
+
+    Timer {
         id: timeoutTimer
 
         repeat: false
@@ -134,8 +145,6 @@ Scope {
     QtObject {
         id: engine
 
-        // Backoff tiers in milliseconds for network errors, timeouts, invalid
-        // responses, and 5xx responses; 429 uses throttleTiers.
         readonly property var backoffTiers: [600000, 1800000, 3600000, 10800000, 21600000]
         readonly property var throttleTiers: [3600000, 10800000, 21600000]
         readonly property real backoffJitterFraction: 0.2
@@ -143,23 +152,31 @@ Scope {
         readonly property int startupJitterMs: 30000
         readonly property int expiresFallbackMs: 3600000
         readonly property int minimumRefreshGapMs: 600000
+        readonly property int manualRefreshCooldownMs: 60000
         readonly property int staleCutoffMs: 21600000
         readonly property int maximumTimestepAgeMs: 5400000
+        readonly property int maximumTimeseriesEntries: 512
+        readonly property int maximumObjectCount: 4096
+        readonly property int maximumObjectDepth: 12
+        readonly property int maximumStringLength: 256
         readonly property real minimumTemperatureC: -90
         readonly property real maximumTemperatureC: 60
+        readonly property real minimumWindMs: 0
+        readonly property real maximumWindMs: 150
+        readonly property real minimumHumidity: 0
+        readonly property real maximumHumidity: 100
 
         property string locationKey: ""
         property string activeVersion: ""
-        property string coarseLatitude: ""
-        property string coarseLongitude: ""
-        property var coarseAltitude: null
+        property string requestLatitude: ""
+        property string requestLongitude: ""
 
         property var cache: null
         property real expiresEpoch: Number.NaN
-        property var snapshot: null
+        property var normalized: null
+        property var model: null
+        property int modelGeneration: 0
         property real fetchedAt: Number.NaN
-
-        property bool available: false
         property bool stale: false
         property string failure: "unconfigured"
 
@@ -167,6 +184,9 @@ Scope {
         property int throttleTier: 0
         property var permanentKey: null
         property real nextRequestAt: 0
+        property real providerNotBeforeAt: 0
+        property real lastManualRefreshAt: 0
+        property int manualAvailabilityRevision: 0
 
         property bool inFlight: false
         property int requestCount: 0
@@ -174,6 +194,12 @@ Scope {
         property var activeRequest: null
         property var warnedKeys: ({})
         property bool locationSyncScheduled: false
+
+        onLocationKeyChanged: armManualAvailability()
+        onPermanentKeyChanged: armManualAvailability()
+        onProviderNotBeforeAtChanged: armManualAvailability()
+        onLastManualRefreshAtChanged: armManualAvailability()
+        onInFlightChanged: armManualAvailability()
 
         function currentTime() {
             const value = root.wallNow === null ? Date.now() : root.wallNow();
@@ -203,44 +229,48 @@ Scope {
             console.warn(message);
         }
 
-        // Truncation toward zero at two decimals with a tolerance for binary
-        // rounding dust around exact hundredths, so 48.85 stays 48.85 while
-        // 48.8566 still truncates to 48.85.
+        // MET Norway permits at most four decimals. Truncating toward zero
+        // avoids disclosing more precision through rounding.
         function truncateCoordinate(value) {
-            const scaled = value * 100;
+            const scaled = value * 10000;
             const rounded = Math.round(scaled);
             const corrected = Math.abs(scaled - rounded) < 0.000001 ? rounded : scaled;
             const truncated = corrected < 0 ? Math.ceil(corrected) : Math.floor(corrected);
-            return truncated === 0 ? 0 : truncated / 100;
+            return truncated === 0 ? 0 : truncated / 10000;
+        }
+
+        function labelFingerprint(value) {
+            let hash = 2166136261;
+            for (let index = 0; index < value.length; index += 1) {
+                hash ^= value.charCodeAt(index);
+                hash = Math.imul(hash, 16777619);
+            }
+            return (hash >>> 0).toString(16);
+        }
+
+        function utf8Length(value) {
+            try {
+                return encodeURIComponent(value).replace(/%[0-9A-F]{2}/gi, "x").length;
+            } catch (error) {
+                return Infinity;
+            }
         }
 
         function validatedLocation() {
             if (!root.enabled || typeof root.latitude !== "number" || !Number.isFinite(root.latitude)
                     || typeof root.longitude !== "number" || !Number.isFinite(root.longitude)
                     || root.latitude < -90 || root.latitude > 90 || root.longitude < -180
-                    || root.longitude > 180) {
+                    || root.longitude > 180 || typeof root.label !== "string" || root.label.length
+                    === 0 || utf8Length(root.label) > 128 || /[\x00-\x1F\x7F]/.test(root.label)) {
                 return null;
             }
 
-            let altitudeValue = null;
-            if (root.altitude !== null && root.altitude !== undefined) {
-                if (typeof root.altitude !== "number" || !Number.isFinite(root.altitude) || !Number.isInteger(
-                            root.altitude)) {
-                    return null;
-                }
-
-                altitudeValue = root.altitude;
-            }
-
-            const latitude = truncateCoordinate(root.latitude);
-            const longitude = truncateCoordinate(root.longitude);
+            const latitude = truncateCoordinate(root.latitude).toFixed(4);
+            const longitude = truncateCoordinate(root.longitude).toFixed(4);
             return {
-                "key": "v1|" + latitude.toFixed(2) + "|" + longitude.toFixed(2) + (altitudeValue
-                                                                                   === null ? "" :
-                                                                                              "|" + altitudeValue),
-                "latitude": latitude.toFixed(2),
-                "longitude": longitude.toFixed(2),
-                "altitude": altitudeValue === null ? null : String(altitudeValue)
+                "key": "v2|" + latitude + "|" + longitude + "|" + labelFingerprint(root.label),
+                "latitude": latitude,
+                "longitude": longitude
             };
         }
 
@@ -266,6 +296,7 @@ Scope {
             const version = typeof root.version === "string" && root.version.length > 0
                   ? root.version : "unknown";
             if (key === locationKey && version === activeVersion) {
+                rebuildModel();
                 return;
             }
 
@@ -274,28 +305,29 @@ Scope {
             cache = null;
             expiresEpoch = Number.NaN;
             nextRequestAt = 0;
+            providerNotBeforeAt = 0;
+            lastManualRefreshAt = 0;
             backoffIndex = 0;
             throttleTier = 0;
             permanentKey = null;
-            snapshot = null;
+            normalized = null;
+            model = null;
             fetchedAt = Number.NaN;
-            available = false;
             stale = false;
             locationKey = key;
             activeVersion = version;
 
             if (key === "") {
-                coarseLatitude = "";
-                coarseLongitude = "";
-                coarseAltitude = null;
+                requestLatitude = "";
+                requestLongitude = "";
                 failure = "unconfigured";
                 clearCacheFile();
+                modelGeneration += 1;
                 return;
             }
 
-            coarseLatitude = location.latitude;
-            coarseLongitude = location.longitude;
-            coarseAltitude = location.altitude;
+            requestLatitude = location.latitude;
+            requestLongitude = location.longitude;
 
             const now = currentTime();
             const record = loadCacheRecord(key);
@@ -304,10 +336,15 @@ Scope {
                 cache = record;
                 const parsedExpires = Date.parse(record.expires);
                 expiresEpoch = Number.isFinite(parsedExpires) ? parsedExpires : Number.NaN;
+                providerNotBeforeAt = Number.isFinite(expiresEpoch) ? Math.max(expiresEpoch,
+                                                                               record.validatedAt
+                                                                               + minimumRefreshGapMs) :
+                                                                      record.validatedAt
+                                                                      + expiresFallbackMs;
                 adoptRecord(now);
-                armRefresh(expiresEpoch > now ? expiresEpoch + jitter(refreshJitterMs) : now
-                                                + jitter(startupJitterMs));
+                armRefresh(successRefreshAt(record.validatedAt, expiresEpoch));
             } else {
+                providerNotBeforeAt = now;
                 armRefresh(now + jitter(startupJitterMs));
             }
         }
@@ -340,16 +377,13 @@ Scope {
             return record;
         }
 
-        // Re-derives visible state from the adopted cache body without any
-        // request, exactly as ADR-0003 requires on startup.
         function adoptRecord(now) {
-            const selection = selectTimestep(cache.body, now);
-            if (selection.ok) {
-                commitSnapshot(selection.snapshot, cache.retrievedAt);
-            } else {
+            const parsed = normalizeForecast(cache.body, now);
+            if (parsed === null) {
                 clearWeather("stale");
+            } else {
+                commitNormalized(parsed, cache.retrievedAt);
             }
-
             armLocalDeadline();
         }
 
@@ -368,88 +402,236 @@ Scope {
                 return;
             }
 
-            const selection = selectTimestep(cache.body, now);
-            if (selection.ok) {
-                snapshot = selection.snapshot;
-                available = true;
+            const parsed = normalizeForecast(cache.body, now);
+            if (parsed === null) {
+                clearWeather("stale");
+            } else {
+                normalized = parsed;
                 stale = Number.isFinite(expiresEpoch) && expiresEpoch <= now;
+                rebuildModel();
                 if (failure === "stale") {
                     failure = "none";
                 }
-            } else {
-                clearWeather("stale");
             }
-
             armLocalDeadline();
         }
 
-        // Selects the latest timeseries entry not later than now, no more than
-        // 90 minutes old, whose same entry carries both required fields.
-        function selectTimestep(bodyText, now) {
+        function boundedGraph(value) {
+            let objectCount = 0;
+            const stack = [
+                      {
+                          "value": value,
+                          "depth": 0
+                      }
+                  ];
+            while (stack.length > 0) {
+                const frame = stack.pop();
+                if (frame.depth > maximumObjectDepth) {
+                    return false;
+                }
+                if (typeof frame.value === "string") {
+                    if (frame.value.length > maximumStringLength) {
+                        return false;
+                    }
+                    continue;
+                }
+                if (frame.value === null || typeof frame.value !== "object") {
+                    continue;
+                }
+                objectCount += 1;
+                if (objectCount > maximumObjectCount) {
+                    return false;
+                }
+                const keys = Object.keys(frame.value);
+                if (keys.length > maximumTimeseriesEntries) {
+                    return false;
+                }
+                for (let index = 0; index < keys.length; index += 1) {
+                    if (keys[index].length > 64) {
+                        return false;
+                    }
+                    stack.push({
+                                   "value": frame.value[keys[index]],
+                                   "depth": frame.depth + 1
+                               });
+                }
+            }
+            return true;
+        }
+
+        function finiteRange(value, minimum, maximum) {
+            return typeof value === "number" && Number.isFinite(value) && value >= minimum && value
+                    <= maximum;
+        }
+
+        function normalizeEntry(entry) {
+            if (entry === null || typeof entry !== "object" || typeof entry.time !== "string"
+                    || entry.time.length > 40) {
+                return null;
+            }
+            const epoch = Date.parse(entry.time);
+            const data = entry.data;
+            const details = data !== null && typeof data === "object" && data.instant !== null
+                  && typeof data.instant === "object" && data.instant.details !== null
+                  && typeof data.instant.details === "object" ? data.instant.details : null;
+            if (!Number.isFinite(epoch) || details === null || !finiteRange(details.air_temperature,
+                                                                            minimumTemperatureC,
+                                                                            maximumTemperatureC) ||
+                    !finiteRange(details.relative_humidity, minimumHumidity, maximumHumidity) ||
+                    !finiteRange(details.wind_speed, minimumWindMs, maximumWindMs)) {
+                return null;
+            }
+
+            const nextHour = data.next_1_hours;
+            const summary = nextHour !== null && typeof nextHour === "object" && nextHour.summary !== null
+                  && typeof nextHour.summary === "object" ? nextHour.summary : null;
+            const code = summary === null ? "" : summary.symbol_code;
+            if (code !== "" && (typeof code !== "string" || !/^[a-z0-9_]{1,64}$/.test(code))) {
+                return null;
+            }
+            const symbol = code === "" ? {
+                                             "condition": "unknown",
+                                             "dayPhase": "day"
+                                         } : normalizeSymbol(code);
+            return {
+                "forecastEpoch": epoch,
+                "temperatureC": details.air_temperature,
+                "humidity": details.relative_humidity,
+                "windMs": details.wind_speed,
+                "condition": symbol.condition,
+                "dayPhase": symbol.dayPhase,
+                "hasSymbol": code !== ""
+            };
+        }
+
+        function feelsLikeC(temperatureC, humidity, windMs) {
+            if (temperatureC > 26 && humidity > 40) {
+                const fahrenheit = temperatureC * 9 / 5 + 32;
+                const heatIndexF = -42.379 + 2.04901523 * fahrenheit + 10.14333127 * humidity
+                      - 0.22475541 * fahrenheit * humidity - 0.00683783 * fahrenheit * fahrenheit
+                      - 0.05481717 * humidity * humidity + 0.00122874 * fahrenheit * fahrenheit
+                      * humidity + 0.00085282 * fahrenheit * humidity * humidity - 0.00000199
+                      * fahrenheit * fahrenheit * humidity * humidity;
+                return Math.max(temperatureC, Math.min(80, (heatIndexF - 32) * 5 / 9));
+            }
+            if (temperatureC < 10 && windMs > 1.33) {
+                const windKmhPower = Math.pow(windMs * 3.6, 0.16);
+                return Math.max(-120, 13.12 + 0.6215 * temperatureC - 11.37 * windKmhPower + 0.3965
+                                * temperatureC * windKmhPower);
+            }
+            return temperatureC;
+        }
+
+        function dailyEntries(entries, now) {
+            const groups = {};
+            const order = [];
+            for (let index = 0; index < entries.length; index += 1) {
+                const entry = entries[index];
+                if (entry.forecastEpoch < now - maximumTimestepAgeMs) {
+                    continue;
+                }
+                const date = new Date(entry.forecastEpoch);
+                const key = date.getFullYear() + "-" + date.getMonth() + "-" + date.getDate();
+                if (groups[key] === undefined) {
+                    if (order.length >= 5) {
+                        continue;
+                    }
+                    groups[key] = [];
+                    order.push({
+                                   "key": key,
+                                   "epoch": new Date(date.getFullYear(), date.getMonth(),
+                                                     date.getDate()).getTime()
+                               });
+                }
+                groups[key].push(entry);
+            }
+
+            const result = [];
+            for (let index = 0; index < order.length; index += 1) {
+                const values = groups[order[index].key];
+                let minimum = Infinity;
+                let maximum = -Infinity;
+                let representative = values[0];
+                let representativeDistance = Infinity;
+                for (let valueIndex = 0; valueIndex < values.length; valueIndex += 1) {
+                    const value = values[valueIndex];
+                    minimum = Math.min(minimum, value.temperatureC);
+                    maximum = Math.max(maximum, value.temperatureC);
+                    const hourDistance = Math.abs(new Date(value.forecastEpoch).getHours() - 12);
+                    if (value.hasSymbol && hourDistance < representativeDistance) {
+                        representative = value;
+                        representativeDistance = hourDistance;
+                    }
+                }
+                result.push({
+                                "dateEpoch": order[index].epoch,
+                                "minimumTemperatureC": minimum,
+                                "maximumTemperatureC": maximum,
+                                "condition": representative.condition,
+                                "dayPhase": representative.dayPhase
+                            });
+            }
+            return result;
+        }
+
+        function normalizeForecast(bodyText, now) {
             let parsed = null;
             try {
                 parsed = JSON.parse(bodyText);
             } catch (error) {
-                parsed = null;
+                return null;
+            }
+            if (!boundedGraph(parsed) || parsed === null || typeof parsed !== "object" || parsed.properties
+                    === null || typeof parsed.properties !== "object" || parsed.properties.meta
+                    === null || typeof parsed.properties.meta !== "object"
+                    || parsed.properties.meta.units === null || typeof parsed.properties.meta.units
+                    !== "object" || parsed.properties.meta.units.air_temperature !== "celsius"
+                    || parsed.properties.meta.units.relative_humidity !== "%"
+                    || parsed.properties.meta.units.wind_speed !== "m/s" || !Array.isArray(
+                        parsed.properties.timeseries) || parsed.properties.timeseries.length === 0
+                    || parsed.properties.timeseries.length > maximumTimeseriesEntries) {
+                return null;
             }
 
-            const timeseries = parsed !== null && typeof parsed === "object" && parsed.properties
-                  !== null && typeof parsed.properties === "object" && parsed.properties.timeseries
-                  !== null && typeof parsed.properties.timeseries === "object"
-                  && parsed.properties.timeseries.length > 0 ? parsed.properties.timeseries : null;
-            if (timeseries === null) {
-                return {
-                    "ok": false
-                };
+            const entries = [];
+            for (let index = 0; index < parsed.properties.timeseries.length; index += 1) {
+                const entry = normalizeEntry(parsed.properties.timeseries[index]);
+                if (entry === null || (entries.length > 0 && entry.forecastEpoch
+                                       <= entries[entries.length - 1].forecastEpoch)) {
+                    return null;
+                }
+                entries.push(entry);
             }
 
-            let best = null;
-            let bestTime = -Infinity;
-            for (let index = 0; index < timeseries.length; index += 1) {
-                const entry = timeseries[index];
-                if (entry === null || typeof entry !== "object" || typeof entry.time !== "string") {
-                    continue;
-                }
-
-                const time = Date.parse(entry.time);
-                if (!Number.isFinite(time) || time > now || now - time > maximumTimestepAgeMs) {
-                    continue;
-                }
-
-                const details = entry.data !== null && typeof entry.data === "object"
-                      && entry.data.instant !== null && typeof entry.data.instant === "object"
-                      && entry.data.instant.details !== null && typeof entry.data.instant.details
-                      === "object" ? entry.data.instant.details : null;
-                const summary = entry.data !== null && typeof entry.data === "object"
-                      && entry.data.next_1_hours !== null && typeof entry.data.next_1_hours
-                      === "object" && entry.data.next_1_hours.summary !== null
-                      && typeof entry.data.next_1_hours.summary === "object"
-                      ? entry.data.next_1_hours.summary : null;
-                const temperature = details === null ? null : details.air_temperature;
-                const symbolCode = summary === null ? null : summary.symbol_code;
-                if (typeof temperature !== "number" || !Number.isFinite(temperature) || temperature
-                        < minimumTemperatureC || temperature > maximumTemperatureC
-                        || typeof symbolCode !== "string" || symbolCode.length === 0) {
-                    continue;
-                }
-
-                if (time > bestTime) {
-                    bestTime = time;
-                    const normalized = normalizeSymbol(symbolCode);
-                    best = {
-                        "temperatureC": temperature,
-                        "condition": normalized.condition,
-                        "dayPhase": normalized.dayPhase,
-                        "forecastEpoch": time
-                    };
+            let currentEntry = null;
+            for (let index = 0; index < entries.length; index += 1) {
+                if (entries[index].forecastEpoch <= now && now - entries[index].forecastEpoch
+                        <= maximumTimestepAgeMs && entries[index].hasSymbol) {
+                    currentEntry = entries[index];
                 }
             }
+            if (currentEntry === null) {
+                return null;
+            }
 
-            return best === null ? {
-                                       "ok": false
-                                   } : {
-                "ok": true,
-                "snapshot": best
+            const currentValue = Object.assign({}, currentEntry, {
+                                                   "feelsLikeC": feelsLikeC(
+                                                                     currentEntry.temperatureC,
+                                                                     currentEntry.humidity,
+                                                                     currentEntry.windMs),
+                                                   "feelsLikeCalculated": true
+                                               });
+            const hourly = [];
+            const horizon = now + 12 * 60 * 60 * 1000;
+            for (let index = 0; index < entries.length && hourly.length < 12; index += 1) {
+                if (entries[index].forecastEpoch > now && entries[index].forecastEpoch <= horizon) {
+                    hourly.push(entries[index]);
+                }
+            }
+            return {
+                "current": currentValue,
+                "hourly": hourly,
+                "daily": dailyEntries(entries, now)
             };
         }
 
@@ -505,18 +687,104 @@ Scope {
             };
         }
 
-        function commitSnapshot(snapshotValue, fetchedEpoch) {
-            snapshot = snapshotValue;
+        function resolvedTemperatureUnit() {
+            if (root.temperatureUnit === "celsius" || root.temperatureUnit === "fahrenheit") {
+                return root.temperatureUnit;
+            }
+            return Qt.locale().measurementSystem === Locale.ImperialUSSystem ? "fahrenheit" :
+                                                                               "celsius";
+        }
+
+        function resolvedWindUnit() {
+            if (root.windUnit === "kmh" || root.windUnit === "mph" || root.windUnit === "ms") {
+                return root.windUnit;
+            }
+            return Qt.locale().measurementSystem === Locale.ImperialUSSystem ? "mph" : "kmh";
+        }
+
+        function convertTemperature(value, unit) {
+            return unit === "fahrenheit" ? value * 9 / 5 + 32 : value;
+        }
+
+        function convertWind(value, unit) {
+            return unit === "mph" ? value * 2.2369362921 : unit === "kmh" ? value * 3.6 : value;
+        }
+
+        function presentationEntry(entry, temperatureUnitValue, windUnitValue) {
+            const result = {
+                "forecastEpoch": entry.forecastEpoch,
+                "temperatureC": entry.temperatureC,
+                "temperature": convertTemperature(entry.temperatureC, temperatureUnitValue),
+                "temperatureUnit": temperatureUnitValue,
+                "humidity": entry.humidity,
+                "windMs": entry.windMs,
+                "wind": convertWind(entry.windMs, windUnitValue),
+                "windUnit": windUnitValue,
+                "condition": entry.condition,
+                "dayPhase": entry.dayPhase
+            };
+            if (entry.feelsLikeC !== undefined) {
+                result.feelsLikeC = entry.feelsLikeC;
+                result.feelsLike = convertTemperature(entry.feelsLikeC, temperatureUnitValue);
+                result.feelsLikeCalculated = true;
+            }
+            return Object.freeze(result);
+        }
+
+        function rebuildModel() {
+            if (normalized === null) {
+                return;
+            }
+            const temperatureUnitValue = resolvedTemperatureUnit();
+            const windUnitValue = resolvedWindUnit();
+            const hourlyValues = [];
+            for (let index = 0; index < normalized.hourly.length; index += 1) {
+                hourlyValues.push(presentationEntry(normalized.hourly[index], temperatureUnitValue,
+                                                    windUnitValue));
+            }
+            const dailyValues = [];
+            for (let index = 0; index < normalized.daily.length; index += 1) {
+                const entry = normalized.daily[index];
+                dailyValues.push(Object.freeze({
+                                                   "dateEpoch": entry.dateEpoch,
+                                                   "minimumTemperature": convertTemperature(
+                                                                             entry.minimumTemperatureC,
+                                                                             temperatureUnitValue),
+                                                   "maximumTemperature": convertTemperature(
+                                                                             entry.maximumTemperatureC,
+                                                                             temperatureUnitValue),
+                                                   "temperatureUnit": temperatureUnitValue,
+                                                   "condition": entry.condition,
+                                                   "dayPhase": entry.dayPhase
+                                               }));
+            }
+            modelGeneration += 1;
+            model = Object.freeze({
+                                      "generation": modelGeneration,
+                                      "location": root.label,
+                                      "current": presentationEntry(normalized.current,
+                                                                   temperatureUnitValue,
+                                                                   windUnitValue),
+                                      "hourly": Object.freeze(hourlyValues),
+                                      "daily": Object.freeze(dailyValues),
+                                      "stale": stale,
+                                      "fetchedAtEpoch": fetchedAt
+                                  });
+        }
+
+        function commitNormalized(value, fetchedEpoch) {
+            normalized = value;
             fetchedAt = fetchedEpoch;
-            available = true;
             stale = Number.isFinite(expiresEpoch) && expiresEpoch <= currentTime();
             failure = "none";
+            rebuildModel();
         }
 
         function clearWeather(kind) {
-            snapshot = null;
+            normalized = null;
+            model = null;
+            modelGeneration += 1;
             fetchedAt = Number.NaN;
-            available = false;
             stale = false;
             failure = kind;
         }
@@ -525,25 +793,19 @@ Scope {
             if (locationKey === "" || permanentKey !== null || inFlight) {
                 return;
             }
-
             const now = currentTime();
-            if (nextRequestAt > now) {
+            if (nextRequestAt > now || providerNotBeforeAt > now) {
                 return;
             }
-
-            let url = "https://api.met.no/weatherapi/locationforecast/2.0/compact?lat="
-                + coarseLatitude + "&lon=" + coarseLongitude;
-            if (coarseAltitude !== null) {
-                url += "&altitude=" + coarseAltitude;
-            }
-
+            const url = "https://api.met.no/weatherapi/locationforecast/2.0/compact?lat="
+                  + requestLatitude + "&lon=" + requestLongitude;
             const headers = {
+                // Qt's network stack transparently negotiates gzip/deflate.
                 "User-Agent": root.userAgentValue
             };
             if (cache !== null && cache.lastModified !== "") {
                 headers["If-Modified-Since"] = cache.lastModified;
             }
-
             startRequest(url, headers);
         }
 
@@ -566,8 +828,13 @@ Scope {
                     finishRequest(outcome);
                 }
             };
-            activeRequest = root.transport === null ? builtinRequest(request) :
-                                                      root.transport.create(request);
+            const handle = root.transport === null ? builtinRequest(request) : root.transport.create(
+                                                         request);
+
+
+            if (serial === requestSerial && inFlight) {
+                activeRequest = handle;
+            }
         }
 
         // Built-in asynchronous XMLHttpRequest transport. Qt exposes no request
@@ -608,6 +875,7 @@ Scope {
 
         function finishRequest(outcome) {
             inFlight = false;
+            activeRequest = null;
             timeoutTimer.stop();
             handleOutcome(outcome);
         }
@@ -656,30 +924,30 @@ Scope {
                 scheduleBackoff();
                 return;
             }
-
-            const selection = selectTimestep(body, now);
-            if (!selection.ok) {
+            const parsed = normalizeForecast(body, now);
+            if (parsed === null) {
                 scheduleBackoff();
                 return;
             }
 
-            const expiresRaw = typeof headers["expires"] === "string" ? headers["expires"] : "";
-            const lastModifiedRaw = typeof headers["last-modified"] === "string"
+            const expiresHeader = typeof headers["expires"] === "string" ? headers["expires"] : "";
+            const parsedExpires = Date.parse(expiresHeader);
+            expiresEpoch = Number.isFinite(parsedExpires) ? parsedExpires : now + expiresFallbackMs;
+            const lastModified = typeof headers["last-modified"] === "string"
                   ? headers["last-modified"] : "";
-            const parsedExpires = Date.parse(expiresRaw);
             cache = {
                 "schemaVersion": root.cacheSchemaVersion,
                 "locationKey": locationKey,
                 "body": body,
-                "expires": expiresRaw,
-                "lastModified": lastModifiedRaw,
+                "expires": new Date(expiresEpoch).toUTCString(),
+                "lastModified": lastModified,
                 "retrievedAt": now,
                 "validatedAt": now
             };
-            expiresEpoch = Number.isFinite(parsedExpires) ? parsedExpires : Number.NaN;
             backoffIndex = 0;
             throttleTier = 0;
-            commitSnapshot(selection.snapshot, now);
+            providerNotBeforeAt = Math.max(expiresEpoch, now + minimumRefreshGapMs);
+            commitNormalized(parsed, now);
             writeCache(cache);
             armRefresh(successRefreshAt(now, expiresEpoch));
             armLocalDeadline();
@@ -689,61 +957,96 @@ Scope {
             }
         }
 
-        // A 304 keeps the cached body, re-selects the current timestep locally,
-        // refreshes validation metadata from the new headers, and schedules the
-        // next request without downloading a replacement body.
         function adoptNotModified(outcome, now) {
             if (cache === null || cache.lastModified === "") {
                 scheduleBackoff();
                 return;
             }
-
             const headers = outcome.headers !== null && typeof outcome.headers === "object" ? outcome.headers :
                                                                                               {};
-            const expiresRaw = typeof headers["expires"] === "string" ? headers["expires"] : "";
-            let refreshedExpires = cache.expires;
-            if (expiresRaw !== "") {
-                const parsedExpires = Date.parse(expiresRaw);
-                if (Number.isFinite(parsedExpires)) {
-                    refreshedExpires = expiresRaw;
-                    expiresEpoch = parsedExpires;
-                }
-            }
-
-            const lastModifiedRaw = typeof headers["last-modified"] === "string"
+            const expiresHeader = typeof headers["expires"] === "string" ? headers["expires"] : "";
+            const parsedExpires = Date.parse(expiresHeader);
+            expiresEpoch = Number.isFinite(parsedExpires) ? parsedExpires : now + expiresFallbackMs;
+            const lastModified = typeof headers["last-modified"] === "string"
                   ? headers["last-modified"] : "";
-            // Records are replaced wholesale instead of mutated in place.
             cache = {
                 "schemaVersion": cache.schemaVersion,
                 "locationKey": cache.locationKey,
                 "body": cache.body,
-                "expires": refreshedExpires,
-                "lastModified": lastModifiedRaw === "" ? cache.lastModified : lastModifiedRaw,
+                "expires": new Date(expiresEpoch).toUTCString(),
+                "lastModified": lastModified === "" ? cache.lastModified : lastModified,
                 "retrievedAt": cache.retrievedAt,
                 "validatedAt": now
             };
+            const parsed = normalizeForecast(cache.body, now);
+            if (parsed === null) {
+                scheduleBackoff();
+                return;
+            }
             backoffIndex = 0;
             throttleTier = 0;
-            const selection = selectTimestep(cache.body, now);
-            if (selection.ok) {
-                commitSnapshot(selection.snapshot, cache.retrievedAt);
-            } else {
-                clearWeather("stale");
-            }
-
+            providerNotBeforeAt = Math.max(expiresEpoch, now + minimumRefreshGapMs);
+            commitNormalized(parsed, cache.retrievedAt);
             writeCache(cache);
             armRefresh(successRefreshAt(now, expiresEpoch));
             armLocalDeadline();
         }
 
-        // Next request after a successful validation: the response expiry plus
-        // positive jitter, with the 60-minute fallback when headers are missing
-        // or invalid, never sooner than ten minutes after completion.
+        function refreshPresetMs() {
+            if (root.refreshPreset === "15m")
+                return 900000;
+            if (root.refreshPreset === "30m")
+                return 1800000;
+            if (root.refreshPreset === "3h")
+                return 10800000;
+            return 3600000;
+        }
+
         function successRefreshAt(now, expiresEpochValue) {
-            const base = Number.isFinite(expiresEpochValue) ? Math.max(expiresEpochValue, now
-                                                                       + minimumRefreshGapMs) : now
-                                                              + expiresFallbackMs;
-            return base + jitter(refreshJitterMs);
+            const providerAt = Number.isFinite(expiresEpochValue) ? Math.max(expiresEpochValue, now
+                                                                             + minimumRefreshGapMs) :
+                                                                    now + expiresFallbackMs;
+            providerNotBeforeAt = providerAt;
+            return Math.max(providerAt, now + refreshPresetMs()) + jitter(refreshJitterMs);
+        }
+
+        function rearmSuccessfulSchedule() {
+            if (cache !== null && permanentKey === null && !inFlight) {
+                armRefresh(successRefreshAt(cache.validatedAt, expiresEpoch));
+            }
+        }
+
+        function nextManualRefreshAt() {
+            return Math.max(providerNotBeforeAt, lastManualRefreshAt + manualRefreshCooldownMs);
+        }
+
+        function canManualRefresh() {
+            return locationKey !== "" && permanentKey === null && !inFlight && currentTime()
+                    >= nextManualRefreshAt();
+        }
+
+        function armManualAvailability() {
+            manualRefreshTimer.stop();
+            manualAvailabilityRevision += 1;
+            if (locationKey === "" || permanentKey !== null || inFlight) {
+                return;
+            }
+            const now = currentTime();
+            const deadline = nextManualRefreshAt();
+            if (deadline > now) {
+                manualRefreshTimer.interval = Math.max(1, Math.floor(deadline - now));
+                manualRefreshTimer.restart();
+            }
+        }
+
+        function manualRefresh() {
+            if (!canManualRefresh()) {
+                return false;
+            }
+            lastManualRefreshAt = currentTime();
+            armRefresh(lastManualRefreshAt);
+            runRefresh();
+            return true;
         }
 
         function scheduleBackoff() {
@@ -753,7 +1056,8 @@ Scope {
             const delay = backoffTiers[index] + jitter(Math.floor(backoffTiers[index]
                                                                   * backoffJitterFraction));
             failure = "transient";
-            armRefresh(now + delay);
+            providerNotBeforeAt = now + delay;
+            armRefresh(providerNotBeforeAt);
         }
 
         function scheduleThrottle(headers, now) {
@@ -761,20 +1065,20 @@ Scope {
                   === "string" ? headers["retry-after"] : "";
             let retryAfter = 0;
             if (/^[0-9]+$/.test(raw)) {
-                retryAfter = parseInt(raw, 10) * 1000;
+                retryAfter = Math.min(parseInt(raw, 10) * 1000, staleCutoffMs);
             } else {
                 const parsed = Date.parse(raw);
                 if (Number.isFinite(parsed)) {
-                    retryAfter = Math.max(0, parsed - now);
+                    retryAfter = Math.max(0, Math.min(parsed - now, staleCutoffMs));
                 }
             }
-
             const tierDelay = throttleTiers[Math.min(throttleTier, throttleTiers.length - 1)];
             throttleTier = Math.min(throttleTier + 1, throttleTiers.length - 1);
             const base = Math.max(retryAfter, tierDelay);
             const delay = base + jitter(Math.floor(base * backoffJitterFraction));
             failure = "throttled";
-            armRefresh(now + delay);
+            providerNotBeforeAt = now + delay;
+            armRefresh(providerNotBeforeAt);
         }
 
         function markPermanent() {
@@ -846,12 +1150,14 @@ Scope {
             refreshTimer.stop();
             stopLocalTimer();
             timeoutTimer.stop();
+            manualRefreshTimer.stop();
         }
 
         function abortActiveRequest() {
             requestSerial += 1;
             const active = activeRequest;
             activeRequest = null;
+            inFlight = false;
             if (active !== null && active !== undefined && active.abort !== undefined && active.abort
                     !== null) {
                 active.abort();
@@ -881,7 +1187,7 @@ Scope {
     }
 
     readonly property string userAgentValue: "NagiShell/" + version
-                                             + " github.com/Anthodev/nagi-shell"
+                                             + " https://github.com/Anthodev/nagi-shell"
 
     function applyLocation() {
         engine.applyLocation();

--- a/qml/WeatherLocationSearchAdapter.qml
+++ b/qml/WeatherLocationSearchAdapter.qml
@@ -1,0 +1,364 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import QtQuick
+
+// Explicit, bounded city/postal lookup. It owns no location history and starts
+// network work only from search(). Results are normalized before publication;
+// queries, URLs, coordinates, and raw provider content never enter logs.
+Scope {
+    id: root
+
+    property bool allowed: false
+    property string version: "0.1.0"
+    property var wallNow: null
+    property var transport: null
+    property int requestTimeoutMs: 10000
+    property string nominatimEndpoint: "https://nominatim.openstreetmap.org"
+
+    readonly property bool inFlight: engine.inFlight
+    readonly property var results: engine.results
+    readonly property string failure: engine.failure
+    readonly property string attribution: engine.attribution
+    readonly property int requestCount: engine.requestCount
+    readonly property int maximumResults: 5
+    readonly property int maximumResponseCharacters: 262144
+    readonly property var emptyResults: Object.freeze([])
+
+    function search(query) {
+        return engine.search(query);
+    }
+
+    function clear() {
+        engine.clear();
+    }
+
+    function requestTimeoutReached() {
+        engine.requestTimeoutReached();
+    }
+
+    onAllowedChanged: {
+        if (!allowed) {
+            clear();
+        }
+    }
+
+    Timer {
+        id: timeoutTimer
+        repeat: false
+        onTriggered: root.requestTimeoutReached()
+    }
+
+    QtObject {
+        id: engine
+
+        property bool inFlight: false
+        property var results: root.emptyResults
+        property string failure: "none"
+        property string attribution: "Location data by GeoNames via Open-Meteo · CC BY 4.0"
+        property int requestCount: 0
+        property int serial: 0
+        property var activeRequest: null
+        property string activeProvider: ""
+        property string activeEncodedQuery: ""
+        property real lastNominatimAt: -1000
+
+        function currentTime() {
+            const value = root.wallNow === null ? Date.now() : root.wallNow();
+            return typeof value === "number" && Number.isFinite(value) ? value : 0;
+        }
+
+        function utf8Length(value) {
+            try {
+                return encodeURIComponent(value).replace(/%[0-9A-F]{2}/gi, "x").length;
+            } catch (error) {
+                return Infinity;
+            }
+        }
+
+        function validQuery(query) {
+            if (typeof query !== "string") {
+                return "";
+            }
+            const value = query.trim();
+            if (value.length < 2 || utf8Length(value) > 128 || /[\x00-\x1F\x7F]/.test(value)) {
+                return "";
+            }
+            return value;
+        }
+
+        function search(query) {
+            if (!root.allowed || inFlight) {
+                return false;
+            }
+            const value = validQuery(query);
+            if (value === "") {
+                failure = "invalid-query";
+                results = root.emptyResults;
+                return false;
+            }
+            results = root.emptyResults;
+            failure = "none";
+            attribution = "Location data by GeoNames via Open-Meteo · CC BY 4.0";
+            activeEncodedQuery = encodeURIComponent(value);
+            start("openmeteo", "https://geocoding-api.open-meteo.com/v1/search?name="
+                  + activeEncodedQuery + "&count=5&format=json&language=en");
+            return true;
+        }
+
+        function start(provider, url) {
+            serial += 1;
+            const requestSerial = serial;
+            activeProvider = provider;
+            inFlight = true;
+            requestCount += 1;
+            timeoutTimer.interval = Math.max(1, root.requestTimeoutMs);
+            timeoutTimer.restart();
+            const request = {
+                "url": url,
+                "headers": {
+                    "User-Agent": "NagiShell/" + root.version
+                                  + " https://github.com/Anthodev/nagi-shell"
+                },
+                "onCompleted": function (outcome) {
+                    if (requestSerial !== serial || !inFlight) {
+                        return;
+                    }
+                    finish(outcome);
+                }
+            };
+            const handle = root.transport === null ? builtinRequest(request) : root.transport.create(
+                                                         request);
+
+
+            if (requestSerial === serial && inFlight) {
+                activeRequest = handle;
+            }
+        }
+
+        function builtinRequest(request) {
+            const xhr = new XMLHttpRequest();
+            xhr.onreadystatechange = function () {
+                if (xhr.readyState !== XMLHttpRequest.DONE) {
+                    return;
+                }
+                request.onCompleted(xhr.status === 0 ? {
+                                                           "networkError": true
+                                                       } : {
+                                        "status": xhr.status,
+                                        "bodyText": xhr.responseText
+                                    });
+            };
+            xhr.open("GET", request.url, true);
+            xhr.setRequestHeader("User-Agent", request.headers["User-Agent"]);
+            xhr.send();
+            return {
+                "abort": function () {
+                    xhr.abort();
+                }
+            };
+        }
+
+        function finish(outcome) {
+            inFlight = false;
+            activeRequest = null;
+            timeoutTimer.stop();
+            if (outcome === null || typeof outcome !== "object" || outcome.networkError === true
+                    || typeof outcome.status !== "number") {
+                fallbackOrFail();
+                return;
+            }
+            const status = Math.floor(outcome.status);
+            if (status === 200) {
+                const normalized = activeProvider === "openmeteo" ? normalizeOpenMeteo(
+                                                                        outcome.bodyText) :
+                                                                    normalizeNominatim(
+                                                                        outcome.bodyText);
+                if (normalized === null) {
+                    fallbackOrFail();
+                    return;
+                }
+                results = Object.freeze(normalized);
+                failure = normalized.length === 0 ? "no-results" : "none";
+                activeEncodedQuery = "";
+                return;
+            }
+            if (status === 429) {
+                failure = "throttled";
+                results = root.emptyResults;
+                activeEncodedQuery = "";
+                return;
+            }
+            if (status >= 500) {
+                fallbackOrFail();
+                return;
+            }
+            failure = "provider";
+            results = root.emptyResults;
+            activeEncodedQuery = "";
+        }
+
+        function fallbackOrFail() {
+            if (activeProvider !== "openmeteo") {
+                failure = "unavailable";
+                results = root.emptyResults;
+                activeEncodedQuery = "";
+                return;
+            }
+            const now = currentTime();
+            if (now - lastNominatimAt < 1000) {
+                failure = "rate-limited";
+                activeEncodedQuery = "";
+                return;
+            }
+            if (activeEncodedQuery === "") {
+                failure = "unavailable";
+                return;
+            }
+            const endpoint = normalizedNominatimEndpoint();
+            if (endpoint === "") {
+                failure = "unavailable";
+                activeEncodedQuery = "";
+                return;
+            }
+            lastNominatimAt = now;
+            attribution = "Location data © OpenStreetMap contributors · ODbL";
+            start("nominatim", endpoint + "/search?format=jsonv2&limit=5&addressdetails=1&q="
+                  + activeEncodedQuery);
+        }
+
+        function normalizedNominatimEndpoint() {
+            const value = root.nominatimEndpoint.replace(/\/+$/, "");
+            return /^https:\/\/[A-Za-z0-9.-]+(?::[0-9]{1,5})?(?:\/[A-Za-z0-9._~-]*)*$/.test(value)
+                    ? value : "";
+        }
+
+        function boundedString(value, maximum, allowEmpty) {
+            return typeof value === "string" && utf8Length(value) <= maximum && (allowEmpty
+                                                                                 || value.length
+                                                                                 > 0) && !
+                    /[\x00-\x1F\x7F]/.test(value);
+        }
+
+        function location(labelParts, latitude, longitude) {
+            if (!Number.isFinite(latitude) || latitude < -90 || latitude > 90 || !Number.isFinite(
+                        longitude) || longitude < -180 || longitude > 180) {
+                return null;
+            }
+            const parts = [];
+            for (let index = 0; index < labelParts.length; index += 1) {
+                const part = labelParts[index];
+                if (boundedString(part, 128, true) && part !== "" && parts.indexOf(part) === -1) {
+                    parts.push(part);
+                }
+            }
+            const label = parts.join(", ");
+            if (!boundedString(label, 128, false)) {
+                return null;
+            }
+            return Object.freeze({
+                                     "label": label,
+                                     "latitude": latitude,
+                                     "longitude": longitude
+                                 });
+        }
+
+        function normalizeOpenMeteo(bodyText) {
+            if (typeof bodyText !== "string" || bodyText.length === 0 || bodyText.length
+                    > root.maximumResponseCharacters) {
+                return null;
+            }
+            let parsed = null;
+            try {
+                parsed = JSON.parse(bodyText);
+            } catch (error) {
+                return null;
+            }
+            if (parsed === null || typeof parsed !== "object" || (parsed.results !== undefined &&
+                                                                  !Array.isArray(parsed.results))) {
+                return null;
+            }
+            const source = parsed.results ?? [];
+            if (source.length > 100) {
+                return null;
+            }
+            const values = [];
+            for (let index = 0; index < source.length && values.length < root.maximumResults; index
+                 += 1) {
+                const item = source[index];
+                if (item === null || typeof item !== "object" || !boundedString(item.name, 128,
+                                                                                false)) {
+                    return null;
+                }
+                const value = location([item.name, item.admin1 ?? "", item.country ?? ""], item.latitude,
+                                       item.longitude);
+                if (value === null) {
+                    return null;
+                }
+                values.push(value);
+            }
+            return values;
+        }
+
+        function normalizeNominatim(bodyText) {
+            if (typeof bodyText !== "string" || bodyText.length === 0 || bodyText.length
+                    > root.maximumResponseCharacters) {
+                return null;
+            }
+            let parsed = null;
+            try {
+                parsed = JSON.parse(bodyText);
+            } catch (error) {
+                return null;
+            }
+            if (!Array.isArray(parsed) || parsed.length > 50) {
+                return null;
+            }
+            const values = [];
+            for (let index = 0; index < parsed.length && values.length < root.maximumResults; index
+                 += 1) {
+                const item = parsed[index];
+                if (item === null || typeof item !== "object" || !boundedString(item.display_name,
+                                                                                512, false)) {
+                    return null;
+                }
+                const parts = item.display_name.split(",").slice(0, 3).map(function (part) {
+                    return part.trim();
+                });
+                const value = location(parts, Number(item.lat), Number(item.lon));
+                if (value === null) {
+                    return null;
+                }
+                values.push(value);
+            }
+            return values;
+        }
+
+        function requestTimeoutReached() {
+            if (!inFlight) {
+                return;
+            }
+            abort();
+            failure = "timeout";
+        }
+
+        function abort() {
+            serial += 1;
+            const request = activeRequest;
+            activeRequest = null;
+            inFlight = false;
+            timeoutTimer.stop();
+            if (request !== null && request !== undefined && typeof request.abort === "function") {
+                request.abort();
+            }
+        }
+
+        function clear() {
+            abort();
+            results = root.emptyResults;
+            failure = "none";
+            activeProvider = "";
+            activeEncodedQuery = "";
+        }
+    }
+}

--- a/qml/WeatherPage.qml
+++ b/qml/WeatherPage.qml
@@ -1,0 +1,459 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Flickable {
+    id: root
+
+    required property var settingsModel
+    required property var weather
+    required property var locationSearch
+    property bool reducedMotion: false
+    property bool privacyAccepted: settingsModel.snapshot.weather.consent
+    property string failureText: ""
+
+    readonly property bool lookupAllowed: visible && privacyAccepted
+    readonly property bool configured: settingsModel.snapshot.weather.enabled
+                                       && settingsModel.snapshot.weather.consent
+                                       && settingsModel.snapshot.weather.locationLabel !== ""
+
+    clip: true
+    contentWidth: width
+    contentHeight: content.implicitHeight
+    boundsBehavior: Flickable.StopAtBounds
+    ScrollBar.vertical: ScrollBar {
+        policy: root.contentHeight > root.height ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
+    }
+
+    Component.onDestruction: locationSearch.clear()
+    onLookupAllowedChanged: {
+        if (!lookupAllowed) {
+            locationSearch.clear();
+        }
+    }
+
+    function request(changes) {
+        if (settingsModel.updatePage("weather", changes, false)) {
+            failureText = "";
+            return true;
+        }
+        failureText = settingsModel.errorMessage !== "" ? settingsModel.errorMessage :
+                                                          "The Weather change could not be applied.";
+        return false;
+    }
+
+    function search() {
+        failureText = "";
+        if (!privacyAccepted) {
+            failureText = "Accept the privacy notice before searching.";
+            return false;
+        }
+        if (!locationSearch.search(searchInput.text)) {
+            failureText = locationSearch.failure === "invalid-query"
+                    ? "Enter at least two city or postal characters." :
+                      "Location search is currently unavailable.";
+            return false;
+        }
+        return true;
+    }
+
+    function confirm(result) {
+        if (result === null || typeof result !== "object") {
+            return false;
+        }
+        const accepted = request({
+                                     "enabled": true,
+                                     "consent": true,
+                                     "locationLabel": result.label,
+                                     "latitude": result.latitude,
+                                     "longitude": result.longitude
+                                 });
+        if (accepted) {
+            searchInput.text = "";
+            locationSearch.clear();
+        }
+        return accepted;
+    }
+
+    function disableWeather() {
+        const accepted = request({
+                                     "enabled": false,
+                                     "consent": false,
+                                     "locationLabel": "",
+                                     "latitude": null,
+                                     "longitude": null
+                                 });
+        if (accepted) {
+            privacyAccepted = false;
+            searchInput.text = "";
+            locationSearch.clear();
+        }
+        return accepted;
+    }
+
+    function lookupFailureText() {
+        if (locationSearch.failure === "no-results")
+            return "No matching city or postal location was found.";
+        if (locationSearch.failure === "throttled" || locationSearch.failure === "rate-limited")
+            return "Location search is rate limited. Wait before trying again.";
+        if (locationSearch.failure === "timeout")
+            return "Location search timed out. Try again.";
+        if (locationSearch.failure !== "none")
+            return "Location search is unavailable. Try again later.";
+        return "";
+    }
+
+    ColumnLayout {
+        id: content
+
+        width: root.width - (root.contentHeight > root.height ? Theme.spacing.md : 0)
+        spacing: Theme.spacing.md
+
+        IslandText {
+            text: "Weather"
+            size: "title"
+            Accessible.role: Accessible.Heading
+            Accessible.name: text
+        }
+
+        IslandPanel {
+            Layout.fillWidth: true
+            implicitHeight: privacyColumn.implicitHeight + Theme.spacing.lg * 2
+            color: Theme.color.controlFill
+
+            ColumnLayout {
+                id: privacyColumn
+
+                anchors.fill: parent
+                anchors.margins: Theme.spacing.lg
+                spacing: Theme.spacing.sm
+
+                IslandText {
+                    Layout.fillWidth: true
+                    text: "Privacy before configuration"
+                    size: "title"
+                    Accessible.role: Accessible.Heading
+                    Accessible.name: text
+                }
+
+                IslandText {
+                    Layout.fillWidth: true
+                    text: "A manual search sends the submitted city or postal text and your IP address to Open-Meteo. If that service is unavailable, Nagi may send the same submitted search to the configured Nominatim endpoint. After confirmation, forecasts send your IP address and four-decimal coordinates directly to MET Norway. Nagi stores only the confirmed label and coordinates; it keeps no search history and never uses IP geolocation or automatic location tracking."
+                    textFormat: Text.PlainText
+                    size: "body"
+                    color: Theme.color.textSecondary
+                    wrapMode: Text.Wrap
+                    Accessible.name: text
+                }
+            }
+        }
+
+        SettingToggleRow {
+            Layout.fillWidth: true
+            label: "I understand the Weather privacy disclosure"
+            description:
+            "Required before a manual city or postal search. This choice is saved only with a confirmed location."
+            value: root.privacyAccepted
+            writable: root.settingsModel.writable
+            onValueRequested: value => {
+                root.privacyAccepted = value;
+                if (!value) {
+                    root.locationSearch.clear();
+                }
+            }
+        }
+
+        IslandPanel {
+            Layout.fillWidth: true
+            implicitHeight: locationColumn.implicitHeight + Theme.spacing.lg * 2
+            color: Theme.color.controlFill
+            visible: root.configured
+
+            ColumnLayout {
+                id: locationColumn
+
+                anchors.fill: parent
+                anchors.margins: Theme.spacing.lg
+                spacing: Theme.spacing.sm
+
+                IslandText {
+                    Layout.fillWidth: true
+                    text: root.settingsModel.snapshot.weather.locationLabel
+                    size: "title"
+                    wrapMode: Text.Wrap
+                    Accessible.name: "Confirmed Weather location " + text
+                }
+
+                IslandText {
+                    Layout.fillWidth: true
+                    text: root.weather !== null && root.weather.available ? Math.round(
+                                                                                root.weather.current.temperature)
+                                                                            + (root.weather.current.temperatureUnit
+                                                                               === "fahrenheit"
+                                                                               ? "°F" : "°C") + (
+                                                                                root.weather.stale
+                                                                                ? " · stale" :
+                                                                                  " · current") :
+                                                                            "Forecast unavailable"
+                    size: "body"
+                    color: Theme.color.textSecondary
+                    Accessible.name: "Weather preview " + text
+                }
+
+                IslandButton {
+                    label: "Disable and clear Weather"
+                    variant: "danger"
+                    reducedMotion: root.reducedMotion
+                    enabled: root.settingsModel.writable
+                    Accessible.description:
+                    "Stop requests and clear the confirmed location and cache"
+                    onClicked: root.disableWeather()
+                }
+            }
+        }
+
+        IslandText {
+            Layout.fillWidth: true
+            text: root.configured ? "Search to replace the confirmed location" :
+                                    "Search for one location"
+            size: "title"
+            Accessible.role: Accessible.Heading
+            Accessible.name: text
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacing.sm
+
+            Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: Theme.size.controlHeightMd
+                radius: Theme.radius.md
+                color: Theme.color.controlFill
+                border.width: Theme.size.hairlineWidth
+                border.color: searchInput.activeFocus ? Theme.snapshot.focusRing :
+                                                        Theme.color.surfaceBorder
+                opacity: root.lookupAllowed ? 1 : Theme.opacity.disabled
+
+                IslandText {
+                    anchors.fill: parent
+                    anchors.leftMargin: Theme.spacing.md
+                    text: "City or postal code"
+                    tone: "muted"
+                    verticalAlignment: Text.AlignVCenter
+                    visible: searchInput.text === ""
+                }
+
+                TextInput {
+                    id: searchInput
+
+                    anchors.fill: parent
+                    leftPadding: Theme.spacing.md
+                    rightPadding: Theme.spacing.md
+                    enabled: root.lookupAllowed && !root.locationSearch.inFlight
+                    color: Theme.color.textPrimary
+                    selectionColor: Theme.snapshot.accent
+                    selectedTextColor: Theme.snapshot.accentForeground
+                    font.pixelSize: Theme.type.body
+                    font.family: Theme.type.family
+                    verticalAlignment: TextInput.AlignVCenter
+                    clip: true
+                    activeFocusOnTab: true
+                    inputMethodHints: Qt.ImhNoPredictiveText
+                    maximumLength: 128
+                    Accessible.role: Accessible.EditableText
+                    Accessible.name: "City or postal location"
+                    Keys.onReturnPressed: event => {
+                        root.search();
+                        event.accepted = true;
+                    }
+                    Keys.onEnterPressed: event => {
+                        root.search();
+                        event.accepted = true;
+                    }
+                }
+            }
+
+            IslandButton {
+                label: root.locationSearch.inFlight ? "Searching…" : "Search"
+                reducedMotion: root.reducedMotion
+                enabled: root.lookupAllowed && !root.locationSearch.inFlight
+                         && searchInput.text.trim().length >= 2
+                onClicked: root.search()
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: root.locationSearch.results.length > 0
+            spacing: Theme.spacing.sm
+            Accessible.role: Accessible.List
+            Accessible.name: "Location search results"
+
+            Repeater {
+                model: root.visible ? root.locationSearch.results : []
+
+                delegate: IslandButton {
+                    required property var modelData
+
+                    Layout.fillWidth: true
+                    label: modelData.label
+                    reducedMotion: root.reducedMotion
+                    Accessible.role: Accessible.ListItem
+                    Accessible.description: "Use this location and enable Weather"
+                    onClicked: root.confirm(modelData)
+                }
+            }
+        }
+
+        IslandText {
+            Layout.fillWidth: true
+            visible: root.lookupFailureText() !== ""
+            text: root.lookupFailureText()
+            size: "caption"
+            color: Theme.color.danger
+            wrapMode: Text.Wrap
+            Accessible.role: Accessible.AlertMessage
+            Accessible.name: text
+        }
+
+        IslandText {
+            Layout.fillWidth: true
+            text: root.locationSearch.attribution
+            size: "caption"
+            color: Theme.color.textMuted
+            wrapMode: Text.Wrap
+            Accessible.name: text
+        }
+
+        SettingChoiceRow {
+            Layout.fillWidth: true
+            label: "Temperature"
+            description: "Follow the locale or override temperature independently."
+            value: root.settingsModel.snapshot.weather.temperatureUnit
+            choices: [
+                {
+                    "label": "Locale",
+                    "value": "auto"
+                },
+                {
+                    "label": "Celsius",
+                    "value": "celsius"
+                },
+                {
+                    "label": "Fahrenheit",
+                    "value": "fahrenheit"
+                }
+            ]
+            writable: root.settingsModel.writable
+            reducedMotion: root.reducedMotion
+            onValueRequested: value => root.request({
+                                                        "temperatureUnit": value
+                                                    })
+        }
+
+        SettingChoiceRow {
+            Layout.fillWidth: true
+            label: "Wind speed"
+            description: "Follow the locale or override wind independently."
+            value: root.settingsModel.snapshot.weather.windUnit
+            choices: [
+                {
+                    "label": "Locale",
+                    "value": "auto"
+                },
+                {
+                    "label": "km/h",
+                    "value": "kmh"
+                },
+                {
+                    "label": "mph",
+                    "value": "mph"
+                },
+                {
+                    "label": "m/s",
+                    "value": "ms"
+                }
+            ]
+            writable: root.settingsModel.writable
+            reducedMotion: root.reducedMotion
+            onValueRequested: value => root.request({
+                                                        "windUnit": value
+                                                    })
+        }
+
+        SettingChoiceRow {
+            Layout.fillWidth: true
+            label: "Refresh preference"
+            description:
+            "Provider cache expiry, minimum gaps, throttling, Retry-After, and backoff always take precedence."
+            value: root.settingsModel.snapshot.weather.refreshPreset
+            choices: [
+                {
+                    "label": "15 minutes",
+                    "value": "15m"
+                },
+                {
+                    "label": "30 minutes",
+                    "value": "30m"
+                },
+                {
+                    "label": "1 hour",
+                    "value": "1h"
+                },
+                {
+                    "label": "3 hours",
+                    "value": "3h"
+                }
+            ]
+            writable: root.settingsModel.writable
+            reducedMotion: root.reducedMotion
+            onValueRequested: value => root.request({
+                                                        "refreshPreset": value
+                                                    })
+        }
+
+        IslandText {
+            Layout.fillWidth: true
+            visible: root.failureText !== ""
+            text: root.failureText
+            size: "caption"
+            color: Theme.color.danger
+            wrapMode: Text.Wrap
+            Accessible.role: Accessible.AlertMessage
+            Accessible.name: text
+        }
+
+        SettingsResetActions {
+            Layout.fillWidth: true
+            pageId: "weather"
+            writable: root.settingsModel.writable
+            errorText: root.settingsModel.status === "write-failed"
+                       ? root.settingsModel.errorMessage : ""
+            reducedMotion: root.reducedMotion
+            onResetPageRequested: pageId => {
+                if (root.settingsModel.resetPage(pageId)) {
+                    root.privacyAccepted = false;
+                    root.locationSearch.clear();
+                }
+            }
+            onResetAllRequested: {
+                if (root.settingsModel.resetAll()) {
+                    root.privacyAccepted = false;
+                    root.locationSearch.clear();
+                }
+            }
+        }
+
+        IslandText {
+            Layout.fillWidth: true
+            text: "Forecasts: MET Norway (NLOD 2.0 / CC BY 4.0). Search: GeoNames/Open-Meteo (CC BY 4.0), or OpenStreetMap contributors (ODbL) when the Nominatim fallback is active."
+            size: "caption"
+            color: Theme.color.textMuted
+            wrapMode: Text.Wrap
+            Accessible.name: text
+        }
+    }
+}

--- a/qml/WeatherView.qml
+++ b/qml/WeatherView.qml
@@ -1,0 +1,371 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+
+FocusScope {
+    id: view
+
+    required property var adapter
+    required property real ownerEpoch
+    property bool active: true
+    property bool reducedMotion: false
+
+    readonly property bool hasModel: adapter !== null && adapter.model !== null
+    readonly property var current: hasModel ? adapter.current : null
+    readonly property var hourly: active && hasModel ? adapter.hourly : []
+    readonly property var daily: active && hasModel ? adapter.daily : []
+
+    implicitWidth: frame.implicitWidth
+    implicitHeight: frame.implicitHeight
+    visible: active
+
+    signal cancelled(real ownerEpoch)
+
+    function conditionText(condition) {
+        if (condition === "clear")
+            return "Clear";
+        if (condition === "mostlyClear")
+            return "Mostly clear";
+        if (condition === "partlyCloudy")
+            return "Partly cloudy";
+        if (condition === "cloudy")
+            return "Cloudy";
+        if (condition === "fog")
+            return "Fog";
+        if (condition === "rain")
+            return "Rain";
+        if (condition === "sleet")
+            return "Sleet";
+        if (condition === "snow")
+            return "Snow";
+        if (condition === "thunderstorm")
+            return "Thunderstorm";
+        return "Unknown conditions";
+    }
+
+    function temperatureSuffix(unit) {
+        return unit === "fahrenheit" ? "°F" : "°C";
+    }
+
+    function windSuffix(unit) {
+        if (unit === "mph")
+            return "mph";
+        if (unit === "ms")
+            return "m/s";
+        return "km/h";
+    }
+
+    function ageText() {
+        if (adapter === null || !Number.isFinite(adapter.lastUpdatedAgeMs)) {
+            return "Update time unavailable";
+        }
+        const minutes = Math.max(0, Math.floor(adapter.lastUpdatedAgeMs / 60000));
+        if (minutes < 1)
+            return "Updated just now";
+        if (minutes < 60)
+            return "Updated " + minutes + " min ago";
+        return "Updated " + Math.floor(minutes / 60) + " h ago";
+    }
+
+    function failureText() {
+        if (adapter === null || adapter.failure === "unconfigured")
+            return "Configure Weather in the Control Center.";
+        if (adapter.failure === "throttled")
+            return "The provider is limiting requests. Nagi will retry later.";
+        if (adapter.failure === "permanent")
+            return "This location is unavailable. Confirm another location in the Control Center.";
+        if (adapter.failure === "transient")
+            return "Weather could not refresh. Cached data remains available when safe.";
+        if (adapter.failure === "stale")
+            return "Cached weather expired. Try again later or confirm the location.";
+        return "Weather is temporarily unavailable.";
+    }
+
+    function focusInitialControl() {
+        if (refreshButton.visible && refreshButton.enabled) {
+            refreshButton.forceActiveFocus(Qt.ShortcutFocusReason);
+            return true;
+        }
+        return frame.focusInitialControl();
+    }
+
+    SubviewFrame {
+        id: frame
+        objectName: "weatherSubviewFrame"
+
+        anchors.fill: parent
+        active: view.active
+        title: view.hasModel ? view.adapter.model.location : "Weather"
+        reducedMotion: view.reducedMotion
+        initialFocusItem: refreshButton.visible && refreshButton.enabled ? refreshButton : null
+        onBackRequested: view.cancelled(view.ownerEpoch)
+        onEscapePressed: view.cancelled(view.ownerEpoch)
+
+        Item {
+            id: contentRoot
+
+            implicitWidth: Math.max(Theme.spacing.xxl * 18, hourlyRow.implicitWidth,
+                                    dailyRow.implicitWidth)
+            width: Math.max(implicitWidth, parent.width)
+            height: content.implicitHeight
+
+            ColumnLayout {
+                id: content
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                spacing: Theme.spacing.lg
+
+                IslandPanel {
+                    Layout.fillWidth: true
+                    implicitHeight: currentLayout.implicitHeight + Theme.spacing.lg * 2
+                    color: Theme.color.controlFill
+                    visible: view.hasModel
+
+                    RowLayout {
+                        id: currentLayout
+
+                        anchors.fill: parent
+                        anchors.margins: Theme.spacing.lg
+                        spacing: Theme.spacing.lg
+
+                        WeatherGlyph {
+                            condition: view.current === null ? "unknown" : view.current.condition
+                            dayPhase: view.current === null ? "day" : view.current.dayPhase
+                            implicitWidth: Theme.spacing.xxl * 2
+                            implicitHeight: implicitWidth
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: Theme.spacing.xs
+
+                            IslandText {
+                                text: view.current === null ? "" : Math.round(
+                                                                  view.current.temperature)
+                                                              + view.temperatureSuffix(
+                                                                  view.current.temperatureUnit)
+                                size: "display"
+                                Accessible.name: "Current temperature " + text
+                            }
+
+                            IslandText {
+                                Layout.fillWidth: true
+                                text: view.current === null ? "" : view.conditionText(
+                                                                  view.current.condition)
+                                size: "body"
+                                color: Theme.color.textSecondary
+                                wrapMode: Text.Wrap
+                            }
+
+                            IslandText {
+                                Layout.fillWidth: true
+                                text: view.ageText() + (view.adapter !== null && view.adapter.stale
+                                                        ? " · Stale" : "")
+                                size: "caption"
+                                color: view.adapter !== null && view.adapter.stale
+                                       ? Theme.color.warning : Theme.color.textMuted
+                                Accessible.name: text
+                            }
+                        }
+
+                        ColumnLayout {
+                            spacing: Theme.spacing.xs
+
+                            IslandText {
+                                text: view.current === null ? "" : "Feels like " + Math.round(
+                                                                  view.current.feelsLike)
+                                                              + view.temperatureSuffix(
+                                                                  view.current.temperatureUnit)
+                                                              + " (calculated)"
+                                size: "caption"
+                                color: Theme.color.textSecondary
+                                Accessible.name: text
+                            }
+
+                            IslandText {
+                                text: view.current === null ? "" : "Humidity " + Math.round(
+                                                                  view.current.humidity) + "%"
+                                size: "caption"
+                                color: Theme.color.textSecondary
+                                Accessible.name: text
+                            }
+
+                            IslandText {
+                                text: view.current === null ? "" : "Wind " + Math.round(
+                                                                  view.current.wind) + " "
+                                                              + view.windSuffix(
+                                                                  view.current.windUnit)
+                                size: "caption"
+                                color: Theme.color.textSecondary
+                                Accessible.name: text
+                            }
+                        }
+                    }
+                }
+
+                IslandText {
+                    Layout.fillWidth: true
+                    visible: !view.hasModel
+                    text: view.failureText()
+                    size: "body"
+                    color: Theme.color.textSecondary
+                    wrapMode: Text.Wrap
+                    Accessible.role: Accessible.AlertMessage
+                    Accessible.name: text
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.spacing.md
+
+                    IslandText {
+                        Layout.fillWidth: true
+                        text: "Next 12 hours"
+                        size: "title"
+                        Accessible.role: Accessible.Heading
+                        Accessible.name: text
+                    }
+
+                    IslandButton {
+                        id: refreshButton
+
+                        visible: view.adapter !== null
+                        enabled: view.adapter !== null && view.adapter.manualRefreshAvailable
+                        label: view.adapter !== null && view.adapter.refreshInFlight
+                               ? "Refreshing…" : "Refresh"
+                        reducedMotion: view.reducedMotion
+                        Accessible.description: enabled ? "Refresh weather now" :
+                                                          "Refresh is cooling down"
+                        onClicked: view.adapter.manualRefresh()
+                    }
+                }
+
+                RowLayout {
+                    id: hourlyRow
+                    Layout.fillWidth: true
+                    visible: view.hourly.length > 0
+                    spacing: Theme.spacing.sm
+                    Accessible.role: Accessible.List
+                    Accessible.name: "Hourly forecast"
+
+                    Repeater {
+                        model: view.hourly
+
+                        delegate: ForecastCard {
+                            required property var modelData
+
+                            heading: Qt.formatTime(new Date(modelData.forecastEpoch), "HH:mm")
+                            condition: modelData.condition
+                            dayPhase: modelData.dayPhase
+                            temperature: Math.round(modelData.temperature) + view.temperatureSuffix(
+                                             modelData.temperatureUnit)
+                        }
+                    }
+                }
+
+                IslandText {
+                    Layout.fillWidth: true
+                    visible: view.hourly.length === 0
+                    text: "Hourly forecast unavailable"
+                    size: "caption"
+                    color: Theme.color.textMuted
+                }
+
+                IslandText {
+                    Layout.fillWidth: true
+                    text: "Next 5 days"
+                    size: "title"
+                    Accessible.role: Accessible.Heading
+                    Accessible.name: text
+                }
+
+                RowLayout {
+                    id: dailyRow
+                    Layout.fillWidth: true
+                    visible: view.daily.length > 0
+                    spacing: Theme.spacing.sm
+                    Accessible.role: Accessible.List
+                    Accessible.name: "Daily forecast"
+
+                    Repeater {
+                        model: view.daily
+
+                        delegate: ForecastCard {
+                            required property var modelData
+
+                            heading: Qt.formatDate(new Date(modelData.dateEpoch), "ddd")
+                            condition: modelData.condition
+                            dayPhase: modelData.dayPhase
+                            temperature: Math.round(modelData.minimumTemperature) + "–" + Math.round(
+                                             modelData.maximumTemperature) + view.temperatureSuffix(
+                                             modelData.temperatureUnit)
+                        }
+                    }
+                }
+
+                IslandText {
+                    Layout.fillWidth: true
+                    visible: view.daily.length === 0
+                    text: "Daily forecast unavailable"
+                    size: "caption"
+                    color: Theme.color.textMuted
+                }
+
+                IslandText {
+                    Layout.fillWidth: true
+                    text: "Weather data from MET Norway · NLOD 2.0 / CC BY 4.0"
+                    size: "caption"
+                    color: Theme.color.textMuted
+                    wrapMode: Text.Wrap
+                    Accessible.name: text
+                }
+            }
+        }
+    }
+
+    component ForecastCard: IslandPanel {
+        id: card
+        required property string heading
+        required property string condition
+        required property string dayPhase
+        required property string temperature
+
+        Layout.fillWidth: true
+        Layout.minimumWidth: Theme.spacing.xxl * 2
+        implicitHeight: cardContent.implicitHeight + Theme.spacing.md * 2
+        color: Theme.color.controlFill
+        Accessible.role: Accessible.ListItem
+        Accessible.name: heading + ", " + view.conditionText(condition) + ", " + temperature
+
+        ColumnLayout {
+            id: cardContent
+
+            anchors.fill: parent
+            anchors.margins: Theme.spacing.md
+            spacing: Theme.spacing.xs
+
+            IslandText {
+                Layout.fillWidth: true
+                text: card.heading
+                size: "caption"
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            WeatherGlyph {
+                Layout.alignment: Qt.AlignHCenter
+                condition: card.condition
+                dayPhase: card.dayPhase
+            }
+
+            IslandText {
+                Layout.fillWidth: true
+                text: card.temperature
+                size: "body"
+                horizontalAlignment: Text.AlignHCenter
+                font.weight: Theme.type.weightMedium
+            }
+        }
+    }
+}

--- a/shell.qml
+++ b/shell.qml
@@ -52,11 +52,20 @@ ShellRoot {
         }
     }
 
+    WeatherLocationSearchAdapter {
+        id: weatherLocationSearch
+        allowed: controlCenter.weatherLookupAllowed
+    }
+
     WeatherAdapter {
         id: weather
-        enabled: UserConfig.snapshot.weather.enabled && UserConfig.snapshot.island.showWeather
+        enabled: UserConfig.snapshot.weather.enabled
+        label: UserConfig.snapshot.weather.locationLabel
         latitude: UserConfig.snapshot.weather.latitude ?? Number.NaN
         longitude: UserConfig.snapshot.weather.longitude ?? Number.NaN
+        temperatureUnit: UserConfig.snapshot.weather.temperatureUnit
+        windUnit: UserConfig.snapshot.weather.windUnit
+        refreshPreset: UserConfig.snapshot.weather.refreshPreset
     }
 
     MediaAdapter {
@@ -149,6 +158,8 @@ ShellRoot {
         clock: clockState
         media: mediaAdapter
         notificationService: notificationService
+        weather: weather
+        locationSearch: weatherLocationSearch
         reducedMotion: Theme.motion.effectiveMode === "minimal"
         capabilities: ({
                            "displayRouting": islandHost.liveSurfaceCount > 0,
@@ -166,8 +177,8 @@ ShellRoot {
 
         function activate(reason: string): bool {
             if (reason !== "control-center" && reason !== "island" && reason !== "appearance" && reason
-                    !== "clock-date" && reason !== "media" && reason !== "notifications" && reason
-                    !== "displays" && reason !== "about") {
+                    !== "clock-date" && reason !== "media" && reason !== "weather" && reason
+                    !== "notifications" && reason !== "displays" && reason !== "about") {
                 return false;
             }
             return openControlCenter(reason, null);

--- a/tests/control-center/shell.qml
+++ b/tests/control-center/shell.qml
@@ -134,14 +134,15 @@ ShellRoot {
                 && controlCenter.title === "Nagi Control Center"
                 && controlCenter.parentWindow === null,
                 "normal independent window exposes tested semantic minimum bounds");
-        require(routeNamesExact() && controlCenter.availableRoutes.length === 7
+        require(routeNamesExact() && controlCenter.availableRoutes.length === 8
                 && controlCenter.availableRoutes[0].id === "island"
                 && controlCenter.availableRoutes[1].id === "appearance"
                 && controlCenter.availableRoutes[2].id === "clock-date"
                 && controlCenter.availableRoutes[3].id === "media"
-                && controlCenter.availableRoutes[4].id === "notifications"
-                && controlCenter.availableRoutes[5].id === "displays"
-                && controlCenter.availableRoutes[6].id === "about",
+                && controlCenter.availableRoutes[4].id === "weather"
+                && controlCenter.availableRoutes[5].id === "notifications"
+                && controlCenter.availableRoutes[6].id === "displays"
+                && controlCenter.availableRoutes[7].id === "about",
                 "final route names stay fixed and all complete pages are exposed");
         createControls();
         exerciseControls();
@@ -194,6 +195,26 @@ ShellRoot {
     function mediaStage() {
         require(controlCenter.loadedPageItem !== null && fakeMedia.availableApplications.length === 1,
                 "Media receives the normalized shared application policy source");
+        require(controlCenter.open("weather", tokenB)
+                && controlCenter.currentPageId === "weather",
+                "Weather joins the shared responsive page viewport");
+        stage = "weather";
+        settle.restart();
+    }
+
+    function weatherStage() {
+        const page = controlCenter.loadedPageItem;
+        require(page !== null && !controlCenter.weatherLookupAllowed,
+                "Weather preview loads without enabling location lookup");
+        page.privacyAccepted = true;
+        require(controlCenter.weatherLookupAllowed && fakeLocationSearch.search("Paris"),
+                "privacy acceptance gates explicit location search");
+        require(page.confirm(fakeLocationSearch.results[0])
+                && UserConfig.snapshot.weather.enabled
+                && UserConfig.snapshot.weather.locationLabel === "Paris, France",
+                "confirmed normalized location atomically enables Weather");
+        require(fakeLocationSearch.results.length === 0,
+                "confirmation clears page-owned lookup models and query state");
         require(controlCenter.open("notifications", tokenB)
                 && controlCenter.currentPageId === "notifications",
                 "Notifications joins the shared responsive page viewport");
@@ -317,6 +338,9 @@ ShellRoot {
         case "media":
             mediaStage();
             break;
+        case "weather":
+            weatherStage();
+            break;
         case "notifications":
             notificationsStage();
             break;
@@ -416,6 +440,36 @@ ShellRoot {
     }
 
     QtObject {
+        id: fakeWeather
+        property bool available: false
+        property bool stale: false
+        property var model: null
+        property var current: null
+    }
+
+    QtObject {
+        id: fakeLocationSearch
+        property bool inFlight: false
+        property var results: []
+        property string failure: "none"
+        property string attribution: "Location data by GeoNames via Open-Meteo · CC BY 4.0"
+        function search(query) {
+            if (query !== "Paris")
+                return false;
+            results = [{
+                           "label": "Paris, France",
+                           "latitude": 48.8534,
+                           "longitude": 2.3488
+                       }];
+            return true;
+        }
+        function clear() {
+            results = [];
+            failure = "none";
+        }
+    }
+
+    QtObject {
         id: fakeNotifications
         property int historyCount: 1
         function clearHistory() {
@@ -431,6 +485,8 @@ ShellRoot {
         clock: fakeClock
         media: fakeMedia
         notificationService: fakeNotifications
+        weather: fakeWeather
+        locationSearch: fakeLocationSearch
         capabilities: ({
                            "displayRouting": true,
                            "audio": false,

--- a/tests/coordinator/shell.qml
+++ b/tests/coordinator/shell.qml
@@ -68,6 +68,16 @@ ShellRoot {
                 "lower-rank Interactive activation cannot preempt Session");
         require(coordinator.cancelInteractive(sessionEpoch), "current Interactive task cancels");
         require(snapshot(thirdToken).ownerName === "idle", "cancellation restores local baseline");
+
+        require(coordinator.openWeather(secondToken),
+                "Weather opens on its initiating surface");
+        const weatherSnapshot = snapshot(secondToken);
+        require(weatherSnapshot.ownerName === "weather"
+                && weatherSnapshot.focusTarget === coordinator.focusWeather
+                && coordinator.interactiveHostToken === secondToken,
+                "Weather uses the global Interactive owner and dedicated focus target");
+        require(coordinator.cancelInteractive(weatherSnapshot.ownerEpoch),
+                "Weather closes through normal Interactive cancellation");
     }
 
     function verifyDisableAndLoss() {

--- a/tests/idle/shell.qml
+++ b/tests/idle/shell.qml
@@ -18,6 +18,7 @@ ShellRoot {
     id: test
 
     property string pendingMotionStage: ""
+    property int weatherRequests: 0
 
     function require(condition, message) {
         if (!condition) {
@@ -116,6 +117,11 @@ ShellRoot {
         require(islandFull.temperatureText === "24°", "temperature renders rounded Celsius");
         require(islandFull.weatherCaptionText === "Clear · Day",
                 "weather renders normalized condition and day phase context");
+        require(islandFull.weatherBlock.Accessible.role === Accessible.Button,
+                "compact Weather exposes one accessible detail action");
+        islandFull.weatherBlock.clicked();
+        require(weatherRequests === 1,
+                "activating compact Weather requests its detailed subview once");
         require(islandFull.mediaSummary === "Artist — Track", "media renders the selected summary");
         require(islandFull.workspaceBlock.x < islandFull.workspaceBoundary.x
                 && islandFull.workspaceBoundary.x < islandFull.clockGroupBlock.x
@@ -418,6 +424,7 @@ ShellRoot {
         clock: FakeClock {}
         weather: islandFullWeather
         media: FakeMedia {}
+        onWeatherRequested: test.weatherRequests += 1
     }
 
     IdleIsland {

--- a/tests/surface-state/shell.qml
+++ b/tests/surface-state/shell.qml
@@ -15,8 +15,10 @@ ShellRoot {
     property real historyEpoch: 0
     property real trayEpoch: 0
     property real audioEpoch: 0
+    property real weatherEpoch: 0
     property bool audioVerified: false
     property bool trayVerified: false
+    property bool weatherVerified: false
     property var initialSurfaceToken: null
     property int initialSurfaceGeneration: 0
     property int compactTransientWidth: 0
@@ -505,6 +507,34 @@ ShellRoot {
                         "disabled outgoing Audio cannot dispatch pointer selection");
                 audioVerified = true;
                 step = 11;
+            } else if (!weatherVerified && coordinator.ownerName === "weather") {
+                if (!awaitState(coordinator.presentationVisible && host.surfaceFocusable
+                                && host.weatherLoaded && host.weatherFocused
+                                && host.surfaceWidth > 0 && host.surfaceHeight > 0,
+                                "Weather view did not settle: loaded=" + host.weatherLoaded
+                                + " focused=" + host.weatherFocused + " surface="
+                                + host.surfaceWidth + "x" + host.surfaceHeight + " natural="
+                                + weatherReference.implicitWidth + "x"
+                                + weatherReference.implicitHeight)) {
+                    return;
+                }
+                require(coordinator.focusTarget === coordinator.focusWeather,
+                        "Weather presentation receives its dedicated focus target");
+                require(fakeWeatherAdapter.hourly.length === 12
+                        && fakeWeatherAdapter.daily.length === 5,
+                        "Weather renders the bounded shared 12-hour and five-day models");
+                require(host.surfaceWidth <= weatherReference.implicitWidth
+                        && host.surfaceHeight <= weatherReference.implicitHeight
+                        && host.backgroundCoversSurface,
+                        "Weather natural content is screen-bounded and clipped by SubviewFrame");
+                require(coordinator.cancelInteractive(weatherEpoch),
+                        "Weather Back accepts the current owner epoch");
+                require(host.interactiveExitRunning && host.weatherLoaded && !host.surfaceFocusable,
+                        "generic reverse exit retains Weather only for its fade");
+                require(!host.interactiveExitLoaderEnabled,
+                        "outgoing Weather disables actions immediately");
+                weatherVerified = true;
+                step = 11;
             } else {
                 if (!awaitState(coordinator.ownerName === "expanded"
                                 && coordinator.presentationVisible && host.dashboardFocused,
@@ -527,9 +557,16 @@ ShellRoot {
                             "visible dashboard audio entry is admitted");
                     audioEpoch = coordinator.ownerEpoch;
                     step = 11;
-                } else {
+                } else if (!weatherVerified) {
                     require(!host.audioLoaded,
                             "Audio unloads only after its reverse exit completes");
+                    require(coordinator.openWeather(host.surfaceToken),
+                            "compact Weather route is admitted on the initiating surface");
+                    weatherEpoch = coordinator.ownerEpoch;
+                    step = 11;
+                } else {
+                    require(!host.weatherLoaded,
+                            "Weather unloads only after its reverse exit completes");
                     require(host.cancelDashboard(), "restored dashboard remains cancellable");
                 }
             }
@@ -1168,6 +1205,67 @@ ShellRoot {
         }
     }
 
+    QtObject {
+        id: fakeWeatherAdapter
+
+        readonly property real temperatureC: current.temperature
+        readonly property string condition: current.condition
+        readonly property string dayPhase: current.dayPhase
+        readonly property bool stale: false
+        readonly property string failure: "none"
+        readonly property real lastUpdatedAgeMs: 600000
+        readonly property bool manualRefreshAvailable: true
+        readonly property bool refreshInFlight: false
+        readonly property var current: ({
+                                            "temperature": 18,
+                                            "temperatureUnit": "celsius",
+                                            "feelsLike": 17,
+                                            "feelsLikeCalculated": true,
+                                            "humidity": 62,
+                                            "wind": 12,
+                                            "windUnit": "kmh",
+                                            "condition": "partlyCloudy",
+                                            "dayPhase": "day"
+                                        })
+        readonly property var hourly: {
+            const values = [];
+            for (let index = 1; index <= 12; index += 1) {
+                values.push({
+                                "forecastEpoch": Date.now() + index * 3600000,
+                                "temperature": 18 + index / 10,
+                                "temperatureUnit": "celsius",
+                                "condition": "partlyCloudy",
+                                "dayPhase": "day"
+                            });
+            }
+            return values;
+        }
+        readonly property var daily: {
+            const values = [];
+            for (let index = 0; index < 5; index += 1) {
+                values.push({
+                                "dateEpoch": Date.now() + index * 86400000,
+                                "minimumTemperature": 10 + index,
+                                "maximumTemperature": 20 + index,
+                                "temperatureUnit": "celsius",
+                                "condition": "clear",
+                                "dayPhase": "day"
+                            });
+            }
+            return values;
+        }
+        readonly property var model: ({
+                                          "location": "Fixture City",
+                                          "current": current,
+                                          "hourly": hourly,
+                                          "daily": daily
+                                      })
+
+        function manualRefresh() {
+            return true;
+        }
+    }
+
     Item {
         visible: false
 
@@ -1176,6 +1274,15 @@ ShellRoot {
 
             active: false
             adapter: fakeAudioAdapter
+            ownerEpoch: 0
+            reducedMotion: true
+        }
+
+        WeatherView {
+            id: weatherReference
+
+            active: true
+            adapter: fakeWeatherAdapter
             ownerEpoch: 0
             reducedMotion: true
         }
@@ -1244,6 +1351,7 @@ ShellRoot {
         readonly property int focusNotificationHistory: coordinatorCore.focusNotificationHistory
         readonly property int focusTray: coordinatorCore.focusTray
         readonly property int focusAudio: coordinatorCore.focusAudio
+        readonly property int focusWeather: coordinatorCore.focusWeather
 
         function refreshFallback(result) {
             if (host.fallbackSurface !== null) {
@@ -1260,6 +1368,9 @@ ShellRoot {
         }
         function openAudio(token) {
             return coordinatorCore.openAudio(token);
+        }
+        function openWeather(token) {
+            return coordinatorCore.openWeather(token);
         }
         function openHistory(token) {
             return coordinatorCore.openHistory(token);
@@ -1315,6 +1426,7 @@ ShellRoot {
         sessionService: fakeSessionService
         trayAdapter: fakeTrayAdapter
         audioAdapter: fakeAudioAdapter
+        weather: fakeWeatherAdapter
         polkitController: fakePolkitController
         notificationService: fakeNotificationService
         applicationModel: fakeApplicationModel

--- a/tests/theme-config/shell.qml
+++ b/tests/theme-config/shell.qml
@@ -451,6 +451,10 @@ ShellRoot {
                 && UserConfig.snapshot.appearance.customAccent === "#123456"
                 && UserConfig.snapshot.appearance.surfaceOpacity === 0.85
                 && !UserConfig.snapshot.media.enabled && UserConfig.snapshot.weather.enabled
+                && UserConfig.snapshot.weather.consent
+                && UserConfig.snapshot.weather.locationLabel === "Configured location"
+                && UserConfig.snapshot.weather.latitude === -90
+                && UserConfig.snapshot.weather.longitude === 180
                 && UserConfig.snapshot.clock.format === "12h",
                 "all valid V1 values migrated without loss");
         require(backupReader.text() === legacyContent,

--- a/tests/weather/shell.qml
+++ b/tests/weather/shell.qml
@@ -58,27 +58,39 @@ ShellRoot {
         };
     }
 
-    function metEntry(offsetMs, temperature, symbolCode) {
-        return {
-            "time": new Date(test.nowMs + offsetMs).toISOString(),
-            "data": {
-                "instant": {
-                    "details": {
-                        "air_temperature": temperature
-                    }
-                },
-                "next_1_hours": {
-                    "summary": {
-                        "symbol_code": symbolCode
-                    }
+    function metEntry(offsetMs, temperature, symbolCode, humidity, windMs) {
+        const data = {
+            "instant": {
+                "details": {
+                    "air_temperature": temperature,
+                    "relative_humidity": humidity === undefined ? 55 : humidity,
+                    "wind_speed": windMs === undefined ? 3 : windMs
                 }
             }
+        };
+        if (symbolCode !== null) {
+            data.next_1_hours = {
+                "summary": {
+                    "symbol_code": symbolCode
+                }
+            };
+        }
+        return {
+            "time": new Date(test.nowMs + offsetMs).toISOString(),
+            "data": data
         };
     }
 
     function metBody(entries) {
         return JSON.stringify({
                                   "properties": {
+                                      "meta": {
+                                          "units": {
+                                              "air_temperature": "celsius",
+                                              "relative_humidity": "%",
+                                              "wind_speed": "m/s"
+                                          }
+                                      },
                                       "timeseries": entries
                                   }
                               });
@@ -98,6 +110,7 @@ ShellRoot {
     function makeWeather(overrides) {
         const properties = {
             "enabled": true,
+            "label": "Test location",
             "wallNow": function () {
                 return test.nowMs;
             },
@@ -112,6 +125,139 @@ ShellRoot {
         }
 
         return weatherFactory.createObject(test, properties);
+    }
+
+    function makeLookup(overrides) {
+        const properties = {
+            "allowed": true,
+            "wallNow": function () {
+                return test.nowMs;
+            }
+        };
+        for (const key in overrides) {
+            properties[key] = overrides[key];
+        }
+        return lookupFactory.createObject(test, properties);
+    }
+
+    function runLocationLookupTests() {
+        const disabledCap = newCapture(null);
+        const disabledLookup = makeLookup({
+                                                   "allowed": false,
+                                                   "transport": disabledCap.transport
+                                               });
+        require(!disabledLookup.search("Paris") && disabledCap.record.requests.length === 0,
+                "disabled location lookup performs zero requests");
+
+        const cityCap = newCapture(function () {
+            return {
+                "status": 200,
+                "bodyText": JSON.stringify({
+                                                "results": [{
+                                                        "name": "Paris",
+                                                        "admin1": "Île-de-France",
+                                                        "country": "France",
+                                                        "latitude": 48.85341,
+                                                        "longitude": 2.3488
+                                                    }]
+                                            })
+            };
+        });
+        const cityLookup = makeLookup({
+                                               "transport": cityCap.transport
+                                           });
+        require(cityLookup.search("Paris, France") && cityLookup.results.length === 1
+                && cityLookup.results[0].label === "Paris, Île-de-France, France",
+                "explicit city lookup publishes one bounded normalized result");
+        require(cityCap.record.requests[0].url.indexOf("Paris%2C%20France") !== -1
+                && cityLookup.results[0].latitude === 48.85341,
+                "city query is submitted only on explicit search and coordinates stay normalized");
+
+        const postalCap = newCapture(function () {
+            return {
+                "status": 200,
+                "bodyText": JSON.stringify({
+                                                "results": [{
+                                                        "name": "Berlin",
+                                                        "country": "Germany",
+                                                        "latitude": 52.52,
+                                                        "longitude": 13.41
+                                                    }]
+                                            })
+            };
+        });
+        const postalLookup = makeLookup({
+                                                 "transport": postalCap.transport
+                                             });
+        require(postalLookup.search("10115")
+                && postalCap.record.requests[0].url.indexOf("name=10115") !== -1,
+                "postal input uses the same explicit bounded lookup contract");
+
+        const fallbackCap = newCapture(function (index) {
+            return index === 1 ? {
+                                     "networkError": true
+                                 } : {
+                "status": 200,
+                "bodyText": JSON.stringify([{
+                                                "display_name": "Paris, Île-de-France, France",
+                                                "lat": "48.8534",
+                                                "lon": "2.3488"
+                                            }])
+            };
+        });
+        const fallbackLookup = makeLookup({
+                                                   "transport": fallbackCap.transport
+                                               });
+        require(fallbackLookup.search("Paris") && fallbackCap.record.requests.length === 2
+                && fallbackCap.record.requests[1].url.indexOf("/search?format=jsonv2") !== -1
+                && fallbackLookup.results.length === 1
+                && fallbackLookup.attribution.indexOf("OpenStreetMap") !== -1,
+                "Open-Meteo failure uses the bounded attributed Nominatim fallback");
+        fallbackLookup.clear();
+        require(fallbackLookup.results.length === 0 && fallbackLookup.failure === "none",
+                "clearing lookup retains no result or query history");
+
+        const boundedQueryCap = newCapture(null);
+        const boundedQuery = makeLookup({
+                                                 "transport": boundedQueryCap.transport
+                                             });
+        require(!boundedQuery.search("é".repeat(65))
+                && boundedQueryCap.record.requests.length === 0
+                && boundedQuery.failure === "invalid-query",
+                "location queries are bounded by UTF-8 bytes before transport");
+
+        const invalidEndpointCap = newCapture(function () {
+            return {
+                "networkError": true
+            };
+        });
+        const invalidEndpoint = makeLookup({
+                                                    "nominatimEndpoint": "http://unsafe.example",
+                                                    "transport": invalidEndpointCap.transport
+                                                });
+        require(invalidEndpoint.search("Paris") && invalidEndpointCap.record.requests.length === 1
+                && invalidEndpoint.failure === "unavailable",
+                "fallback rejects a non-HTTPS endpoint before dispatch");
+
+        const cancellation = {
+            "aborted": false
+        };
+        const pendingLookup = makeLookup({
+                                                  "transport": {
+                                                      "create": function () {
+                                                          return {
+                                                              "abort": function () {
+                                                                  cancellation.aborted = true;
+                                                              }
+                                                          };
+                                                      }
+                                                  }
+                                              });
+        require(pendingLookup.search("Helsinki") && pendingLookup.inFlight,
+                "lookup exposes one pending request");
+        pendingLookup.allowed = false;
+        require(!pendingLookup.inFlight && cancellation.aborted && pendingLookup.results.length === 0,
+                "closing the lookup gate cancels work and clears normalized results");
     }
 
     function conditionFor(symbolCode) {
@@ -135,6 +281,7 @@ ShellRoot {
 
     function run() {
         rngQueue = [];
+        runLocationLookupTests();
 
         const disabledCap = newCapture(null);
         const disabled = makeWeather({
@@ -172,25 +319,13 @@ ShellRoot {
                 && invalidLatitudeCap.record.requests.length === 0,
                 "out-of-range latitude performs no request");
 
-        const fractionalAltitudeCap = newCapture(null);
-        const fractionalAltitude = makeWeather({
-                                                   "latitude": 10.0,
-                                                   "longitude": 10.0,
-                                                   "altitude": 12.5,
-                                                   "transport": fractionalAltitudeCap.transport
-                                               });
-        fractionalAltitude.refreshDeadlineReached();
-        require(fractionalAltitude.failure === "unconfigured"
-                && fractionalAltitudeCap.record.requests.length === 0,
-                "fractional altitude performs no request");
 
-        // Requests carry truncated coarse coordinates, the identifying public
-        // User-Agent, no credential, and never the local label.
+        // Requests carry four-decimal coordinates and the identifying public
+        // User-Agent only; Qt supplies transparent compression support.
         const shapedCap = newCapture(null);
         const shaped = makeWeather({
-                                       "latitude": 48.8566,
-                                       "longitude": 2.3522,
-                                       "altitude": 35,
+                                       "latitude": 48.85667,
+                                       "longitude": 2.35229,
                                        "label": "Home label",
                                        "transport": shapedCap.transport
                                    });
@@ -199,35 +334,36 @@ ShellRoot {
                 "configured weather sends exactly its scheduled request");
         const shapedRequest = shapedCap.record.requests[0];
         require(shapedRequest.url
-                === "https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=48.85&lon=2.35&altitude=35",
-                "request URL uses two-decimal truncated coordinates");
+                === "https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=48.8566&lon=2.3522",
+                "request URL uses four-decimal truncated coordinates");
         require(shapedRequest.headers["User-Agent"]
-                === "NagiShell/0.1.0 github.com/Anthodev/nagi-shell",
+                === "NagiShell/0.1.0 https://github.com/Anthodev/nagi-shell",
                 "requests identify Nagi Shell with the public User-Agent");
+        require(Object.keys(shapedRequest.headers).length === 1,
+                "requests add no credential or provider-unsupported custom header");
         require(shapedRequest.url.indexOf("Home") === -1,
                 "the local label never leaves the machine");
-        require(Object.keys(shapedRequest.headers).length === 1,
-                "requests carry no credential or extra header");
 
         const negativeShapedCap = newCapture(null);
         const negativeShaped = makeWeather({
-                                               "latitude": -33.8688,
-                                               "longitude": -74.0066,
+                                               "latitude": -33.86889,
+                                               "longitude": -74.00669,
                                                "transport": negativeShapedCap.transport
                                            });
         negativeShaped.refreshDeadlineReached();
-        require(negativeShapedCap.record.requests[0].url.indexOf("?lat=-33.86&lon=-74.00")
-                !== -1 && negativeShapedCap.record.requests[0].url.indexOf("altitude") === -1,
-                "negative coordinates truncate toward zero and unknown altitude is omitted");
+        require(negativeShapedCap.record.requests[0].url.indexOf(
+                    "?lat=-33.8688&lon=-74.0066") !== -1,
+                "negative coordinates truncate toward zero");
 
         const zeroishShapedCap = newCapture(null);
         const zeroishShaped = makeWeather({
-                                              "latitude": 0.001,
-                                              "longitude": -0.001,
+                                              "latitude": 0.00001,
+                                              "longitude": -0.00001,
                                               "transport": zeroishShapedCap.transport
                                           });
         zeroishShaped.refreshDeadlineReached();
-        require(zeroishShapedCap.record.requests[0].url.indexOf("?lat=0.00&lon=0.00") !== -1,
+        require(zeroishShapedCap.record.requests[0].url.indexOf(
+                    "?lat=0.0000&lon=0.0000") !== -1,
                 "near-zero coordinates normalize without a negative-zero sign");
 
         // A valid response exposes temperature and normalized condition from
@@ -255,9 +391,103 @@ ShellRoot {
                 "forecast time matches the selected entry");
         require(valid.fetchedAt.getTime() === completionTime,
                 "fetched time marks the retrieval");
-        require(valid.nextRequestAt === Math.max(completionTime + 1800000,
-                                                 completionTime + 600000),
-                "zero jitter schedules the next request exactly at expiry");
+        require(valid.nextRequestAt === completionTime + 3600000,
+                "refresh preference defers a shorter provider expiry");
+        valid.label = "Replacement location";
+        valid.applyLocation();
+        require(!valid.available && valid.failure === "none",
+                "changing the confirmed label atomically invalidates prior-location state");
+        valid.refreshDeadlineReached();
+        require(validCap.record.requests.length === 2
+                && validCap.record.requests[1].headers["If-Modified-Since"] === undefined,
+                "a changed location never reuses the old label's conditional cache");
+
+        // Extended state publishes one deeply frozen, provider-independent
+        // generation with bounded 12-hour and five-day projections.
+        const forecastEntries = [metEntry(-600000, 30, "clearsky_day", 70, 1)];
+        for (let hour = 1; hour <= 144; hour += 1) {
+            forecastEntries.push(metEntry(hour * 3600000, 10 + hour / 10,
+                                          hour % 2 === 0 ? "partlycloudy_day" : "rain",
+                                          40 + hour % 50, 2 + hour % 8));
+        }
+        const modelCap = newCapture(function () {
+            return ok(200, metBody(forecastEntries), 900000, "LM-MODEL");
+        });
+        const extended = makeWeather({
+                                         "latitude": 48.8566,
+                                         "longitude": 2.3522,
+                                         "temperatureUnit": "celsius",
+                                         "windUnit": "ms",
+                                         "transport": modelCap.transport
+                                     });
+        extended.refreshDeadlineReached();
+        require(extended.model !== null && extended.current.location === undefined
+                && extended.model.location === "Test location",
+                "normalized model keeps only the local bounded location label");
+        require(extended.hourly.length === 12 && extended.daily.length === 5,
+                "forecast model caps returned hourly and daily projections at 12 and 5");
+        require(Object.isFrozen(extended.model) && Object.isFrozen(extended.current)
+                && Object.isFrozen(extended.hourly) && Object.isFrozen(extended.daily),
+                "one immutable model generation publishes atomically");
+        require(extended.current.feelsLikeCalculated
+                && extended.current.feelsLike > extended.current.temperature,
+                "hot humid conditions expose a calculated heat-index feels-like value");
+        const celsiusGeneration = extended.modelGeneration;
+        extended.temperatureUnit = "fahrenheit";
+        extended.windUnit = "mph";
+        require(extended.modelGeneration > celsiusGeneration
+                && Math.round(extended.current.temperature) === 86
+                && extended.current.temperatureUnit === "fahrenheit"
+                && extended.current.windUnit === "mph",
+                "independent temperature and wind overrides rebuild converted presentation");
+
+        const windChillCap = newCapture(function () {
+            return ok(200, metBody([metEntry(-600000, 0, "snow", 70, 10)]), 3600000,
+                      "LM-CHILL");
+        });
+        const windChill = makeWeather({
+                                        "latitude": 48.8566,
+                                        "longitude": 2.3522,
+                                        "temperatureUnit": "celsius",
+                                        "transport": windChillCap.transport
+                                    });
+        windChill.refreshDeadlineReached();
+        require(windChill.current.feelsLikeCalculated && windChill.current.feelsLike < 0,
+                "cold windy conditions expose a calculated wind-chill value");
+
+        const badUnitsCap = newCapture(function () {
+            const payload = JSON.parse(metBody([metEntry(-600000, 12, "clear")]));
+            payload.properties.meta.units.wind_speed = "knots";
+            return ok(200, JSON.stringify(payload), 3600000, "LM-BAD-UNITS");
+        });
+        const badUnits = makeWeather({
+                                         "latitude": 48.8566,
+                                         "longitude": 2.3522,
+                                         "transport": badUnitsCap.transport
+                                     });
+        badUnits.refreshDeadlineReached();
+        require(!badUnits.available && badUnits.failure === "transient",
+                "unexpected provider units reject the complete generation");
+
+        const manualCap = newCapture(null);
+        const manual = makeWeather({
+                                      "latitude": 48.8566,
+                                      "longitude": 2.3522,
+                                      "refreshPreset": "3h",
+                                      "transport": manualCap.transport
+                                  });
+        manual.refreshDeadlineReached();
+        manualCap.record.requests[0].onCompleted(ok(200,
+                                                    metBody([metEntry(-600000, 12, "clear")]),
+                                                    900000, "LM-MANUAL"));
+        require(manual.nextRequestAt === test.nowMs + 10800000
+                && !manual.manualRefreshAvailable && !manual.manualRefresh(),
+                "provider expiry and cooldown block premature manual refresh");
+        test.nowMs += 900000;
+        manual.manualRefreshDeadlineReached();
+        require(manual.manualRefreshAvailable && manual.manualRefresh()
+                && manualCap.record.requests.length === 2,
+                "manual refresh bypasses the preference only after provider expiry");
 
         // Symbol normalization matrix: intensity and shower variants collapse;
         // day-phase suffixes separate; thunder wins over precipitation families.
@@ -441,7 +671,7 @@ ShellRoot {
                                                        metBody([metEntry(-600000, 7.5, "fog")]),
                                                        600000, "LM-3"));
         require(resilient.temperatureC === 7.5, "preservation scenario reaches a valid state");
-        test.nowMs += 600000;
+        test.nowMs = resilient.nextRequestAt;
         resilient.localDeadlineReached();
         resilient.refreshDeadlineReached();
         resilientCap.record.requests[1].onCompleted(ok(200, "{not json", 600000, "LM-4"));
@@ -639,6 +869,12 @@ ShellRoot {
         id: weatherFactory
 
         WeatherAdapter {}
+    }
+
+    Component {
+        id: lookupFactory
+
+        WeatherLocationSearchAdapter {}
     }
 
     CompactClock {


### PR DESCRIPTION
Add privacy-gated location search, bounded hourly and daily forecasts,
unit preferences, provider-aware scheduling, and the detailed island
subview.

Closes #76